### PR TITLE
feat(unifi): webhook fast path via Alarm Manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,8 @@ dev-deploy: dev-context ## Build the image and install/upgrade the chart on DEV_
 		--set unifi.insecureSkipVerify=$(if $(UNIFI_INSECURE_SKIP_VERIFY),$(UNIFI_INSECURE_SKIP_VERIFY),true) \
 		$(if $(UNIFI_POLL_INTERVAL),--set unifi.pollInterval=$(UNIFI_POLL_INTERVAL),) \
 		--set image.repository=$(word 1,$(subst :, ,$(DEV_IMG))) \
-		--set image.tag=$(word 2,$(subst :, ,$(DEV_IMG)))
+		--set image.tag=$(word 2,$(subst :, ,$(DEV_IMG))) \
+		$(HELM_EXTRA_ARGS)
 	$(KUBECTL_DEV) -n $(DEV_NAMESPACE) rollout restart deployment/$(DEV_RELEASE)
 	$(KUBECTL_DEV) -n $(DEV_NAMESPACE) rollout status deployment/$(DEV_RELEASE) --timeout=120s
 
@@ -221,8 +222,16 @@ dev-hello: dev-context ## Deploy the hello-world demos (nginx scaled by observed
 	$(KUBECTL_DEV) apply -f hack/dev/hello-ups.yaml
 
 .PHONY: dev-mock
-dev-mock: ## Run a mock UniFi API on :9443 serving captured payloads. POST /flip (WAN) or /ups (power).
+dev-mock: ## Run a mock UniFi API on :9443 serving captured payloads. POST /flip (WAN), /ups (power), /alarm-fire (webhook).
 	go run ./hack/mock-unifi
+
+.PHONY: dev-webhook
+dev-webhook: ## Make the mock console fire a webhook delivery at whatever rule Reactor registered with it.
+	curl -sS -X POST http://localhost:9443/alarm-fire
+
+.PHONY: sanitize-webhook-capture
+sanitize-webhook-capture: ## Turn a raw delivery from hack/webhook-logger.mjs into a committable fixture. Run with no args for usage.
+	./hack/sanitize-webhook-capture.sh $(ARGS)
 
 .PHONY: dev-clean
 dev-clean: dev-context ## Remove the demos and the controller from DEV_CONTEXT.

--- a/README.md
+++ b/README.md
@@ -241,9 +241,18 @@ Chart values ([full reference](charts/reactor/README.md)):
 | `log.level` | `info` | `debug` adds the per-observation lines used to work out why an automation did not fire |
 | `unifi.ups.lowBatteryPercent` | `30` | charge at or below this reports `ups.battery: low` |
 | `unifi.ups.criticalBatteryPercent` | `10` | charge at or below this reports `ups.battery: critical` |
+| `unifi.webhook.enabled` | `false` | webhook fast path (below) |
 | `rbac.clusterWide` | `true` | when `false`, restricts the operator to its own namespace |
 
 `Automation` resources are namespaced. An action targets its own namespace by default; naming a different one in `target.namespace` requires `rbac.clusterWide: true`.
+
+### Webhook fast path
+
+Reactions are normally no faster than `unifi.pollInterval`. UniFi's Alarm Manager can post to Reactor instead, cutting that to about a second — and Reactor can create that Alarm Manager rule itself, rather than asking you to click through the UniFi UI.
+
+It is off by default and stays an optimization. A delivery **triggers a poll**; it never sets state. Its payload is not parsed at all, so a delivery that is dropped, duplicated, replayed or forged costs at most one extra request to your console. Every delivery must present a shared secret, the receiver is not exposed outside the cluster unless you expose it, and self-registration fails soft — if the console does not behave as expected, Reactor logs why and carries on polling.
+
+See the [chart reference](charts/reactor/README.md#webhook-fast-path-optional-off-by-default) for the values, how to make the receiver reachable from your console, and what is worth knowing before turning self-registration on.
 
 ## Documentation
 
@@ -263,11 +272,10 @@ Early days: the API group is `v1alpha1` and the project is pre-1.0, so expect br
 
 **The name stays `unifi-reactor` through v1**, and adding providers does not change that. The user-facing surface is already provider-neutral — the API group is `reactor.robbeverhelst.com`, the kind is `Automation` with a `provider` field, the chart is `reactor`, the namespace is `reactor-system` — so a NUT, Proxmox, or Prometheus provider lands with no breaking change and nothing to migrate. Only the repository, the Go module path, and the image carry the `unifi-` prefix, and those are the surfaces you touch least. Discovery favours the specific name besides: people search for a UniFi Kubernetes operator, and `reactor` alone has a lot of prior art. If a second provider ever gains real users, renaming is a repository rename (GitHub redirects), a transition period publishing the image under both paths, and a major-version bump of the module path — a decision for when it has users, not for a version boundary on its own.
 
-Parsers are written against real captured API responses committed to [`testdata/`](testdata/unifi/), never against assumed formats. One caveat worth stating plainly: the `wan` mapping is derived from a gateway with a second uplink configured, but a genuine failover has not yet been observed end-to-end. Treat `wan` as less battle-tested than `ups`.
+Parsers are written against real captured API responses committed to [`testdata/`](testdata/unifi/), never against assumed formats. Two caveats worth stating plainly. The `wan` mapping is derived from a gateway with a second uplink configured, but a genuine failover has not yet been observed end-to-end, so treat `wan` as less battle-tested than `ups`. And the webhook fast path has been exercised against the mock console, not a real one — which is a large part of why it defaults off and why nothing depends on it being right.
 
 ## Roadmap
 
-- Webhook fast path — UniFi's Alarm Manager triggers an immediate re-observation instead of waiting for the next poll ([the API for it is already mapped](docs/unifi-alarm-manager-api.md))
 - Event triggers for genuinely point-in-time things, like a client connecting
 - More actions: HTTP requests, notifications, `restart`, CronJob suspend
 - Prometheus metrics and richer status conditions

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -162,6 +162,80 @@ escalation:
       ups.battery: critical    # all keys must match
 ```
 
+## Webhook fast path (optional, off by default)
+
+Reaction latency is normally bounded by `unifi.pollInterval`. UniFi's Alarm Manager can post to
+Reactor instead, and Reactor then re-observes immediately.
+
+A delivery only ever **triggers a poll**. Its payload is never read and can never set state, so a
+delivery that is dropped, duplicated, replayed or forged costs at most one extra request to your
+console. Polling stays the source of truth; leaving this off costs latency and nothing else.
+
+```sh
+kubectl -n reactor-system create secret generic unifi-reactor-webhook \
+  --from-literal=UNIFI_WEBHOOK_TOKEN="$(openssl rand -hex 32)"
+
+helm upgrade reactor ... --set unifi.webhook.enabled=true
+```
+
+Every delivery must present that secret, as `Authorization: Bearer <token>` or
+`X-Reactor-Token: <token>`. A receiver with no secret configured rejects everything rather than
+accepting everything.
+
+It composes with `unifi.debounce` rather than overriding it. A delivery can bring an observation
+forward, but it cannot supply the consecutive samples a debounced key needs — those always come
+from `unifi.pollInterval`. So a key you asked to settle still settles at the pace you asked for,
+and no one who can reach the endpoint can hurry it along.
+
+### Exposing it
+
+**The receiver is not reachable from your console by default.** Enabling it creates a ClusterIP
+Service, and your UniFi gateway is not in the cluster. Reaching it is a deliberate choice:
+
+| How | Values |
+| --- | --- |
+| LoadBalancer on a LAN-routable address | `unifi.webhook.service.type=LoadBalancer`, `unifi.webhook.service.loadBalancerIP=<address>` |
+| NodePort | `unifi.webhook.service.type=NodePort` |
+| Your own Ingress | leave it a ClusterIP and point an Ingress at `<release>-webhook:9090` |
+| Not at all | `unifi.webhook.service.enabled=false` — useful when something else fronts the pod |
+
+The chart ships no Ingress: TLS, class and annotations vary too much for a default to be right.
+
+With `replicaCount > 1` the endpoint answers on every replica, but only the leader polls, so a
+delivery landing on a standby is accepted and dropped — the same cost as a missed delivery.
+
+### Letting Reactor register its own rule
+
+Reactor can create the Alarm Manager rule itself instead of you creating it in the UniFi UI:
+
+```sh
+kubectl -n reactor-system create secret generic unifi-reactor-console \
+  --from-literal=UNIFI_USERNAME=<local console account> \
+  --from-literal=UNIFI_PASSWORD=<password>
+
+helm upgrade reactor ... \
+  --set unifi.webhook.enabled=true \
+  --set unifi.webhook.registration.enabled=true \
+  --set unifi.webhook.registration.publicURL=http://<reachable address>:9090/webhooks/unifi
+```
+
+This is a second, separate credential: the Alarm Manager API sits at the UniFi OS layer and rejects
+the API key the poller uses.
+
+Worth knowing before switching it on:
+
+- It writes to your gateway over an **undocumented, reverse-engineered, version-fragile** API
+  ([notes](https://github.com/robbeverhelst/unifi-reactor/blob/main/docs/unifi-alarm-manager-api.md)),
+  verified against UniFi Network 10.5.67 only.
+- It **only ever creates** its rule. It never edits or deletes one, because those verbs were never
+  confirmed against a real console. If `publicURL` changes later, the stale rule is reported in the
+  logs and left for you to remove in the UniFi UI.
+- It **fails soft**. Anything unexpected — login refused, the catalog missing the webhook action,
+  the console rejecting the body — is logged and abandoned, and polling continues untouched.
+- Creating the rule by hand in the UniFi UI is the conservative option, and it works: point a
+  Custom Webhook action at the receiver with a bearer token, or with an `Authorization` header in
+  the action's custom-headers list.
+
 ## Operations
 
 ### Log level
@@ -231,6 +305,22 @@ networkPolicy:
         - { protocol: TCP, port: 443 }
 ```
 
+Denying all inbound is right until you turn the webhook fast path on, at which
+point the console does need to reach the receiver. The chart does **not** widen
+`networkPolicy.ingress` for you — a policy that opens a port you did not write
+there would be a bad surprise — so add the rule yourself. Without it, deliveries
+are dropped and Reactor quietly falls back to the poll interval, which is the
+one failure here that looks like nothing at all:
+
+```yaml
+networkPolicy:
+  ingress:
+    - from:
+        - ipBlock: { cidr: <your UniFi console IP>/32 }
+      ports:
+        - { protocol: TCP, port: 9090 }
+```
+
 ## Values
 
 | Key | Default | Description |
@@ -254,6 +344,21 @@ networkPolicy:
 | `unifi.ups.criticalBatteryPercent` | `10` | charge at or below this reports `ups.battery: critical` |
 | `unifi.debounce.default` | `1` | consecutive observations a changed value needs before Reactor acts; each extra sample costs one `pollInterval` of reaction time |
 | `unifi.debounce.keys` | `{ups.battery: 2}` | per-key overrides for signals that settle rather than switch |
+| `unifi.webhook.enabled` | `false` | Run the webhook receiver; a delivery triggers a poll, never a state change |
+| `unifi.webhook.port` | `9090` | Port the receiver listens on inside the pod |
+| `unifi.webhook.path` | `/webhooks/unifi` | URL path deliveries are accepted on |
+| `unifi.webhook.existingSecret` | `unifi-reactor-webhook` | Secret containing the shared secret |
+| `unifi.webhook.tokenKey` | `UNIFI_WEBHOOK_TOKEN` | Key in that Secret |
+| `unifi.webhook.minObserveInterval` | `500ms` | Floor between observations, so a delivery burst is not a request burst |
+| `unifi.webhook.service.enabled` | `true` | Create a Service for the receiver |
+| `unifi.webhook.service.type` | `ClusterIP` | **Not reachable from your console**; see [Exposing it](#exposing-it) |
+| `unifi.webhook.service.port` | `9090` | Service port |
+| `unifi.webhook.service.annotations` | `{}` | Service annotations (MetalLB pools, cloud LB hints, …) |
+| `unifi.webhook.service.loadBalancerIP` | `""` | Address to request when `type: LoadBalancer` |
+| `unifi.webhook.registration.enabled` | `false` | Let Reactor create its own Alarm Manager rule on the console |
+| `unifi.webhook.registration.publicURL` | `""` | URL the console should POST to (required when registering) |
+| `unifi.webhook.registration.ruleTitle` | `unifi-reactor` | Title of the rule Reactor creates and recognizes |
+| `unifi.webhook.registration.existingSecret` | `unifi-reactor-console` | Secret containing `UNIFI_USERNAME` and `UNIFI_PASSWORD` |
 | `uninstall.releaseClaims` | `true` | Run a pre-delete Job that hands every held workload back before the operator is removed |
 | `uninstall.timeoutSeconds` | `120` | Hard bound on that Job, so a stuck release delays rather than blocks the uninstall |
 | `rbac.clusterWide` | `true` | `false` restricts the operator to the release namespace (cross-namespace `target.namespace` stops working) |

--- a/charts/reactor/templates/deployment.yaml
+++ b/charts/reactor/templates/deployment.yaml
@@ -1,3 +1,14 @@
+{{- if and .Values.unifi.webhook.enabled (not .Values.unifi.url) }}
+{{- fail "unifi.webhook.enabled needs unifi.url set: there is no console to re-observe" }}
+{{- end }}
+{{- if .Values.unifi.webhook.registration.enabled }}
+{{- if not .Values.unifi.webhook.enabled }}
+{{- fail "unifi.webhook.registration.enabled needs unifi.webhook.enabled: registering a rule for a receiver that is not running only creates failing deliveries" }}
+{{- end }}
+{{- if not .Values.unifi.webhook.registration.publicURL }}
+{{- fail "unifi.webhook.registration.enabled needs unifi.webhook.registration.publicURL: the URL your UniFi console should POST to, which Reactor cannot work out for itself" }}
+{{- end }}
+{{- end }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -67,6 +78,46 @@ spec:
             # poll instead of waiting for someone to restart the pod.
             - name: UNIFI_API_KEY_FILE
               value: /etc/unifi-reactor/credentials/UNIFI_API_KEY
+            {{- if .Values.unifi.webhook.enabled }}
+            - name: UNIFI_WEBHOOK_ENABLED
+              value: "true"
+            - name: UNIFI_WEBHOOK_BIND_ADDRESS
+              value: ":{{ .Values.unifi.webhook.port }}"
+            - name: UNIFI_WEBHOOK_PATH
+              value: {{ .Values.unifi.webhook.path | quote }}
+            - name: UNIFI_WEBHOOK_MIN_INTERVAL
+              value: {{ .Values.unifi.webhook.minObserveInterval | quote }}
+            # Injected once at startup, unlike the API key above: rotating this
+            # secret also means recreating the Alarm Manager rule that carries
+            # it, which Reactor deliberately never edits, so there is no
+            # restart-free rotation to preserve here.
+            # Not optional either: a receiver with no shared secret rejects
+            # every delivery, so a missing key should fail loudly here rather
+            # than look like a console that stopped calling.
+            - name: UNIFI_WEBHOOK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.unifi.webhook.existingSecret | quote }}
+                  key: {{ .Values.unifi.webhook.tokenKey | quote }}
+            {{- if .Values.unifi.webhook.registration.enabled }}
+            - name: UNIFI_WEBHOOK_REGISTER
+              value: "true"
+            - name: UNIFI_WEBHOOK_PUBLIC_URL
+              value: {{ .Values.unifi.webhook.registration.publicURL | quote }}
+            - name: UNIFI_WEBHOOK_RULE_TITLE
+              value: {{ .Values.unifi.webhook.registration.ruleTitle | quote }}
+            - name: UNIFI_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.unifi.webhook.registration.existingSecret | quote }}
+                  key: UNIFI_USERNAME
+            - name: UNIFI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.unifi.webhook.registration.existingSecret | quote }}
+                  key: UNIFI_PASSWORD
+            {{- end }}
+            {{- end }}
             {{- end }}
           securityContext:
             allowPrivilegeEscalation: false
@@ -76,6 +127,10 @@ spec:
           ports:
             - name: healthz
               containerPort: 8081
+            {{- if .Values.unifi.webhook.enabled }}
+            - name: webhook
+              containerPort: {{ .Values.unifi.webhook.port }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/charts/reactor/templates/webhook-service.yaml
+++ b/charts/reactor/templates/webhook-service.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.unifi.webhook.enabled .Values.unifi.webhook.service.enabled }}
+# Service for the webhook fast path.
+#
+# A ClusterIP — the default — is NOT reachable from a UniFi console: the
+# gateway is not in the cluster. Reaching it needs a deliberate choice about
+# exposure: type LoadBalancer on a LAN-routable address, type NodePort, or your
+# own Ingress pointed at this Service. Reactor does not guess, because the wrong
+# guess publishes an endpoint the operator did not ask to publish.
+#
+# Whatever the exposure, deliveries still have to present the shared secret, and
+# the worst an accepted one can do is cause an extra poll.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "reactor.fullname" . }}-webhook
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+  {{- with .Values.unifi.webhook.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.unifi.webhook.service.type }}
+  {{- with .Values.unifi.webhook.service.loadBalancerIP }}
+  loadBalancerIP: {{ . | quote }}
+  {{- end }}
+  selector:
+    {{- include "reactor.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: webhook
+      port: {{ .Values.unifi.webhook.service.port }}
+      targetPort: webhook
+      protocol: TCP
+{{- end }}

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -46,6 +46,61 @@ unifi:
   #     --from-literal=UNIFI_API_KEY=<your API key>
   existingSecret: unifi-reactor-credentials
 
+  # Webhook fast path. UniFi's Alarm Manager posts here and Reactor re-observes
+  # state straight away instead of waiting for the next poll.
+  #
+  # A delivery only ever triggers a poll — its payload is never read and can
+  # never set state — so polling stays the source of truth. Leaving this off
+  # costs reaction latency and nothing else.
+  webhook:
+    enabled: false
+    # Port the receiver listens on inside the pod.
+    port: 9090
+    path: /webhooks/unifi
+    # Secret holding the shared secret every delivery must present, as
+    # "Authorization: Bearer <token>" or "X-Reactor-Token: <token>". Nothing is
+    # accepted without it. Create it with:
+    #   kubectl -n <namespace> create secret generic unifi-reactor-webhook \
+    #     --from-literal=UNIFI_WEBHOOK_TOKEN="$(openssl rand -hex 32)"
+    existingSecret: unifi-reactor-webhook
+    tokenKey: UNIFI_WEBHOOK_TOKEN
+    # Floor between two observations. A real outage fires several triggers at
+    # once and a retrying console repeats them; this is what keeps a burst of
+    # deliveries — or a flood from whoever finds the endpoint — from becoming a
+    # burst of requests to your gateway.
+    minObserveInterval: 500ms
+
+    # The receiver is NOT reachable from your console by default: this Service
+    # is a ClusterIP, and your UniFi gateway is not in the cluster. Give it a
+    # type your console can reach (LoadBalancer on a LAN-routable address, or
+    # NodePort), or point your own Ingress at it.
+    service:
+      enabled: true
+      type: ClusterIP
+      port: 9090
+      annotations: {}
+      loadBalancerIP: ""
+
+    # Optional: let Reactor create its own Alarm Manager rule on the console,
+    # instead of you creating it in the UniFi UI.
+    #
+    # This writes to your gateway on every start, over an API that is
+    # undocumented, reverse-engineered and version-fragile. It fails soft and
+    # never blocks polling, and Reactor only ever creates its rule — it never
+    # edits or deletes one. Off by default for good reason; creating the rule
+    # by hand in the UniFi UI is the conservative option.
+    registration:
+      enabled: false
+      # The URL your console should POST to. Reactor cannot work this out: only
+      # you know how the pod is exposed. Must be reachable from the console and
+      # must not be a loopback address.
+      publicURL: ""
+      ruleTitle: unifi-reactor
+      # Secret holding UNIFI_USERNAME and UNIFI_PASSWORD for a UniFi OS local
+      # account. The Alarm Manager API sits at the UniFi OS layer and rejects
+      # the API key the poller uses, so this is a second, separate credential.
+      existingSecret: unifi-reactor-console
+
 log:
   # Verbosity: "debug", "info", "error", or a V-level number ("1", "2").
   # debug turns on the per-observation lines you want while working out why a
@@ -105,8 +160,22 @@ networkPolicy:
   # When enabled, nothing may reach the operator and egress is whatever the
   # rules below allow — narrow them to your API server, DNS, and console.
   enabled: false
-  # Nothing needs to reach the operator: it serves only kubelet health probes,
-  # which most CNIs deliver from the node outside policy enforcement.
+  # Nothing needs to reach the operator by default: it serves only kubelet
+  # health probes, which most CNIs deliver from the node outside policy
+  # enforcement.
+  #
+  # The exception is unifi.webhook.enabled, where the console does need to
+  # reach it. This list is NOT widened for you when the webhook is on — a
+  # policy that opens a port you did not write here would be a bad surprise —
+  # so add the rule yourself, or deliveries are dropped and Reactor quietly
+  # falls back to the poll interval:
+  #   ingress:
+  #     - from:
+  #         - ipBlock:
+  #             cidr: 192.0.2.1/32     # your console
+  #       ports:
+  #         - protocol: TCP
+  #           port: 9090
   ingress: []
   # Unrestricted by default, so enabling the policy cannot silently break
   # polling or the operator's connection to the API server. See the chart

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -18,13 +18,11 @@ package main
 
 import (
 	"crypto/tls"
-	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
-	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -70,25 +68,6 @@ func (w targetAdmissionWarnings) HandleWarningHeader(code int, _ string, text st
 		return
 	}
 	w.log.V(1).Info("API server warning about a targeted resource; the request itself succeeded", "warning", text)
-}
-
-// unifiAPIKey resolves where the API key comes from, and fails fast if it
-// cannot be read at all. UNIFI_API_KEY_FILE points at a mounted Secret and is
-// re-read on every poll, so rotating the key takes effect without a restart;
-// UNIFI_API_KEY holds the key in the environment, where it is fixed for the
-// life of the process and rotation means restarting the pod.
-func unifiAPIKey() (unifi.APIKey, error) {
-	if path := os.Getenv("UNIFI_API_KEY_FILE"); path != "" {
-		key := unifi.FileAPIKey(path)
-		if _, err := key(); err != nil {
-			return nil, err
-		}
-		return key, nil
-	}
-	if key := os.Getenv("UNIFI_API_KEY"); key != "" {
-		return unifi.StaticAPIKey(key), nil
-	}
-	return nil, errors.New("UNIFI_URL is set but neither UNIFI_API_KEY_FILE nor UNIFI_API_KEY is")
 }
 
 func init() {
@@ -305,53 +284,16 @@ func main() {
 
 	// The UniFi provider is configured at the controller level (Helm values /
 	// env), not per-Automation: one UniFi console per Reactor install.
-	if unifiURL := os.Getenv("UNIFI_URL"); unifiURL != "" {
-		apiKey, err := unifiAPIKey()
-		if err != nil {
-			setupLog.Error(err, "Failed to resolve the UniFi API key")
+	unifiConfig, unifiEnabled, err := unifi.ConfigFromEnv(os.Getenv)
+	if err != nil {
+		setupLog.Error(err, "Failed to configure the UniFi provider")
+		os.Exit(1)
+	}
+	if unifiEnabled {
+		if err := setupUniFi(mgr, unifiConfig, store, wake); err != nil {
+			setupLog.Error(err, "Failed to set up the UniFi provider")
 			os.Exit(1)
 		}
-		interval := 30 * time.Second
-		if v := os.Getenv("UNIFI_POLL_INTERVAL"); v != "" {
-			parsed, err := time.ParseDuration(v)
-			if err != nil {
-				setupLog.Error(err, "Invalid UNIFI_POLL_INTERVAL", "value", v)
-				os.Exit(1)
-			}
-			interval = parsed
-		}
-		unifiClient := unifi.NewClient(unifiURL, apiKey, os.Getenv("UNIFI_SITE"),
-			os.Getenv("UNIFI_INSECURE_SKIP_VERIFY") == "true")
-		for _, threshold := range []struct {
-			env    string
-			target *int
-		}{
-			{"UNIFI_UPS_LOW_BATTERY_PERCENT", &unifiClient.LowBatteryPercent},
-			{"UNIFI_UPS_CRITICAL_BATTERY_PERCENT", &unifiClient.CriticalBatteryPercent},
-		} {
-			v := os.Getenv(threshold.env)
-			if v == "" {
-				continue
-			}
-			parsed, err := strconv.Atoi(v)
-			if err != nil {
-				setupLog.Error(err, "Invalid battery threshold", "var", threshold.env, "value", v)
-				os.Exit(1)
-			}
-			*threshold.target = parsed
-		}
-		poller := &controller.UniFiPoller{
-			Client:   unifiClient,
-			Store:    store,
-			Interval: interval,
-			Reader:   mgr.GetClient(),
-			Events:   wake,
-		}
-		if err := mgr.Add(poller); err != nil {
-			setupLog.Error(err, "Failed to add UniFi poller")
-			os.Exit(1)
-		}
-		setupLog.Info("UniFi provider enabled", "url", unifiURL, "interval", interval)
 	} else {
 		setupLog.Info("UniFi provider disabled (UNIFI_URL not set); state triggers will stay pending")
 	}
@@ -382,4 +324,57 @@ func main() {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)
 	}
+}
+
+// setupUniFi wires the poller — the mechanism of record — and, when it is
+// configured, the webhook fast path in front of it.
+//
+// The ordering of failures here is the point: anything wrong with the fast path
+// is reported and skipped, and the poller is added regardless. Reactor with a
+// broken optimization reacts on the poll interval; Reactor without a poller
+// does not react at all.
+func setupUniFi(mgr ctrl.Manager, cfg unifi.Config, store *engine.StateStore, wake chan event.GenericEvent) error {
+	unifiClient := unifi.NewClient(cfg.URL, cfg.APIKey, cfg.Site, cfg.InsecureSkipVerify)
+	unifiClient.LowBatteryPercent = cfg.LowBatteryPercent
+	unifiClient.CriticalBatteryPercent = cfg.CriticalBatteryPercent
+
+	poller := &controller.UniFiPoller{
+		Client:             unifiClient,
+		Store:              store,
+		Interval:           cfg.PollInterval,
+		Reader:             mgr.GetClient(),
+		Events:             wake,
+		MinObserveInterval: cfg.Webhook.MinObserveInterval,
+	}
+
+	switch err := cfg.Webhook.Validate(); {
+	case err != nil:
+		setupLog.Error(err, "Webhook fast path not started; UniFi state still converges on the poll interval")
+	case cfg.Webhook.Enabled:
+		receiver := unifi.NewReceiver(cfg.Webhook)
+		poller.Nudge = receiver.Requests()
+		if err := mgr.Add(receiver); err != nil {
+			return err
+		}
+		setupLog.Info("Webhook fast path enabled",
+			"address", cfg.Webhook.BindAddress, "path", cfg.Webhook.Path,
+			"minObserveInterval", cfg.Webhook.MinObserveInterval)
+		if cfg.Webhook.Register {
+			registrar, err := unifi.NewAlarmRegistrar(cfg)
+			if err != nil {
+				return err
+			}
+			if err := mgr.Add(registrar); err != nil {
+				return err
+			}
+			setupLog.Info("Alarm Manager self-registration enabled",
+				"rule", cfg.Webhook.RuleTitle, "callbackURL", cfg.Webhook.PublicURL)
+		}
+	}
+
+	if err := mgr.Add(poller); err != nil {
+		return err
+	}
+	setupLog.Info("UniFi provider enabled", "url", cfg.URL, "interval", cfg.PollInterval)
+	return nil
 }

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -125,25 +125,67 @@ A full wake channel must never stall observation. The wake is an optimization; t
 
 `wake` filters the Automation list by `Spec.When.Provider`, so your poller only wakes its own. That filter is currently written once per poller. When the second provider lands, the obvious refactor is lifting it into a shared helper parameterized by provider name — a change inside `internal/controller/`, not `internal/engine/`.
 
+**Do not confuse `Events` with `Nudge`.** They point in opposite directions and only one is required. `Events` is outbound — the poller telling the reconciler that something changed, as above. `Nudge` is inbound and optional: something outside the loop asking for an observation to happen *sooner*, which is how the UniFi webhook fast path works. It is a separate `<-chan struct{}` in the same `select`, and a nil channel simply means the provider has no fast path:
+
+```go
+select {
+case <-ctx.Done():
+    return nil
+case <-ticker.C:
+case <-p.Nudge:
+    // A nudge says "look now". It never says what changed.
+    if !waitFor(ctx, minInterval-time.Since(observedAt)) {
+        return nil
+    }
+}
+```
+
+Three properties make that safe to copy. The nudge channel holds a **single slot** with a non-blocking send at the other end, so a burst of requests coalesces into one pending observation rather than one per request. `MinObserveInterval` floors the gap between two observations, so whoever is sending nudges — including someone who should not be — cannot turn them into unbounded upstream traffic. And the observation that follows is what decides the state; a nudge carries no data at all.
+
+**A nudge must not interact with debounce.** This is the one place the fast path and the settling policy below genuinely meet, and getting it wrong is a security bug rather than a bug. Debounce reports a changed value only after N consecutive observations — but if a nudge can cause an observation, then anyone able to send nudges can also supply those N samples, and push a debounced key through its settling time in a fraction of the intended window. The fix is one condition, using `StateStore.Proving` to ask whether anything is part-way through its threshold:
+
+```go
+case <-p.Nudge:
+    if p.Store.Proving(unifi.ProviderName) {
+        // A delivery may make Reactor look sooner. It may not make
+        // Reactor believe something sooner.
+        continue
+    }
+```
+
+A nudge is still allowed to *start* a debounce — that is "look sooner", and it costs one observation. Every later nudge is refused until the value is either promoted or abandoned, so the samples that promote it always come from the poll cadence. If your provider has an inbound trigger and any debounced key, copy this condition too.
+
 ### 4. `cmd/main.go` — the wiring
 
 The provider is constructed only when its configuration is present, and its absence is logged rather than fatal:
 
 ```go
-if unifiURL := os.Getenv("UNIFI_URL"); unifiURL != "" {
-    // ... read config, construct client ...
-    poller := &controller.UniFiPoller{
-        Client: unifiClient, Store: store, Interval: interval,
-        Reader: mgr.GetClient(), Events: wake,
-    }
-    if err := mgr.Add(poller); err != nil { /* fatal */ }
-    setupLog.Info("UniFi provider enabled", "url", unifiURL, "interval", interval)
+unifiConfig, unifiEnabled, err := unifi.ConfigFromEnv(os.Getenv)
+if err != nil { /* fatal */ }
+if unifiEnabled {
+    if err := setupUniFi(mgr, unifiConfig, store, wake); err != nil { /* fatal */ }
 } else {
     setupLog.Info("UniFi provider disabled (UNIFI_URL not set); state triggers will stay pending")
 }
 ```
 
-Both `store` and `wake` are created once and shared by every provider. A second provider adds a second `if` block against the same two values. Missing *credentials* when the provider is enabled is fatal — `unifiAPIKey()` resolves the key and `main` exits if it cannot be read at all — while a *disabled* provider is not. Follow that split: an operator that silently polls nothing is worse than one that refuses to start.
+Reading the environment lives in the provider package, not in `main`: `unifi.ConfigFromEnv` takes a `lookup func(string) string`, returns a `Config` plus whether the provider is configured at all, and is unit-tested without touching process state. `main` keeps only the wiring. Copy that split — `main` grows one block per provider and stays readable, and the mapping from environment to behaviour gets tests instead of a code review.
+
+Both `store` and `wake` are created once and shared by every provider. A second provider adds a second block against the same two values. Missing *credentials* when the provider is enabled is fatal — `ConfigFromEnv` resolves the key and `main` exits if it cannot be read at all — while a *disabled* provider is not. Follow that split: an operator that silently polls nothing is worse than one that refuses to start.
+
+The one place that rule bends is an **optional** part of a provider that is not the mechanism of record. `setupUniFi` validates the webhook fast path separately, and a fast path that cannot start is logged and skipped while the poller is added regardless:
+
+```go
+switch err := cfg.Webhook.Validate(); {
+case err != nil:
+    setupLog.Error(err, "Webhook fast path not started; UniFi state still converges on the poll interval")
+case cfg.Webhook.Enabled:
+    // ... receiver, and optionally self-registration ...
+}
+if err := mgr.Add(poller); err != nil { return err }
+```
+
+The test for which side of that line something sits on: if it is broken, does the operator still converge? A missing credential means it never observes anything, so that is fatal. A misconfigured optimization only costs latency, so it is a log line.
 
 ### Credentials: resolve per request, not at startup
 
@@ -209,11 +251,12 @@ Three layers, all runnable with `make test` and none needing hardware:
 
 - [ ] `internal/providers/<name>/state.go` — `ProviderName` plus unexported key and value constants
 - [ ] `internal/providers/<name>/client.go` — `Observe(ctx) (map[string]string, error)`, transport split from derivation
+- [ ] `internal/providers/<name>/config.go` — `ConfigFromEnv(lookup)`, so the environment mapping is tested rather than reviewed
 - [ ] `hack/capture-<name>.sh` — allowlist-first capture, placeholders for anything identifying
 - [ ] `testdata/<name>/` fixtures plus a README recording hardware, version, and inferred mappings
 - [ ] `hack/verify-testdata.sh` extended with the new provider's secret-bearing fields
 - [ ] `internal/controller/<name>_poller.go` — `Runnable`, `NeedLeaderElection() true`, non-blocking wake
-- [ ] `cmd/main.go` — construct only when configured, log clearly when disabled, share `store` and `wake`
+- [ ] `cmd/main.go` — construct only when configured, log clearly when disabled, share `store` and `wake`; anything optional fails soft while the poller is added regardless
 - [ ] `charts/reactor/values.yaml` and `templates/deployment.yaml` — config values and env, credentials mounted as a directory and pointed at by a `*_FILE` variable
 - [ ] Tests at all three layers
 - [ ] Docs: the state-key table in `README.md` and `charts/reactor/README.md`
@@ -223,8 +266,8 @@ Three layers, all runnable with `make test` and none needing hardware:
 
 Some things genuinely belong in the core, and the test is whether the engine would have to learn a provider's vocabulary:
 
-- **Debounce** — requiring N consecutive identical observations before a value is reported. This belongs in `StateStore.Observe`, not in your provider, so that every Automation reads the same value. Configuration comes from the provider as an opaque key → sample-count map; the engine never learns that `ups` should react fast. Tracked in #30.
-- **A webhook fast path** — a receiver that triggers an immediate re-observation. It never executes actions and never bypasses the poller; it just makes the next observation happen sooner. Tracked in #32 for UniFi.
+- **Debounce** — requiring N consecutive identical observations before a value is reported. This lives in `StateStore.Observe`, not in your provider, so that every Automation reads the same value. Configuration arrives from the provider as an opaque key → sample-count map; the engine never learns that `ups` should react fast. Supply yours with `engine.WithDebounce(ProviderName, ...)`, and if you also have an inbound trigger, see the `Proving` note above.
+- **A webhook fast path** — a receiver that triggers an immediate re-observation. It never executes actions and never bypasses the poller; it just makes the next observation happen sooner. This one turned out **not** to need the engine at all: `internal/providers/unifi/receiver.go` is an HTTP `Runnable` that authenticates a delivery, discards its body without reading it, and sends on the poller's `Nudge` channel. Because no state is derived from a payload, a dropped, duplicated, replayed or forged delivery costs at most one extra observation. If your upstream can push, copy that shape rather than parsing what it pushes.
 
 And some things are a different extension point entirely. **Action types are not providers.** A provider observes; an action acts. Adding `kubernetes.restart` or an HTTP action means extending the action side of the reconciler and the `Action` type's enum, and touches none of the above.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -69,6 +69,64 @@ curl -X POST 'http://localhost:9443/ups?mode=mains&level=100'  # power restored
 
 Point the operator at it with `UNIFI_URL=http://<your-host>:9443 UNIFI_API_KEY=mock`. Use a LAN address rather than `localhost` so the pod can reach your machine.
 
+## Webhook fast path
+
+The receiver turns a UniFi Alarm Manager delivery into an immediate re-observation. It is off by default, and everything about it degrades to poll-only:
+
+```sh
+make dev-deploy DEV_CONTEXT=kind-reactor \
+  UNIFI_URL=http://<your-host>:9443 UNIFI_API_KEY=mock \
+  HELM_EXTRA_ARGS="--set unifi.webhook.enabled=true"
+```
+
+The receiver needs a Secret with the shared secret it will demand from every delivery:
+
+```sh
+kubectl -n reactor-system create secret generic unifi-reactor-webhook \
+  --from-literal=UNIFI_WEBHOOK_TOKEN="$(openssl rand -hex 32)"
+```
+
+Send a delivery by hand — the payload is never read, so any body will do:
+
+```sh
+curl -X POST http://<receiver>:9090/webhooks/unifi \
+  -H 'Authorization: Bearer <token>' \
+  -H 'Content-Type: application/json' \
+  -d @hack/dev/webhook-delivery.json
+```
+
+The logs show the delivery and the observation it caused, in that order:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep -E 'webhook delivery|state observed'
+```
+
+`hack/dev/webhook-delivery.json` is **synthetic**, not a capture. Nothing in Reactor parses a delivery, so a stand-in is enough to drive the path.
+
+### Rehearsing self-registration
+
+`make dev-mock` also mocks the Alarm Manager API, so the registration path can be exercised without touching a real console. Run the mock, start Reactor with `unifi.webhook.registration.enabled=true`, and then have the mock fire a delivery at whatever rule Reactor registered:
+
+```sh
+make dev-webhook
+```
+
+The mock's alarm responses are built from `docs/unifi-alarm-manager-api.md`, not captured from a console. Registration succeeding against the mock proves Reactor sends what those notes describe. It does not prove a real console accepts it.
+
+### Capturing real deliveries
+
+`hack/webhook-logger.mjs` dumps incoming requests verbatim to `testdata/unifi/webhooks/raw/` (gitignored). Raw records contain every header, including the `Authorization` header carrying Reactor's own shared secret, so nothing goes from there into `testdata/` by hand:
+
+```sh
+node hack/webhook-logger.mjs 8080
+
+./hack/sanitize-webhook-capture.sh --paths testdata/unifi/webhooks/raw/<file>.json
+./hack/sanitize-webhook-capture.sh testdata/unifi/webhooks/raw/<file>.json \
+  internet-disconnected alarm.trigger,alarm.title
+```
+
+The first command prints every field path in the body; the second keeps the ones you name and discards the rest, along with every header but `content-type`. Same allowlist discipline as `hack/capture-unifi.sh`, and `hack/verify-testdata.sh` rejects leftover credential material in `testdata/unifi/webhooks/` as a safety net.
+
 ## Captured payloads
 
 Parsers are written and tested against real responses in [`testdata/unifi/`](../testdata/unifi/README.md), never against assumed formats. Capture them with:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -192,6 +192,22 @@ kubectl -n reactor-system get deploy reactor \
 
 For the env path, `kubectl -n reactor-system rollout restart deployment/reactor` after rotating. Better, upgrade the chart. If you would rather restart on change anyway — because you already run something like reloader — the chart takes Deployment `annotations` for it.
 
+### The webhook shared secret
+
+Only relevant with `unifi.webhook.enabled`. This is a **second, separate** credential from the API key, and its failures all look the same from the outside: reactions go back to taking up to `unifi.pollInterval`, because the fast path is an optimization and losing it breaks nothing else. Nothing is stuck — it is just slow again.
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep -i 'webhook'
+```
+
+| What you see | Cause |
+| --- | --- |
+| `Rejected a webhook delivery presenting no valid token` (needs `log.level=debug`) | The console's rule does not carry the secret in `UNIFI_WEBHOOK_TOKEN`, or carries an old one |
+| `Webhook fast path listening` and then nothing | Deliveries never arrive: the console cannot reach the receiver. It is a ClusterIP by default, and a `networkPolicy` with the default `ingress: []` also denies them |
+| `Could not register the Alarm Manager rule` | Self-registration failed; the error names the reason. Polling is unaffected, and the rule can be created by hand in the UniFi UI |
+
+Rotating this secret is not restart-free the way the API key is, and it takes two steps: the console holds a copy inside the Alarm Manager rule, and Reactor never edits that rule. Update the Secret, restart the pod, then update or recreate the rule in the UniFi UI. Deliveries are refused in between, which costs latency and nothing else.
+
 ---
 
 ## 4. `onExit` fired — or did not — when you did not expect it

--- a/docs/unifi-alarm-manager-api.md
+++ b/docs/unifi-alarm-manager-api.md
@@ -71,6 +71,42 @@ The alarms API lives at the UniFi OS layer (no `/proxy/network` prefix) and requ
 - Trigger/action option schemas are self-describing JSON Schema in the manifest — an
   operator can validate config client-side before POSTing.
 
+## What Reactor relies on, and how sure we are
+
+`internal/providers/unifi/alarm.go` implements optional self-registration against this API.
+It is off by default. Split by confidence:
+
+**Observed on a real console (10.5.67), as recorded above:**
+
+- cookie session from `POST /api/auth/login`, CSRF token from the `csrfToken` claim in the
+  `TOKEN` JWT, echoed as `x-csrf-token` on writes
+- `GET /api/v2/alarms/network/manifest`, `GET /api/v2/alarms/network`, `POST /api/v2/alarms/network`
+- the arrays-of-arrays `triggers_data` / `actions_data` shape, and that a flat array is rejected
+- the `network:webhook` action and the three Internet trigger IDs
+- `auth` variants `none | basic | bearer` exist; localhost/127.x destinations are rejected
+
+**Inferred, never confirmed against a console:**
+
+- **the field name carrying the bearer value** — Reactor sends
+  `"auth": {"variant": "bearer", "token": "<secret>"}`. The variant list is documented in the
+  manifest; the key holding the value is a guess. If a console rejects the body, the error it
+  returns is logged verbatim, and the rule can be created by hand in the UniFi UI with an
+  `Authorization` header instead — the receiver also accepts `X-Reactor-Token`, which the
+  Alarm Manager's custom-headers list can send.
+- the shape of the manifest and of the rules list. Reactor never assumes a path through either:
+  it searches the decoded document for the IDs it needs and for a rule carrying its own title,
+  so a console that reorganizes its JSON degrades to "not offered" rather than to a decode error.
+
+**Deliberately not used:**
+
+- editing or deleting rules. `DELETE /api/v2/alarms/network/<id>` is an assumed verb, and `PUT`
+  versus `PATCH` was never established. Reactor creates its rule and then leaves it alone
+  forever; guessing wrong here means silently breaking somebody's alerting. A rule whose
+  destination has gone stale is reported in the logs and left for a human to remove.
+
+Every failure on this path is logged and swallowed. Polling remains the mechanism of record, so
+the worst outcome of this API having moved is that Reactor reacts on the poll interval.
+
 ## Current state on the UDM
 
 Rule **"Reactor spike capture"** (`019ff10d-5b3e-7930-8cd8-78745b579492`) exists,

--- a/hack/dev/webhook-delivery.json
+++ b/hack/dev/webhook-delivery.json
@@ -1,0 +1,9 @@
+{
+  "_comment": "SYNTHETIC. Not a capture. Reactor never reads a delivery body, so this only needs to be a plausible JSON blob for driving the fast path locally. Real captures belong in testdata/unifi/webhooks/ and must go through hack/sanitize-webhook-capture.sh first.",
+  "alarm": {
+    "id": "00000000-0000-0000-0000-000000000001",
+    "title": "unifi-reactor",
+    "trigger": "network:internet_disconnected",
+    "timestamp": "2026-01-01T00:00:00.000Z"
+  }
+}

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -29,18 +29,37 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/ups?level=25'    # drains to low
 //	curl -X POST 'http://localhost:9443/ups?level=5'     # drains to critical
 //	curl -X POST 'http://localhost:9443/ups?mode=mains'  # power restored
+//
+// It also mocks enough of the undocumented Alarm Manager API
+// (docs/unifi-alarm-manager-api.md) for Reactor to register its own webhook
+// rule against, and can then fire a delivery at whatever URL that rule names:
+//
+//	curl -X POST http://localhost:9443/alarm-fire
+//
+// The mock's alarm responses are built from those reverse-engineering notes,
+// not captured from a console. Registration working here means Reactor sends
+// what the notes describe; it does not mean a real console accepts it.
 package main
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
+	"io"
 	"log"
+	"maps"
 	"net/http"
 	"os"
 	"strconv"
 	"sync"
+	"time"
 )
+
+// mockCSRF is the token the mock embeds in its session JWT and demands back on
+// every write, the way a real console does.
+const mockCSRF = "mock-csrf-token"
 
 type mock struct {
 	mu       sync.Mutex
@@ -48,14 +67,27 @@ type mock struct {
 	onBackup bool
 	onBatt   bool
 	battLvl  int
+
+	// delivery is the synthetic body /alarm-fire posts. It is a stand-in, not
+	// a capture: no real Alarm Manager delivery has been recorded yet.
+	delivery []byte
+	// rules holds whatever Reactor registered, keyed by the id the mock made up.
+	rules map[string]map[string]any
 }
 
 func main() {
 	addr := flag.String("addr", ":9443", "listen address")
 	dir := flag.String("testdata", "testdata/unifi/api", "directory holding captured stat/device payloads")
+	deliveryFile := flag.String("delivery", "hack/dev/webhook-delivery.json",
+		"synthetic Alarm Manager delivery body posted by /alarm-fire")
 	flag.Parse()
 
-	m := &mock{battLvl: 100}
+	m := &mock{battLvl: 100, rules: map[string]map[string]any{}}
+	if raw, err := os.ReadFile(*deliveryFile); err == nil {
+		m.delivery = raw
+	} else {
+		log.Printf("no synthetic delivery at %s (%v); /alarm-fire will post an empty body", *deliveryFile, err)
+	}
 	for _, name := range []string{"stat-device-gateway.json", "stat-device-ups.json"} {
 		raw, err := os.ReadFile(*dir + "/" + name)
 		if err != nil {
@@ -74,6 +106,13 @@ func main() {
 	mux.HandleFunc("GET /proxy/network/api/s/{site}/stat/device", m.serveDevices)
 	mux.HandleFunc("POST /flip", m.flipWAN)
 	mux.HandleFunc("POST /ups", m.setUPS)
+
+	// The UniFi OS layer: no /proxy/network prefix, cookie session, csrf header.
+	mux.HandleFunc("POST /api/auth/login", m.login)
+	mux.HandleFunc("GET /api/v2/alarms/network/manifest", m.serveManifest)
+	mux.HandleFunc("GET /api/v2/alarms/network", m.serveRules)
+	mux.HandleFunc("POST /api/v2/alarms/network", m.createRule)
+	mux.HandleFunc("POST /alarm-fire", m.fireAlarm)
 
 	log.Printf("mock UniFi API on %s: %d devices, wan=primary, ups=online (100%%)", *addr, len(m.devices))
 	log.Fatal(http.ListenAndServe(*addr, mux)) // #nosec G114 -- dev tool
@@ -147,4 +186,178 @@ func (m *mock) setUPS(w http.ResponseWriter, r *http.Request) {
 	state := map[bool]string{false: "online", true: "on-battery"}[m.onBatt]
 	log.Printf("ups is now %s at %d%%", state, m.battLvl)
 	_, _ = fmt.Fprintf(w, `{"ups":%q,"battery":%d}`+"\n", state, m.battLvl)
+}
+
+// --- Alarm Manager (UniFi OS layer) -----------------------------------------
+
+// login issues a session cookie shaped like the console's: a JWT whose payload
+// carries the csrfToken claim that every write must echo. Any credentials are
+// accepted; this mock is about shapes, not authentication.
+func (m *mock) login(w http.ResponseWriter, _ *http.Request) {
+	payload := base64.RawURLEncoding.EncodeToString([]byte(`{"csrfToken":"` + mockCSRF + `"}`))
+	http.SetCookie(w, &http.Cookie{Name: "TOKEN", Value: "header." + payload + ".signature", Path: "/"})
+	w.Header().Set("x-csrf-token", mockCSRF)
+	writeJSON(w, map[string]any{"unique_id": "00000000-0000-0000-0000-0000000000ff"})
+}
+
+// serveManifest offers the trigger and action IDs the notes record for Network
+// 10.5.67. Reactor checks its IDs against this before writing anything.
+func (m *mock) serveManifest(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, map[string]any{
+		"triggers": []any{map[string]any{
+			"id": "network:category_internet",
+			"items": []any{
+				map[string]any{"id": "network:internet_disconnected"},
+				map[string]any{"id": "network:high_latency_detected"},
+				map[string]any{"id": "network:packet_loss_detected"},
+				map[string]any{"id": "network:data_limit"},
+			},
+		}},
+		"actions": []any{
+			map[string]any{"id": "network:webhook"},
+			map[string]any{"id": "network:slack"},
+		},
+	})
+}
+
+func (m *mock) serveRules(w http.ResponseWriter, _ *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	rules := make([]any, 0, len(m.rules))
+	for id, rule := range m.rules {
+		listed := map[string]any{"id": id}
+		maps.Copy(listed, rule)
+		rules = append(rules, listed)
+	}
+	writeJSON(w, map[string]any{"data": rules})
+}
+
+// createRule enforces the two things the real API is known to be strict about:
+// the csrf header, and triggers_data / actions_data being sequences of
+// sequences rather than flat arrays.
+func (m *mock) createRule(w http.ResponseWriter, r *http.Request) {
+	if r.Header.Get("x-csrf-token") != mockCSRF {
+		http.Error(w, `{"message":"csrf token mismatch"}`, http.StatusForbidden)
+		return
+	}
+	var rule map[string]any
+	if err := json.NewDecoder(r.Body).Decode(&rule); err != nil {
+		http.Error(w, `{"message":"invalid json"}`, http.StatusBadRequest)
+		return
+	}
+	for _, field := range []string{"triggers_data", "actions_data"} {
+		outer, ok := rule[field].([]any)
+		if !ok || len(outer) == 0 {
+			http.Error(w, `{"message":"`+field+`: expected a sequence of sequences"}`, http.StatusBadRequest)
+			return
+		}
+		if _, ok := outer[0].([]any); !ok {
+			http.Error(w, `{"message":"`+field+`: invalid type: sequence, expected a sequence of sequences"}`,
+				http.StatusBadRequest)
+			return
+		}
+	}
+
+	id := fmt.Sprintf("019ff10d-0000-0000-0000-%012d", len(m.rules)+1)
+	m.mu.Lock()
+	m.rules[id] = rule
+	m.mu.Unlock()
+
+	log.Printf("registered alarm rule %q as %s -> %s", rule["title"], id, ruleURL(rule))
+	rule["id"] = id
+	writeJSON(w, rule)
+}
+
+// fireAlarm posts the synthetic delivery to whatever URL a registered rule
+// names, presenting the token that rule carries. This is the mock standing in
+// for a console that noticed something.
+func (m *mock) fireAlarm(w http.ResponseWriter, r *http.Request) {
+	m.mu.Lock()
+	rules := make([]map[string]any, 0, len(m.rules))
+	for _, rule := range m.rules {
+		rules = append(rules, rule)
+	}
+	m.mu.Unlock()
+
+	if len(rules) == 0 {
+		http.Error(w, "no alarm rule registered; start Reactor with self-registration enabled\n",
+			http.StatusPreconditionFailed)
+		return
+	}
+	for _, rule := range rules {
+		url, token := ruleURL(rule), ruleToken(rule)
+		if url == "" {
+			continue
+		}
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, url, bytes.NewReader(m.delivery))
+		if err != nil {
+			log.Printf("delivery to %s could not be built: %v", url, err)
+			continue
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+		if err != nil {
+			log.Printf("delivery to %s failed: %v", url, err)
+			_, _ = fmt.Fprintf(w, "delivery to %s failed: %v\n", url, err)
+			continue
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		log.Printf("delivered to %s -> %s", url, resp.Status)
+		_, _ = fmt.Fprintf(w, "delivered to %s -> %s\n", url, resp.Status)
+	}
+}
+
+// ruleURL and ruleToken dig the webhook action out of the arrays-of-arrays
+// body, tolerating anything that does not look the way it should.
+func ruleURL(rule map[string]any) string {
+	data, ok := webhookActionData(rule)
+	if !ok {
+		return ""
+	}
+	url, _ := data["url"].(string)
+	return url
+}
+
+func ruleToken(rule map[string]any) string {
+	data, ok := webhookActionData(rule)
+	if !ok {
+		return ""
+	}
+	auth, ok := data["auth"].(map[string]any)
+	if !ok {
+		return ""
+	}
+	token, _ := auth["token"].(string)
+	return token
+}
+
+func webhookActionData(rule map[string]any) (map[string]any, bool) {
+	outer, ok := rule["actions_data"].([]any)
+	if !ok {
+		return nil, false
+	}
+	for _, group := range outer {
+		members, ok := group.([]any)
+		if !ok {
+			continue
+		}
+		for _, member := range members {
+			action, ok := member.(map[string]any)
+			if !ok || action["id"] != "network:webhook" {
+				continue
+			}
+			data, ok := action["data"].(map[string]any)
+			return data, ok
+		}
+	}
+	return nil, false
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(value)
 }

--- a/hack/sanitize-webhook-capture.sh
+++ b/hack/sanitize-webhook-capture.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Turn a raw Alarm Manager delivery captured by hack/webhook-logger.mjs into a
+# committable fixture — allowlist first, exactly like hack/capture-unifi.sh.
+#
+#   ./hack/sanitize-webhook-capture.sh --paths <raw.json>
+#   ./hack/sanitize-webhook-capture.sh <raw.json> <name> <path,path,...>
+#
+# Example:
+#   ./hack/sanitize-webhook-capture.sh --paths testdata/unifi/webhooks/raw/2026-01-01T00-00-00-000Z_000.json
+#   ./hack/sanitize-webhook-capture.sh testdata/unifi/webhooks/raw/2026-01-01T00-00-00-000Z_000.json \
+#     internet-disconnected alarm.trigger,alarm.title
+#
+# Why this is two steps. A raw record contains the whole request: every header,
+# including the Authorization header carrying Reactor's own shared secret, and a
+# body of unknown shape. The envelope can be allowlisted here once and for all,
+# because its fields are known. The body cannot: nobody has seen one yet. So
+# --paths prints every field path in the body and you name the ones the fixture
+# should keep, deliberately, one at a time.
+#
+# Do not reach for a denylist instead. An earlier version of the API fixtures
+# removed the sensitive fields someone thought of rather than keeping only the
+# needed ones, and a live credential reached this repository's history as a
+# result.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+OUT=testdata/unifi/webhooks
+
+usage() {
+  sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
+  exit 1
+}
+
+[ $# -ge 1 ] || usage
+command -v jq >/dev/null || { echo "jq is required" >&2; exit 1; }
+
+if [ "$1" = "--paths" ]; then
+  [ $# -eq 2 ] || usage
+  echo "field paths in the delivery body of $2:"
+  jq -r '.bodyUtf8 | fromjson | [paths | join(".")] | .[]' "$2"
+  echo
+  echo "Name the ones the fixture should keep:"
+  echo "  $0 $2 <name> alarm.trigger,alarm.title"
+  exit 0
+fi
+
+[ $# -eq 3 ] || usage
+RAW="$1"
+NAME="$2"
+[ -f "$RAW" ] || { echo "no such capture: $RAW" >&2; exit 1; }
+
+# The allowlist as jq paths, e.g. "alarm.trigger" -> ["alarm","trigger"].
+PATHS=$(printf '%s' "$3" | jq -R 'split(",") | map(gsub("^\\s+|\\s+$";"") | select(length > 0) | split("."))')
+[ "$PATHS" != "[]" ] || { echo "name at least one field path to keep" >&2; exit 1; }
+
+mkdir -p "$OUT"
+DEST="$OUT/$NAME.json"
+
+# The envelope allowlist. Note what is NOT in it: every request header (the
+# Authorization header carries Reactor's shared secret), the source address, and
+# the base64 copy of the body, which would otherwise smuggle the whole payload
+# back in past every text-based check.
+jq --arg name "$NAME" --argjson paths "$PATHS" '{
+  capture: $name,
+  method: .method,
+  url: .url,
+  contentType: (.headers["content-type"] // null),
+  body: (.bodyUtf8 | fromjson as $body
+    | reduce $paths[] as $path ({};
+        if ($body | getpath($path)) == null then . else setpath($path; $body | getpath($path)) end))
+} | with_entries(select(.value != null))' "$RAW" > "$DEST"
+
+echo "wrote $DEST"
+echo
+./hack/verify-testdata.sh
+echo
+echo "Read $DEST before committing it. This script keeps what you named and"
+echo "nothing else, but only you know whether what you named is safe to publish."

--- a/hack/verify-testdata.sh
+++ b/hack/verify-testdata.sh
@@ -47,6 +47,24 @@ for file in testdata/unifi/api/*.json testdata/unifi/webhooks/*.json; do
   done < <(grep -oiE '\b([0-9a-f]{2}:){5}[0-9a-f]{2}\b' "$file" | grep -viE '^aa:bb:cc:' | sort -u || true)
 done
 
+# Webhook captures carry one risk the API captures do not: a delivery arrives
+# with Reactor's own shared secret in an Authorization header, so a fixture made
+# by keeping "the request" rather than "these fields of the request" leaks the
+# credential that protects the endpoint.
+for file in testdata/unifi/webhooks/*.json; do
+  [ -e "$file" ] || continue
+
+  while IFS= read -r hit; do
+    echo "$file: delivery credential material: $hit"
+    failed=1
+  done < <(grep -oiE '"(authorization|x-reactor-token|cookie|set-cookie|x-csrf-token|token|bodyBase64)"' "$file" || true)
+
+  while IFS= read -r hit; do
+    echo "$file: bearer credential: $hit"
+    failed=1
+  done < <(grep -oiE 'bearer [a-z0-9._~+/-]+' "$file" || true)
+done
+
 if [ "$failed" -ne 0 ]; then
   echo
   echo "Captures must be sanitized before committing — see testdata/unifi/README.md."

--- a/internal/controller/unifi_poller.go
+++ b/internal/controller/unifi_poller.go
@@ -32,7 +32,8 @@ import (
 
 // UniFiPoller periodically observes UniFi state into the shared StateStore.
 // Polling is the source of truth: it makes the system self-healing after
-// restarts and immune to missed webhook deliveries.
+// restarts and immune to missed webhook deliveries. The webhook fast path can
+// only make an observation happen sooner, never make one happen differently.
 type UniFiPoller struct {
 	Client   *unifi.Client
 	Store    *engine.StateStore
@@ -44,6 +45,16 @@ type UniFiPoller struct {
 	// Events wakes the controller as soon as a transition is observed, instead
 	// of leaving it to notice on its next periodic re-evaluation.
 	Events chan<- event.GenericEvent
+
+	// Nudge carries out-of-band re-observation requests from the webhook fast
+	// path. A nudge says only "look now"; the observation below is what decides
+	// what changed, so a dropped, duplicated, replayed or forged delivery can
+	// cost an extra poll and nothing else. Receiving from a nil channel blocks
+	// forever, so leaving this unset simply means poll-only.
+	Nudge <-chan struct{}
+	// MinObserveInterval floors the time between two observations, so a burst
+	// of deliveries cannot become a burst of requests to the console.
+	MinObserveInterval time.Duration
 }
 
 // Start implements manager.Runnable; the manager cancels ctx on shutdown.
@@ -52,31 +63,94 @@ func (p *UniFiPoller) Start(ctx context.Context) error {
 	ctx = logf.IntoContext(ctx, log)
 	interval := p.Interval
 	if interval <= 0 {
-		interval = 30 * time.Second
+		interval = unifi.DefaultPollInterval
+	}
+	minInterval := p.MinObserveInterval
+	if minInterval <= 0 {
+		minInterval = unifi.DefaultMinObserveInterval
 	}
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
-		state, err := p.Client.Observe(ctx)
-		if err != nil {
-			log.Error(err, "state observation failed")
-		} else {
-			observation := events.Observation{Provider: unifi.ProviderName, State: state, ObservedAt: time.Now()}
-			transitions := p.Store.Observe(observation)
-			log.V(1).Info("state observed", "state", state)
-			for _, t := range transitions {
-				log.Info("state transition", "provider", t.Provider, "key", t.Key, "from", t.From, "to", t.To)
-			}
-			if len(transitions) > 0 {
-				p.wake(ctx)
-			}
+		p.observe(ctx)
+		// Restart the interval from the observation that just happened, so a
+		// nudge-driven poll does not leave a periodic one due immediately after.
+		ticker.Reset(interval)
+
+		if !p.awaitNextObservation(ctx, ticker.C, minInterval, time.Now()) {
+			return nil
 		}
+	}
+}
+
+// awaitNextObservation blocks until it is time to observe again, reporting
+// false if the context ended first.
+//
+// A webhook delivery brings the next observation forward, under two limits.
+// MinObserveInterval floors how often that can happen, so a burst of
+// deliveries cannot become a burst of requests to the console. And while a
+// value is still proving itself against the store's debounce threshold, a
+// delivery is ignored outright: those samples stay on the poll cadence.
+//
+// The second limit is the important one. A delivery may make Reactor look
+// sooner, but it must never supply the evidence that promotes a value —
+// otherwise anyone who can reach the endpoint could fast-forward a debounced
+// key straight through the settling time its operator asked for, which is the
+// one thing debounce exists to prevent.
+func (p *UniFiPoller) awaitNextObservation(ctx context.Context, tick <-chan time.Time,
+	minInterval time.Duration, observedAt time.Time) bool {
+	log := logf.FromContext(ctx)
+	for {
 		select {
 		case <-ctx.Done():
-			return nil
-		case <-ticker.C:
+			return false
+		case <-tick:
+			return true
+		case <-p.Nudge:
+			if p.Store != nil && p.Store.Proving(unifi.ProviderName) {
+				log.V(1).Info("ignoring a webhook delivery while a value is still settling")
+				continue
+			}
+			log.V(1).Info("re-observing early on a webhook delivery")
+			return waitFor(ctx, minInterval-time.Since(observedAt))
 		}
+	}
+}
+
+// observe performs one observation and records the transitions it found. Errors
+// are logged and dropped: the next observation is the recovery mechanism.
+func (p *UniFiPoller) observe(ctx context.Context) {
+	log := logf.FromContext(ctx)
+	state, err := p.Client.Observe(ctx)
+	if err != nil {
+		log.Error(err, "state observation failed")
+		return
+	}
+	observation := events.Observation{Provider: unifi.ProviderName, State: state, ObservedAt: time.Now()}
+	transitions := p.Store.Observe(observation)
+	log.V(1).Info("state observed", "state", state)
+	for _, t := range transitions {
+		log.Info("state transition", "provider", t.Provider, "key", t.Key, "from", t.From, "to", t.To)
+	}
+	if len(transitions) > 0 {
+		p.wake(ctx)
+	}
+}
+
+// waitFor sleeps out d, reporting false if the context ended first. A
+// non-positive duration returns immediately.
+func waitFor(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
 	}
 }
 

--- a/internal/controller/unifi_poller_test.go
+++ b/internal/controller/unifi_poller_test.go
@@ -37,7 +37,7 @@ func automation(name, provider, eventType string) *reactorv1alpha1.Automation {
 		a.Spec.Trigger = &reactorv1alpha1.EventTrigger{Provider: provider, Event: eventType}
 		return a
 	}
-	a.Spec.When = &reactorv1alpha1.StateTrigger{Provider: provider, State: map[string]string{"wan": "backup"}}
+	a.Spec.When = &reactorv1alpha1.StateTrigger{Provider: provider, State: map[string]string{"wan": wanBackupValue}}
 	return a
 }
 

--- a/internal/controller/unifi_webhook_test.go
+++ b/internal/controller/unifi_webhook_test.go
@@ -1,0 +1,385 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/engine"
+	"github.com/robbeverhelst/unifi-reactor/internal/events"
+	"github.com/robbeverhelst/unifi-reactor/internal/providers/unifi"
+)
+
+const (
+	webhookTestToken = "s3cr3t-shared-token"
+	// The value the fake console reports once reportBackup has been called.
+	wanBackupValue = "backup"
+)
+
+// fakeConsole serves the real captured device payload and counts how often it
+// is asked for it, which is the only thing these tests measure: whether an
+// observation happened, and when.
+type fakeConsole struct {
+	mu          sync.Mutex
+	body        []byte
+	observation atomic.Int64
+}
+
+// reportBackup rewrites the served payload so the gateway's uplink moves to
+// WAN2, which is what the provider derives "wan: backup" from.
+func (f *fakeConsole) reportBackup(t *testing.T) {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal(f.body, &payload); err != nil {
+		t.Fatalf("parsing the captured payload: %v", err)
+	}
+	for _, device := range payload["data"].([]any) {
+		record, ok := device.(map[string]any)
+		if !ok {
+			continue
+		}
+		if wan1, ok := record["wan1"].(map[string]any); ok {
+			wan1["is_uplink"] = false
+		}
+		if wan2, ok := record["wan2"].(map[string]any); ok {
+			wan2["is_uplink"] = true
+			wan2["up"] = true
+		}
+	}
+	rewritten, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("encoding the payload: %v", err)
+	}
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.body = rewritten
+}
+
+func newFakeConsole(t *testing.T) (*fakeConsole, *httptest.Server) {
+	t.Helper()
+	// The real capture, so the observation being counted is a real one.
+	body, err := os.ReadFile("../../testdata/unifi/api/stat-device-gateway.json")
+	if err != nil {
+		t.Fatalf("reading the captured device payload: %v", err)
+	}
+	console := &fakeConsole{body: body}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		console.observation.Add(1)
+		console.mu.Lock()
+		defer console.mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(console.body)
+	}))
+	t.Cleanup(server.Close)
+	return console, server
+}
+
+// waitForObservations blocks until the console has been asked at least want
+// times, reporting whether it happened inside the deadline.
+func (f *fakeConsole) waitForObservations(want int64, within time.Duration) bool {
+	deadline := time.Now().Add(within)
+	for time.Now().Before(deadline) {
+		if f.observation.Load() >= want {
+			return true
+		}
+		time.Sleep(time.Millisecond)
+	}
+	return f.observation.Load() >= want
+}
+
+// waitForStoredState blocks until an observation has actually landed in the
+// store. The console being asked is not the same instant as the answer being
+// recorded, so a test that reads the store must wait for the store.
+func waitForStoredState(t *testing.T, store *engine.StateStore) events.Observation {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if observation, ok := store.Get(unifi.ProviderName); ok {
+			return observation
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("no observation reached the store")
+	return events.Observation{}
+}
+
+// deliverTo posts an authenticated delivery through the receiver's real
+// handler, so the test exercises the wire path rather than the channel.
+func deliverTo(t *testing.T, receiver *unifi.Receiver) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, unifi.DefaultWebhookPath, strings.NewReader(`{"alarm":"whatever"}`))
+	req.Header.Set("Authorization", "Bearer "+webhookTestToken)
+	rec := httptest.NewRecorder()
+	receiver.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected the delivery to be accepted, got %d", rec.Code)
+	}
+}
+
+// startPoller runs a poller against the fake console with a poll interval long
+// enough that the ticker cannot be what causes any observation the test sees.
+func startPoller(t *testing.T, url string, minInterval time.Duration) (*unifi.Receiver, *engine.StateStore) {
+	t.Helper()
+	return startPollerWith(t, url, minInterval, time.Hour, engine.NewStateStore())
+}
+
+// startPollerWith is the same, with the poll interval and the store — and so
+// the debounce policy — under the test's control.
+func startPollerWith(t *testing.T, url string, minInterval, interval time.Duration,
+	store *engine.StateStore) (*unifi.Receiver, *engine.StateStore) {
+	t.Helper()
+	receiver := unifi.NewReceiver(unifi.WebhookConfig{Enabled: true, Token: webhookTestToken})
+	poller := &UniFiPoller{
+		Client:             unifi.NewClient(url, unifi.StaticAPIKey("key"), "default", false),
+		Store:              store,
+		Interval:           interval,
+		Nudge:              receiver.Requests(),
+		MinObserveInterval: minInterval,
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	stopped := make(chan error, 1)
+	go func() { stopped <- poller.Start(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case err := <-stopped:
+			if err != nil {
+				t.Errorf("expected the poller to stop cleanly, got %v", err)
+			}
+		case <-time.After(10 * time.Second):
+			t.Error("the poller did not stop when its context was cancelled")
+		}
+	})
+	return receiver, store
+}
+
+// The acceptance criterion: a delivery causes state to be re-observed straight
+// away instead of at the next tick, which here is an hour off.
+func TestADeliveryTriggersReObservationImmediately(t *testing.T) {
+	console, server := newFakeConsole(t)
+	receiver, store := startPoller(t, server.URL, time.Millisecond)
+
+	if !console.waitForObservations(1, 5*time.Second) {
+		t.Fatal("expected the poller to observe once on start")
+	}
+	waitForStoredState(t, store)
+
+	start := time.Now()
+	deliverTo(t, receiver)
+	if !console.waitForObservations(2, time.Second) {
+		t.Fatalf("expected a delivery to trigger a re-observation within a second, waited %s", time.Since(start))
+	}
+}
+
+// A delivery is a hint, never a fact: whatever it claims, the state that lands
+// in the store is the one the console reports on the poll that follows.
+func TestADeliveryCannotPutStateInTheStore(t *testing.T) {
+	console, server := newFakeConsole(t)
+	receiver, store := startPoller(t, server.URL, time.Millisecond)
+	if !console.waitForObservations(1, 5*time.Second) {
+		t.Fatal("expected the poller to observe once on start")
+	}
+	before := waitForStoredState(t, store)
+
+	// A delivery insisting the WAN failed over, sent while the console keeps
+	// reporting the primary uplink.
+	req := httptest.NewRequest(http.MethodPost, unifi.DefaultWebhookPath,
+		strings.NewReader(`{"state":{"wan":"backup"},"triggers":["network:internet_disconnected"]}`))
+	req.Header.Set("Authorization", "Bearer "+webhookTestToken)
+	receiver.Handler().ServeHTTP(httptest.NewRecorder(), req)
+
+	if !console.waitForObservations(2, 5*time.Second) {
+		t.Fatal("expected the delivery to trigger a re-observation")
+	}
+	after, _ := store.Get(unifi.ProviderName)
+	if after.State["wan"] != before.State["wan"] {
+		t.Errorf("a delivery moved state from %q to %q; only an observation may do that",
+			before.State["wan"], after.State["wan"])
+	}
+}
+
+// An unauthenticated delivery must not even cost a poll: otherwise the endpoint
+// is a way to make Reactor hammer somebody's gateway for free.
+func TestAnUnauthenticatedDeliveryCausesNoObservation(t *testing.T) {
+	console, server := newFakeConsole(t)
+	receiver, _ := startPoller(t, server.URL, time.Millisecond)
+	if !console.waitForObservations(1, 5*time.Second) {
+		t.Fatal("expected the poller to observe once on start")
+	}
+
+	req := httptest.NewRequest(http.MethodPost, unifi.DefaultWebhookPath, strings.NewReader("{}"))
+	rec := httptest.NewRecorder()
+	receiver.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", rec.Code)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+	if got := console.observation.Load(); got != 1 {
+		t.Errorf("expected the console to be left alone, it was asked %d times", got)
+	}
+}
+
+// A flood of valid deliveries must not become a flood of console requests. The
+// floor is what stands between a chatty (or hostile) sender and the gateway.
+func TestADeliveryFloodIsRateLimited(t *testing.T) {
+	const floor = 400 * time.Millisecond
+	console, server := newFakeConsole(t)
+	receiver, _ := startPoller(t, server.URL, floor)
+	if !console.waitForObservations(1, 5*time.Second) {
+		t.Fatal("expected the poller to observe once on start")
+	}
+
+	for range 200 {
+		deliverTo(t, receiver)
+	}
+	// Well inside the floor, the console must not have been asked again.
+	time.Sleep(floor / 4)
+	if got := console.observation.Load(); got != 1 {
+		t.Errorf("expected the flood to be held off, the console was asked %d times", got)
+	}
+	// And the deliveries must not be lost either — one observation still owed.
+	if !console.waitForObservations(2, 5*time.Second) {
+		t.Error("expected the held-off deliveries to still produce one observation")
+	}
+	if got := console.observation.Load(); got > 3 {
+		t.Errorf("expected 200 deliveries to collapse into about one observation, got %d", got)
+	}
+}
+
+// The fast path being absent is the default, and must change nothing.
+func TestAPollerWithoutTheFastPathStillPolls(t *testing.T) {
+	console, server := newFakeConsole(t)
+	poller := &UniFiPoller{
+		Client:   unifi.NewClient(server.URL, unifi.StaticAPIKey("key"), "default", false),
+		Store:    engine.NewStateStore(),
+		Interval: 50 * time.Millisecond,
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go func() { _ = poller.Start(ctx) }()
+
+	if !console.waitForObservations(3, 5*time.Second) {
+		t.Errorf("expected polling to continue with no nudge channel, got %d observations",
+			console.observation.Load())
+	}
+}
+
+// debouncedStore requires a changed value to hold for samples consecutive
+// observations before it is reported, which is what #54 added and what a
+// delivery must not be able to shortcut.
+func debouncedStore(samples int) *engine.StateStore {
+	return engine.NewStateStore(engine.WithDebounce(unifi.ProviderName,
+		engine.DebounceConfig{Default: samples}))
+}
+
+// The interaction between the fast path and debounce, and the one that would
+// be a security problem if it went the other way: a delivery may make Reactor
+// look sooner, but it must never supply the evidence that promotes a value.
+// Otherwise anyone who can reach the endpoint could push a debounced key
+// straight through the settling time its operator asked for.
+func TestADeliveryBurstCannotFastForwardADebouncedKey(t *testing.T) {
+	console, server := newFakeConsole(t)
+	// A poll interval long enough that no tick can contribute a sample: every
+	// observation in this test is one a delivery asked for.
+	receiver, store := startPollerWith(t, server.URL, time.Millisecond, time.Hour, debouncedStore(3))
+
+	if !console.waitForObservations(1, 5*time.Second) {
+		t.Fatal("expected the poller to observe once on start")
+	}
+	if got := waitForStoredState(t, store).State["wan"]; got != "primary" {
+		t.Fatalf("expected the first observation to report wan=primary, got %q", got)
+	}
+
+	// The console now genuinely reports the failover, so every read from here
+	// on backs the new value. Only the number of reads is in question.
+	console.reportBackup(t)
+
+	for range 200 {
+		deliverTo(t, receiver)
+	}
+	time.Sleep(500 * time.Millisecond)
+
+	if got, _ := store.Get(unifi.ProviderName); got.State["wan"] != "primary" {
+		t.Errorf("200 deliveries promoted a debounced key to %q; only the poll cadence may do that",
+			got.State["wan"])
+	}
+	// One delivery is allowed to start the debounce — that is "look sooner".
+	// Every later one is refused while the value is still proving itself.
+	if got := console.observation.Load(); got > 2 {
+		t.Errorf("expected at most 2 observations (one on start, one from the first delivery), got %d", got)
+	}
+}
+
+// The flip side: refusing deliveries mid-debounce must not wedge the poller.
+// The poll cadence still supplies the samples and the key is still promoted.
+func TestADebouncedKeyIsStillPromotedByThePollCadence(t *testing.T) {
+	console, server := newFakeConsole(t)
+	receiver, store := startPollerWith(t, server.URL, time.Millisecond, 100*time.Millisecond, debouncedStore(3))
+
+	if !console.waitForObservations(1, 5*time.Second) {
+		t.Fatal("expected the poller to observe once on start")
+	}
+	waitForStoredState(t, store)
+	console.reportBackup(t)
+
+	// Deliveries throughout, to prove they neither help nor hinder.
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		deliverTo(t, receiver)
+		if got, _ := store.Get(unifi.ProviderName); got.State["wan"] == wanBackupValue {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	got, _ := store.Get(unifi.ProviderName)
+	t.Errorf("the debounced key was never promoted by the poll cadence, still %q", got.State["wan"])
+}
+
+// One delivery is one sample. Without debounce configured the very first
+// delivery promotes the change, which is the fast path doing its job — the
+// contrast with the test above is entirely the operator's debounce policy.
+func TestWithoutDebounceADeliveryPromotesImmediately(t *testing.T) {
+	console, server := newFakeConsole(t)
+	receiver, store := startPoller(t, server.URL, time.Millisecond)
+
+	if !console.waitForObservations(1, 5*time.Second) {
+		t.Fatal("expected the poller to observe once on start")
+	}
+	waitForStoredState(t, store)
+	console.reportBackup(t)
+
+	deliverTo(t, receiver)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if got, _ := store.Get(unifi.ProviderName); got.State["wan"] == wanBackupValue {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Error("a single delivery did not bring the change forward with no debounce configured")
+}

--- a/internal/engine/state.go
+++ b/internal/engine/state.go
@@ -183,6 +183,21 @@ func (s *StateStore) Observe(o events.Observation) []Transition {
 	return transitions
 }
 
+// Proving reports whether any of a provider's keys is part-way through its
+// debounce threshold: a changed value has been seen, but not yet often enough
+// to be reported.
+//
+// It exists so that anything able to ask for an out-of-band observation cannot
+// also supply the samples that promote a value. Debounce is a statement about
+// how much evidence a change needs before it is believed, and evidence
+// gathered on demand by whoever asked for it is not evidence. Callers that
+// have no such input can ignore this entirely.
+func (s *StateStore) Proving(provider string) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.current[provider].pending) > 0
+}
+
 // Get returns the latest reported state for a provider. Values still proving
 // themselves against the debounce threshold are deliberately not visible here:
 // every caller must see the same state.

--- a/internal/engine/state_test.go
+++ b/internal/engine/state_test.go
@@ -168,3 +168,50 @@ func TestStateStoreProvidersAreIndependent(t *testing.T) {
 		t.Fatal("unifi observation lost")
 	}
 }
+
+// Proving is what lets a caller distinguish "nothing is changing" from "a
+// change is part-way through proving itself", so that a caller able to force
+// an observation cannot also supply the samples that promote a value.
+func TestProvingReportsValuesPartWayThroughDebounce(t *testing.T) {
+	store := NewStateStore(WithDebounce("p", DebounceConfig{Default: 3}))
+
+	if store.Proving("p") {
+		t.Error("an empty store has nothing proving itself")
+	}
+
+	// A first sighting is reported immediately and proves nothing.
+	store.Observe(events.Observation{Provider: "p", State: map[string]string{"k": "a"}})
+	if store.Proving("p") {
+		t.Error("a first observation should not leave anything proving itself")
+	}
+
+	// A change now needs three consecutive samples.
+	store.Observe(events.Observation{Provider: "p", State: map[string]string{"k": "b"}})
+	if !store.Proving("p") {
+		t.Fatal("a changed value below its threshold should be proving itself")
+	}
+	if got, _ := store.Get("p"); got.State["k"] != "a" {
+		t.Errorf("a value still proving itself must not be reported, got %q", got.State["k"])
+	}
+
+	store.Observe(events.Observation{Provider: "p", State: map[string]string{"k": "b"}})
+	transitions := store.Observe(events.Observation{Provider: "p", State: map[string]string{"k": "b"}})
+	if len(transitions) != 1 {
+		t.Fatalf("expected the third sample to promote the value, got %v", transitions)
+	}
+	if store.Proving("p") {
+		t.Error("nothing should be proving itself once the value is reported")
+	}
+
+	// Falling back to the reported value abandons the candidate.
+	store.Observe(events.Observation{Provider: "p", State: map[string]string{"k": "c"}})
+	store.Observe(events.Observation{Provider: "p", State: map[string]string{"k": "b"}})
+	if store.Proving("p") {
+		t.Error("a value that went back to the reported one is no longer proving anything")
+	}
+
+	// An unknown provider is not proving anything, and asking must not create it.
+	if store.Proving("nobody") {
+		t.Error("an unknown provider has nothing proving itself")
+	}
+}

--- a/internal/providers/unifi/alarm.go
+++ b/internal/providers/unifi/alarm.go
@@ -1,0 +1,469 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"time"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// The Alarm Manager API is undocumented and reverse-engineered; every constant
+// here comes from docs/unifi-alarm-manager-api.md, observed on UniFi Network
+// 10.5.67. It lives at the UniFi OS layer, so none of these paths carry the
+// /proxy/network prefix the poller uses.
+const (
+	alarmLoginPath    = "/api/auth/login"
+	alarmRulesPath    = "/api/v2/alarms/network"
+	alarmManifestPath = "/api/v2/alarms/network/manifest"
+
+	alarmWebhookActionID = "network:webhook"
+
+	triggerInternetDisconnected = "network:internet_disconnected"
+	triggerHighLatency          = "network:high_latency_detected"
+	triggerPacketLoss           = "network:packet_loss_detected"
+
+	csrfHeader        = "x-csrf-token"
+	sessionCookieName = "TOKEN"
+
+	// DefaultAlarmRuleTitle titles the rule Reactor creates, and is how it
+	// recognizes its own rule on a later start.
+	DefaultAlarmRuleTitle = "unifi-reactor"
+
+	// maxErrorBodyBytes bounds how much of a console error response is quoted
+	// back into the log. The API's validation errors are how this API was
+	// mapped in the first place, so they are worth showing — but not unbounded.
+	maxErrorBodyBytes = 512
+)
+
+// DefaultAlarmTriggers are the Internet-category triggers that plausibly
+// precede a WAN state change on Network 10.5.67. Reactor asks for all of them
+// and keeps whichever the console's own manifest confirms it offers: which
+// triggers exist varies by version and by how many uplinks are configured.
+//
+// Nothing downstream depends on which trigger fired. They are all just "look
+// at the console again".
+var DefaultAlarmTriggers = []string{
+	triggerInternetDisconnected,
+	triggerHighLatency,
+	triggerPacketLoss,
+}
+
+// AlarmClient talks to the UniFi OS Alarm Manager API. It is separate from
+// Client because it authenticates completely differently: the alarms API sits
+// above the Network application and rejects the X-API-KEY header, requiring a
+// cookie session plus a CSRF token carried inside that cookie.
+type AlarmClient struct {
+	baseURL  string
+	username string
+	password string
+	http     *http.Client
+	csrf     string
+}
+
+// NewAlarmClient builds a client with its own cookie jar; the session cookie
+// never leaves it.
+func NewAlarmClient(baseURL, username, password string, insecureSkipVerify bool) (*AlarmClient, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating a cookie jar for the alarms API: %w", err)
+	}
+	return &AlarmClient{
+		baseURL:  strings.TrimSuffix(baseURL, "/"),
+		username: username,
+		password: password,
+		http: &http.Client{
+			Jar:     jar,
+			Timeout: 15 * time.Second,
+			Transport: &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: insecureSkipVerify}, // #nosec G402 -- self-signed UniFi OS cert, opt-in
+			},
+		},
+	}, nil
+}
+
+// Login opens a UniFi OS session and captures the CSRF token every mutating
+// request has to echo.
+func (c *AlarmClient) Login(ctx context.Context) error {
+	body, err := json.Marshal(map[string]string{"username": c.username, "password": c.password})
+	if err != nil {
+		return fmt.Errorf("encoding the login request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.baseURL+alarmLoginPath, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("logging in to unifi os: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("logging in to unifi os: unexpected status %d", resp.StatusCode)
+	}
+
+	// The csrfToken claim inside the session JWT is what write requests must
+	// match. The response header of the same name is only a fallback for a
+	// console whose cookie does not look like a JWT.
+	for _, cookie := range resp.Cookies() {
+		if cookie.Name != sessionCookieName {
+			continue
+		}
+		if token, err := csrfFromSessionJWT(cookie.Value); err == nil {
+			c.csrf = token
+			return nil
+		}
+	}
+	if header := resp.Header.Get(csrfHeader); header != "" {
+		c.csrf = header
+		return nil
+	}
+	return errors.New("logging in to unifi os: no csrf token in the session cookie or response headers")
+}
+
+// csrfFromSessionJWT pulls the csrfToken claim out of the session cookie. Only
+// the payload segment is decoded: the signature is the console's business, and
+// this value is echoed back to the same console that issued it.
+func csrfFromSessionJWT(token string) (string, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) < 2 {
+		return "", errors.New("the session cookie is not a JWT")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(strings.TrimRight(parts[1], "="))
+	if err != nil {
+		return "", fmt.Errorf("decoding the session cookie payload: %w", err)
+	}
+	var claims struct {
+		CSRFToken string `json:"csrfToken"`
+	}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return "", fmt.Errorf("parsing the session cookie payload: %w", err)
+	}
+	if claims.CSRFToken == "" {
+		return "", errors.New("the session cookie carries no csrfToken claim")
+	}
+	return claims.CSRFToken, nil
+}
+
+// do issues one alarms API request and decodes the response into an untyped
+// document. Untyped is deliberate: the GET representation is not the shape POST
+// accepts, neither is documented, and both move between UniFi OS versions.
+// Reading them structurally keeps a console reorganizing its JSON from turning
+// into a decode error.
+func (c *AlarmClient) do(ctx context.Context, method, path string, body any) (any, error) {
+	var payload io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("encoding the alarms request: %w", err)
+		}
+		payload = bytes.NewReader(encoded)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, c.baseURL+path, payload)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.csrf != "" {
+		req.Header.Set(csrfHeader, c.csrf)
+	}
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("%s %s: %w", method, path, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		detail, _ := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes))
+		return nil, fmt.Errorf("%s %s: status %d: %s", method, path, resp.StatusCode,
+			strings.TrimSpace(string(detail)))
+	}
+
+	var decoded any
+	if err := json.NewDecoder(resp.Body).Decode(&decoded); err != nil {
+		return nil, fmt.Errorf("decoding the response to %s %s: %w", method, path, err)
+	}
+	return decoded, nil
+}
+
+// alarmRule is the create-rule body. triggers_data and actions_data are arrays
+// of arrays — the API rejects a flat array of objects — and this is not the
+// shape GET returns. See docs/unifi-alarm-manager-api.md.
+type alarmRule struct {
+	Title        string          `json:"title"`
+	Scope        alarmScope      `json:"scope"`
+	TriggersData [][]alarmMember `json:"triggers_data"`
+	ActionsData  [][]alarmMember `json:"actions_data"`
+}
+
+type alarmScope struct {
+	Mode string            `json:"mode"`
+	Data map[string]string `json:"data"`
+}
+
+type alarmMember struct {
+	ID   string `json:"id"`
+	Data any    `json:"data"`
+}
+
+// AlarmRegistrar creates Reactor's own Alarm Manager rule on the console, so
+// the fast path can be switched on without anyone clicking through the UniFi
+// UI.
+//
+// Every failure is logged and swallowed. This writes to the operator's gateway
+// over an undocumented, version-fragile API on every start; when the console
+// does not look the way the reverse-engineering notes describe, Reactor says so
+// and keeps polling rather than pushing a guess onto their hardware.
+type AlarmRegistrar struct {
+	Client *AlarmClient
+	// CallbackURL is the address the console will post to. It must be
+	// reachable from the console, which Reactor has no way to verify.
+	CallbackURL string
+	// Token is the shared secret the console should present on each delivery.
+	Token string
+	// RuleTitle identifies Reactor's rule.
+	RuleTitle string
+	// Triggers are the trigger IDs to ask for, filtered against what the
+	// console's manifest actually offers.
+	Triggers []string
+}
+
+// NewAlarmRegistrar builds a registrar from the provider configuration.
+func NewAlarmRegistrar(cfg Config) (*AlarmRegistrar, error) {
+	client, err := NewAlarmClient(cfg.URL, cfg.Webhook.Username, cfg.Webhook.Password, cfg.InsecureSkipVerify)
+	if err != nil {
+		return nil, err
+	}
+	return &AlarmRegistrar{
+		Client:      client,
+		CallbackURL: cfg.Webhook.PublicURL,
+		Token:       cfg.Webhook.Token,
+		RuleTitle:   cfg.Webhook.RuleTitle,
+		Triggers:    DefaultAlarmTriggers,
+	}, nil
+}
+
+// Start implements manager.Runnable. It registers once and returns: the rule
+// lives on the console, so there is nothing to keep running, and nothing here
+// is allowed to fail loudly enough to matter.
+func (a *AlarmRegistrar) Start(ctx context.Context) error {
+	log := logf.FromContext(ctx).WithName("unifi-alarm-registrar")
+	if err := a.register(logf.IntoContext(ctx, log)); err != nil {
+		log.Error(err, "Could not register the Alarm Manager rule; UniFi state still converges on the poll interval",
+			"rule", a.title())
+	}
+	return nil
+}
+
+// NeedLeaderElection reports true: exactly one replica should write to the
+// console.
+func (a *AlarmRegistrar) NeedLeaderElection() bool { return true }
+
+func (a *AlarmRegistrar) title() string {
+	if a.RuleTitle == "" {
+		return DefaultAlarmRuleTitle
+	}
+	return a.RuleTitle
+}
+
+func (a *AlarmRegistrar) register(ctx context.Context) error {
+	log := logf.FromContext(ctx)
+	if a.Token == "" {
+		// Registering a rule the receiver would reject on arrival is worse than
+		// not registering one: the console reports a working alarm action while
+		// every delivery is refused.
+		return errors.New("refusing to register a rule without a shared secret, which the receiver would reject")
+	}
+	if err := validateCallbackURL(a.CallbackURL); err != nil {
+		return err
+	}
+	if err := a.Client.Login(ctx); err != nil {
+		return err
+	}
+
+	manifest, err := a.Client.do(ctx, http.MethodGet, alarmManifestPath, nil)
+	if err != nil {
+		return err
+	}
+	if !jsonHasString(manifest, alarmWebhookActionID) {
+		return fmt.Errorf("this console's alarm manifest does not offer the %q action", alarmWebhookActionID)
+	}
+	triggers := make([]string, 0, len(a.Triggers))
+	for _, id := range a.Triggers {
+		if jsonHasString(manifest, id) {
+			triggers = append(triggers, id)
+			continue
+		}
+		log.Info("Skipping a trigger this console does not offer", "trigger", id)
+	}
+	if len(triggers) == 0 {
+		return errors.New("this console's alarm manifest offers none of the triggers Reactor asks for")
+	}
+
+	rules, err := a.Client.do(ctx, http.MethodGet, alarmRulesPath, nil)
+	if err != nil {
+		return err
+	}
+	if id, found := findRuleID(rules, a.title()); found {
+		// Reactor creates its rule and then leaves it alone forever. Editing
+		// and deleting are verbs the reverse-engineering notes never confirmed
+		// against a real console, and guessing them wrong means silently
+		// breaking somebody's alerting.
+		log.Info("Alarm Manager rule already exists; leaving it untouched",
+			"rule", a.title(), "id", id,
+			"note", "delete it in the UniFi UI if its destination no longer matches")
+		return nil
+	}
+
+	created, err := a.Client.do(ctx, http.MethodPost, alarmRulesPath, a.ruleBody(triggers))
+	if err != nil {
+		return err
+	}
+	id, _ := findRuleID(created, a.title())
+	log.Info("Created the Alarm Manager rule", "rule", a.title(), "id", id, "triggers", triggers)
+	return nil
+}
+
+func (a *AlarmRegistrar) ruleBody(triggers []string) alarmRule {
+	members := make([]alarmMember, 0, len(triggers))
+	for _, id := range triggers {
+		members = append(members, alarmMember{ID: id, Data: map[string]any{}})
+	}
+	return alarmRule{
+		Title: a.title(),
+		Scope: alarmScope{Mode: "include", Data: map[string]string{"site_id": "ALL_ITEMS"}},
+		// One inner array each: the outer sequence is how the API models
+		// alternatives, and Reactor only ever wants the one group.
+		TriggersData: [][]alarmMember{members},
+		ActionsData: [][]alarmMember{{{
+			ID: alarmWebhookActionID,
+			Data: map[string]any{
+				"url":    a.CallbackURL,
+				"method": http.MethodPost,
+				// The manifest documents variants none|basic|bearer. The field
+				// name carrying the bearer value is INFERRED, not verified
+				// against a console: if a console rejects this body, the error
+				// it returns is logged verbatim and the rule can be created by
+				// hand in the UniFi UI instead — the receiver also accepts the
+				// secret in an X-Reactor-Token header, which the Alarm
+				// Manager's custom-headers list can send.
+				"auth": map[string]any{"variant": "bearer", "token": a.Token},
+			},
+		}}},
+	}
+}
+
+// validateCallbackURL rejects up front what the console rejects on submission,
+// so a bad value fails with a sentence instead of an opaque 400 from the
+// gateway. It cannot check the one thing that matters most — whether the
+// console can actually reach this address.
+func validateCallbackURL(raw string) error {
+	if raw == "" {
+		return errors.New("webhook self-registration needs the public URL the console should post to")
+	}
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return fmt.Errorf("parsing the public webhook URL %q: %w", raw, err)
+	}
+	if parsed.Scheme != "http" && parsed.Scheme != "https" {
+		return fmt.Errorf("the public webhook URL must be http or https, got %q", parsed.Scheme)
+	}
+	host := parsed.Hostname()
+	if host == "" {
+		return fmt.Errorf("the public webhook URL %q has no host", raw)
+	}
+	// The console refuses loopback destinations, and it would be right to: a
+	// loopback address there means the gateway itself, not this pod.
+	if strings.EqualFold(host, "localhost") {
+		return errors.New("the public webhook URL must be an address the console can reach, not localhost")
+	}
+	if ip := net.ParseIP(host); ip != nil && ip.IsLoopback() {
+		return fmt.Errorf("the public webhook URL must be an address the console can reach, not the loopback %s", ip)
+	}
+	return nil
+}
+
+// jsonHasString reports whether want appears as a string value anywhere in a
+// decoded JSON document.
+//
+// The Alarm Manager manifest is a large, undocumented, version-dependent
+// catalog of trigger and action IDs. Asking whether an ID is in it at all keeps
+// working when the catalog is reorganized; hard-coding a path through it would
+// turn a cosmetic change into a broken fast path.
+func jsonHasString(doc any, want string) bool {
+	switch value := doc.(type) {
+	case string:
+		return value == want
+	case []any:
+		for _, item := range value {
+			if jsonHasString(item, want) {
+				return true
+			}
+		}
+	case map[string]any:
+		for _, item := range value {
+			if jsonHasString(item, want) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// findRuleID looks for a rule object carrying the given title and returns its
+// id. Whether the list arrives bare or wrapped in an envelope is not
+// documented, so this finds the object rather than assuming where it lives.
+func findRuleID(doc any, title string) (string, bool) {
+	switch value := doc.(type) {
+	case []any:
+		for _, item := range value {
+			if id, found := findRuleID(item, title); found {
+				return id, true
+			}
+		}
+	case map[string]any:
+		if got, ok := value["title"].(string); ok && got == title {
+			id, _ := value["id"].(string)
+			return id, true
+		}
+		for _, item := range value {
+			if id, found := findRuleID(item, title); found {
+				return id, true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/providers/unifi/alarm_test.go
+++ b/internal/providers/unifi/alarm_test.go
@@ -1,0 +1,469 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr/testr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	testCSRF            = "csrf-token-from-the-jwt"
+	testConsoleUser     = "reactor"
+	testConsolePassword = "hunter2"
+
+	keyTriggers = "triggers"
+	keyActions  = "actions"
+	keyTitle    = "title"
+)
+
+// testCtx carries a logger the way the manager does, since register reads it
+// from the context rather than taking one.
+func testCtx(t *testing.T) context.Context {
+	t.Helper()
+	return logf.IntoContext(t.Context(), testr.New(t))
+}
+
+// sessionJWT builds a cookie shaped like the one UniFi OS issues: three
+// dot-separated segments whose middle one is a base64url JSON payload carrying
+// the csrfToken claim. Only that payload is ever read, so the header and
+// signature are arbitrary.
+func sessionJWT(t *testing.T, claims map[string]string) string {
+	t.Helper()
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("encoding the claims: %v", err)
+	}
+	return "header." + base64.RawURLEncoding.EncodeToString(payload) + ".signature"
+}
+
+// fakeConsole stands in for a UniFi OS console's alarms API, matching the
+// shapes recorded in docs/unifi-alarm-manager-api.md.
+type fakeConsole struct {
+	manifest any
+	rules    []any
+
+	// created records the bodies POSTed to the rules endpoint, so a test can
+	// assert on the arrays-of-arrays shape the API demands.
+	created []map[string]any
+	// csrfSeen records the CSRF header presented on the create request.
+	csrfSeen string
+
+	loginStatus    int
+	manifestStatus int
+	createStatus   int
+	// noCSRFClaim issues a session cookie without the csrfToken claim.
+	noCSRFClaim bool
+	// csrfHeaderOnly issues a non-JWT cookie plus the response header fallback.
+	csrfHeaderOnly bool
+}
+
+func (f *fakeConsole) start(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("POST "+alarmLoginPath, func(w http.ResponseWriter, _ *http.Request) {
+		if f.loginStatus != 0 {
+			w.WriteHeader(f.loginStatus)
+			return
+		}
+		switch {
+		case f.csrfHeaderOnly:
+			http.SetCookie(w, &http.Cookie{Name: sessionCookieName, Value: "not-a-jwt"})
+			w.Header().Set(csrfHeader, testCSRF)
+		case f.noCSRFClaim:
+			http.SetCookie(w, &http.Cookie{Name: sessionCookieName, Value: sessionJWT(t, map[string]string{"sub": "x"})})
+		default:
+			http.SetCookie(w, &http.Cookie{
+				Name:  sessionCookieName,
+				Value: sessionJWT(t, map[string]string{"csrfToken": testCSRF}),
+			})
+		}
+		writeJSON(t, w, map[string]any{"unique_id": "00000000-0000-0000-0000-0000000000ff"})
+	})
+
+	mux.HandleFunc("GET "+alarmManifestPath, func(w http.ResponseWriter, _ *http.Request) {
+		if f.manifestStatus != 0 {
+			http.Error(w, "manifest unavailable", f.manifestStatus)
+			return
+		}
+		writeJSON(t, w, f.manifest)
+	})
+
+	mux.HandleFunc("GET "+alarmRulesPath, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, map[string]any{"data": f.rules})
+	})
+
+	mux.HandleFunc("POST "+alarmRulesPath, func(w http.ResponseWriter, r *http.Request) {
+		f.csrfSeen = r.Header.Get(csrfHeader)
+		if f.createStatus != 0 {
+			http.Error(w, `{"message":"triggers_data: invalid type: sequence, expected a sequence of sequences"}`,
+				f.createStatus)
+			return
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decoding the create body: %v", err)
+		}
+		f.created = append(f.created, body)
+		body["id"] = "019ff10d-0000-0000-0000-000000000001"
+		writeJSON(t, w, body)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	return server
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Errorf("writing the response: %v", err)
+	}
+}
+
+// fullManifest nests the identifiers the way a catalog plausibly would, to
+// prove the lookup does not depend on where in the document they sit.
+func fullManifest() any {
+	return map[string]any{
+		keyTriggers: []any{
+			map[string]any{
+				"id": "network:category_internet",
+				"items": []any{
+					map[string]any{"id": triggerInternetDisconnected, "options": map[string]any{}},
+					map[string]any{"id": triggerHighLatency},
+					map[string]any{"id": triggerPacketLoss},
+					map[string]any{"id": "network:data_limit"},
+				},
+			},
+		},
+		keyActions: []any{
+			map[string]any{"id": alarmWebhookActionID, "schema": map[string]any{"type": "object"}},
+			map[string]any{"id": "network:slack"},
+		},
+	}
+}
+
+func testRegistrar(t *testing.T, console *httptest.Server) *AlarmRegistrar {
+	t.Helper()
+	registrar, err := NewAlarmRegistrar(Config{
+		URL: console.URL,
+		Webhook: WebhookConfig{
+			Username:  testConsoleUser,
+			Password:  testConsolePassword,
+			Token:     testToken,
+			PublicURL: "http://reactor.example.test:9090" + DefaultWebhookPath,
+			RuleTitle: DefaultAlarmRuleTitle,
+		},
+	})
+	if err != nil {
+		t.Fatalf("building the registrar: %v", err)
+	}
+	return registrar
+}
+
+func TestRegistrarCreatesTheRuleInTheShapeTheAPIDemands(t *testing.T) {
+	console := &fakeConsole{manifest: fullManifest()}
+	server := console.start(t)
+	registrar := testRegistrar(t, server)
+
+	if err := registrar.register(testCtx(t)); err != nil {
+		t.Fatalf("registering: %v", err)
+	}
+	if len(console.created) != 1 {
+		t.Fatalf("expected exactly one rule created, got %d", len(console.created))
+	}
+	if console.csrfSeen != testCSRF {
+		t.Errorf("expected the csrf token from the session cookie, got %q", console.csrfSeen)
+	}
+
+	rule := console.created[0]
+	if rule["title"] != DefaultAlarmRuleTitle {
+		t.Errorf("expected the rule to be titled %q, got %v", DefaultAlarmRuleTitle, rule["title"])
+	}
+
+	// triggers_data and actions_data are sequences of sequences; a flat array
+	// of objects is rejected by the real API.
+	triggers, ok := rule["triggers_data"].([]any)
+	if !ok || len(triggers) != 1 {
+		t.Fatalf("expected triggers_data to be one outer array, got %#v", rule["triggers_data"])
+	}
+	inner, ok := triggers[0].([]any)
+	if !ok || len(inner) != len(DefaultAlarmTriggers) {
+		t.Fatalf("expected %d triggers in the inner array, got %#v", len(DefaultAlarmTriggers), triggers[0])
+	}
+
+	actions, ok := rule["actions_data"].([]any)
+	if !ok || len(actions) != 1 {
+		t.Fatalf("expected actions_data to be one outer array, got %#v", rule["actions_data"])
+	}
+	action := actions[0].([]any)[0].(map[string]any)
+	if action["id"] != alarmWebhookActionID {
+		t.Errorf("expected the %q action, got %v", alarmWebhookActionID, action["id"])
+	}
+	data := action["data"].(map[string]any)
+	if data["url"] != registrar.CallbackURL || data["method"] != http.MethodPost {
+		t.Errorf("expected a POST to the callback URL, got %v %v", data["method"], data["url"])
+	}
+	if auth := data["auth"].(map[string]any); auth["token"] != testToken {
+		t.Errorf("expected the shared secret to be registered with the rule, got %v", auth)
+	}
+}
+
+// A console whose catalog does not offer the webhook action must be left
+// alone, not written to on the assumption the notes still hold.
+func TestRegistrarWritesNothingWhenTheConsoleOffersNoWebhookAction(t *testing.T) {
+	console := &fakeConsole{manifest: map[string]any{
+		keyActions: []any{map[string]any{"id": "network:slack"}},
+		keyTriggers: []any{
+			map[string]any{"id": triggerInternetDisconnected},
+		},
+	}}
+	registrar := testRegistrar(t, console.start(t))
+
+	if err := registrar.register(testCtx(t)); err == nil {
+		t.Error("expected registration to be refused when the webhook action is absent")
+	}
+	if len(console.created) != 0 {
+		t.Errorf("expected nothing to be written to the console, got %d rules", len(console.created))
+	}
+}
+
+// Triggers the console does not know about are dropped rather than sent, since
+// which triggers exist varies by version and uplink count.
+func TestRegistrarAsksOnlyForTriggersTheConsoleOffers(t *testing.T) {
+	console := &fakeConsole{manifest: map[string]any{
+		keyActions:  []any{map[string]any{"id": alarmWebhookActionID}},
+		keyTriggers: []any{map[string]any{"id": triggerInternetDisconnected}},
+	}}
+	registrar := testRegistrar(t, console.start(t))
+
+	if err := registrar.register(testCtx(t)); err != nil {
+		t.Fatalf("registering: %v", err)
+	}
+	inner := console.created[0]["triggers_data"].([]any)[0].([]any)
+	if len(inner) != 1 {
+		t.Fatalf("expected only the offered trigger, got %#v", inner)
+	}
+	if id := inner[0].(map[string]any)["id"]; id != triggerInternetDisconnected {
+		t.Errorf("expected the offered trigger, got %v", id)
+	}
+}
+
+func TestRegistrarWritesNothingWhenNoTriggerIsOffered(t *testing.T) {
+	console := &fakeConsole{manifest: map[string]any{
+		keyActions:  []any{map[string]any{"id": alarmWebhookActionID}},
+		keyTriggers: []any{map[string]any{"id": "network:something_else"}},
+	}}
+	registrar := testRegistrar(t, console.start(t))
+
+	if err := registrar.register(testCtx(t)); err == nil {
+		t.Error("expected registration to be refused when no requested trigger exists")
+	}
+	if len(console.created) != 0 {
+		t.Errorf("expected nothing to be written to the console, got %d rules", len(console.created))
+	}
+}
+
+// Reactor creates its rule once and never touches it again: editing and
+// deleting are verbs the reverse-engineering notes never confirmed.
+func TestRegistrarLeavesAnExistingRuleAlone(t *testing.T) {
+	console := &fakeConsole{
+		manifest: fullManifest(),
+		rules: []any{map[string]any{
+			"id":     "019ff10d-5b3e-7930-0000-000000000000",
+			keyTitle: DefaultAlarmRuleTitle,
+		}},
+	}
+	registrar := testRegistrar(t, console.start(t))
+
+	if err := registrar.register(testCtx(t)); err != nil {
+		t.Fatalf("registering: %v", err)
+	}
+	if len(console.created) != 0 {
+		t.Errorf("expected an existing rule to be left untouched, got %d writes", len(console.created))
+	}
+}
+
+// Somebody else's rules must not be mistaken for Reactor's own.
+func TestRegistrarIgnoresRulesItDoesNotOwn(t *testing.T) {
+	console := &fakeConsole{
+		manifest: fullManifest(),
+		rules: []any{
+			map[string]any{"id": "a", keyTitle: "Page me on packet loss"},
+			map[string]any{"id": "b", keyTitle: "unifi-reactor-old"},
+		},
+	}
+	registrar := testRegistrar(t, console.start(t))
+
+	if err := registrar.register(testCtx(t)); err != nil {
+		t.Fatalf("registering: %v", err)
+	}
+	if len(console.created) != 1 {
+		t.Errorf("expected Reactor's own rule to be created, got %d writes", len(console.created))
+	}
+}
+
+func TestRegistrarSurfacesTheConsolesOwnValidationError(t *testing.T) {
+	console := &fakeConsole{manifest: fullManifest(), createStatus: http.StatusBadRequest}
+	registrar := testRegistrar(t, console.start(t))
+
+	err := registrar.register(testCtx(t))
+	if err == nil {
+		t.Fatal("expected the rejected create to be reported")
+	}
+	// The console's own message is what makes this API debuggable at all.
+	if !strings.Contains(err.Error(), "sequence of sequences") {
+		t.Errorf("expected the console's validation message to be reported, got %v", err)
+	}
+}
+
+func TestRegistrarFailsSoftAndNeverStopsTheManager(t *testing.T) {
+	for name, console := range map[string]*fakeConsole{
+		"login refused":       {loginStatus: http.StatusUnauthorized, manifest: fullManifest()},
+		"no csrf claim":       {noCSRFClaim: true, manifest: fullManifest()},
+		"manifest unreadable": {manifest: fullManifest(), manifestStatus: http.StatusInternalServerError},
+		"create rejected":     {manifest: fullManifest(), createStatus: http.StatusBadRequest},
+	} {
+		t.Run(name, func(t *testing.T) {
+			registrar := testRegistrar(t, console.start(t))
+			if err := registrar.Start(context.Background()); err != nil {
+				t.Errorf("Start must swallow every failure, got %v", err)
+			}
+		})
+	}
+}
+
+// The response header is only a fallback: the claim inside the cookie is what
+// the notes say write requests must match.
+func TestLoginFallsBackToTheCSRFResponseHeader(t *testing.T) {
+	console := &fakeConsole{manifest: fullManifest(), csrfHeaderOnly: true}
+	registrar := testRegistrar(t, console.start(t))
+
+	if err := registrar.register(testCtx(t)); err != nil {
+		t.Fatalf("registering: %v", err)
+	}
+	if console.csrfSeen != testCSRF {
+		t.Errorf("expected the header fallback to be used, got %q", console.csrfSeen)
+	}
+}
+
+func TestCSRFFromSessionJWT(t *testing.T) {
+	valid := sessionJWT(t, map[string]string{"csrfToken": testCSRF})
+	got, err := csrfFromSessionJWT(valid)
+	if err != nil || got != testCSRF {
+		t.Errorf("expected %q, got %q (%v)", testCSRF, got, err)
+	}
+
+	for name, cookie := range map[string]string{
+		"not a jwt":     "opaque-session-value",
+		"bad base64":    "header.!!!not-base64!!!.signature",
+		"not json":      "header." + base64.RawURLEncoding.EncodeToString([]byte("plain text")) + ".signature",
+		"no csrf claim": sessionJWT(t, map[string]string{"sub": "reactor"}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := csrfFromSessionJWT(cookie); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+// The console rejects loopback destinations, and would be right to: loopback
+// there means the gateway itself, not the Reactor pod.
+func TestValidateCallbackURL(t *testing.T) {
+	for name, raw := range map[string]string{
+		"no url":         "",
+		"no scheme":      "reactor.example.test:9090/webhooks/unifi",
+		"wrong scheme":   "ftp://reactor.example.test/webhooks/unifi",
+		"no host":        "http:///webhooks/unifi",
+		"localhost":      "http://localhost:9090/webhooks/unifi",
+		"loopback ipv4":  "http://127.0.0.1:9090/webhooks/unifi",
+		"loopback ipv6":  "http://[::1]:9090/webhooks/unifi",
+		"uppercase host": "http://LOCALHOST:9090/webhooks/unifi",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateCallbackURL(raw); err == nil {
+				t.Errorf("expected %q to be rejected", raw)
+			}
+		})
+	}
+	for name, raw := range map[string]string{
+		"http by name":  "http://reactor.example.test:9090/webhooks/unifi",
+		"https by name": "https://reactor.example.test/webhooks/unifi",
+		"by address":    "http://198.51.100.20:9090/webhooks/unifi",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validateCallbackURL(raw); err != nil {
+				t.Errorf("expected %q to be accepted, got %v", raw, err)
+			}
+		})
+	}
+}
+
+func TestJSONHasString(t *testing.T) {
+	doc := fullManifest()
+	for _, want := range DefaultAlarmTriggers {
+		if !jsonHasString(doc, want) {
+			t.Errorf("expected %q to be found", want)
+		}
+	}
+	if !jsonHasString(doc, alarmWebhookActionID) {
+		t.Errorf("expected %q to be found", alarmWebhookActionID)
+	}
+	for _, absent := range []string{"network:wan_failover", "", "network:internet_disconnecte"} {
+		if jsonHasString(doc, absent) {
+			t.Errorf("did not expect %q to be found", absent)
+		}
+	}
+}
+
+// Neither the bare nor the wrapped list shape is documented, so both must work.
+func TestFindRuleID(t *testing.T) {
+	rule := map[string]any{"id": "rule-1", keyTitle: DefaultAlarmRuleTitle}
+	for name, doc := range map[string]any{
+		"bare array":      []any{rule},
+		"wrapped in data": map[string]any{"data": []any{rule}},
+		"deeply nested":   map[string]any{"result": map[string]any{"items": []any{rule}}},
+	} {
+		t.Run(name, func(t *testing.T) {
+			id, found := findRuleID(doc, DefaultAlarmRuleTitle)
+			if !found || id != "rule-1" {
+				t.Errorf("expected rule-1, got %q (found %v)", id, found)
+			}
+		})
+	}
+
+	if _, found := findRuleID([]any{rule}, "some other rule"); found {
+		t.Error("did not expect a different title to match")
+	}
+	// A rule with the right title but no readable id still counts as existing:
+	// the point is to not create a second one.
+	id, found := findRuleID([]any{map[string]any{keyTitle: DefaultAlarmRuleTitle}}, DefaultAlarmRuleTitle)
+	if !found || id != "" {
+		t.Errorf("expected a titled rule with no id to be found, got %q (found %v)", id, found)
+	}
+}

--- a/internal/providers/unifi/config.go
+++ b/internal/providers/unifi/config.go
@@ -1,0 +1,247 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultPollInterval is how often state is observed when nothing says
+// otherwise. Polling is the mechanism of record, so this interval — not the
+// webhook fast path — is what bounds correctness.
+const DefaultPollInterval = 30 * time.Second
+
+// envTrue is the only value that turns a boolean environment flag on. Anything
+// else, including "1" and "yes", leaves the flag off: for settings that default
+// off on purpose, a typo must not enable them.
+const envTrue = "true"
+
+// The environment variables the provider reads, named in one place so the
+// contract with the Helm chart is stated once.
+const (
+	envURL                = "UNIFI_URL"
+	envAPIKey             = "UNIFI_API_KEY"
+	envAPIKeyFile         = "UNIFI_API_KEY_FILE" // #nosec G101 -- variable name, not a credential
+	envSite               = "UNIFI_SITE"
+	envInsecureSkipVerify = "UNIFI_INSECURE_SKIP_VERIFY"
+	envPollInterval       = "UNIFI_POLL_INTERVAL"
+	envLowBattery         = "UNIFI_UPS_LOW_BATTERY_PERCENT"
+	envCriticalBattery    = "UNIFI_UPS_CRITICAL_BATTERY_PERCENT"
+
+	envWebhookEnabled     = "UNIFI_WEBHOOK_ENABLED"
+	envWebhookBindAddress = "UNIFI_WEBHOOK_BIND_ADDRESS"
+	envWebhookPath        = "UNIFI_WEBHOOK_PATH"
+	envWebhookToken       = "UNIFI_WEBHOOK_TOKEN" // #nosec G101 -- variable name, not a credential
+	envWebhookMinInterval = "UNIFI_WEBHOOK_MIN_INTERVAL"
+	envWebhookRegister    = "UNIFI_WEBHOOK_REGISTER"
+	envWebhookPublicURL   = "UNIFI_WEBHOOK_PUBLIC_URL"
+	envWebhookRuleTitle   = "UNIFI_WEBHOOK_RULE_TITLE"
+	envUsername           = "UNIFI_USERNAME"
+	envPassword           = "UNIFI_PASSWORD"
+)
+
+// Config is the UniFi provider's install-level configuration. There is one
+// UniFi console per Reactor install, so this comes from the environment (Helm
+// values) rather than from an Automation.
+type Config struct {
+	URL string
+	// APIKey is resolved per request, not held from startup, so rotating a
+	// mounted credential takes effect on the next poll.
+	APIKey                 APIKey
+	Site                   string
+	InsecureSkipVerify     bool
+	PollInterval           time.Duration
+	LowBatteryPercent      int
+	CriticalBatteryPercent int
+	Webhook                WebhookConfig
+}
+
+// WebhookConfig configures the fast path. Every field here defaults off or to
+// something inert: an existing install that upgrades keeps polling and gains
+// no new listening socket, no new credentials, and no writes to the console.
+type WebhookConfig struct {
+	// Enabled starts the receiver. A delivery to it only ever triggers a poll.
+	Enabled bool
+	// BindAddress is where the receiver listens inside the pod.
+	BindAddress string
+	// Path is the URL path deliveries are accepted on.
+	Path string
+	// Token is the shared secret every delivery must present. Without it the
+	// receiver accepts nothing, so it is not optional.
+	Token string
+	// MinObserveInterval floors the time between two observations, bounding how
+	// much console traffic a burst of deliveries can cause.
+	MinObserveInterval time.Duration
+
+	// Register lets Reactor create its own Alarm Manager rule on the console.
+	Register bool
+	// PublicURL is the address the console should post to. Reactor cannot
+	// derive it: only the operator knows how the pod is exposed.
+	PublicURL string
+	// RuleTitle is the title Reactor gives the rule it creates, and the title
+	// it looks for to decide the rule already exists.
+	RuleTitle string
+	// Username and Password are UniFi OS console credentials. The Alarm Manager
+	// API sits at the UniFi OS layer and rejects the API key the poller uses.
+	Username string
+	Password string
+}
+
+// ConfigFromEnv reads the provider configuration. The second return value
+// reports whether the provider is configured at all; lookup is injected so the
+// mapping can be tested without mutating process state.
+func ConfigFromEnv(lookup func(string) string) (Config, bool, error) {
+	cfg := Config{
+		URL:                    lookup(envURL),
+		Site:                   lookup(envSite),
+		InsecureSkipVerify:     lookup(envInsecureSkipVerify) == envTrue,
+		PollInterval:           DefaultPollInterval,
+		LowBatteryPercent:      DefaultLowBatteryPercent,
+		CriticalBatteryPercent: DefaultCriticalBatteryPercent,
+		Webhook: WebhookConfig{
+			Enabled:            lookup(envWebhookEnabled) == envTrue,
+			BindAddress:        DefaultWebhookBindAddress,
+			Path:               DefaultWebhookPath,
+			Token:              lookup(envWebhookToken),
+			MinObserveInterval: DefaultMinObserveInterval,
+			Register:           lookup(envWebhookRegister) == envTrue,
+			PublicURL:          lookup(envWebhookPublicURL),
+			RuleTitle:          DefaultAlarmRuleTitle,
+			Username:           lookup(envUsername),
+			Password:           lookup(envPassword),
+		},
+	}
+
+	// No console configured is not an error; it is how Reactor runs with the
+	// UniFi provider switched off.
+	if cfg.URL == "" {
+		return Config{}, false, nil
+	}
+
+	apiKey, err := apiKeyFromEnv(lookup)
+	if err != nil {
+		return Config{}, false, err
+	}
+	cfg.APIKey = apiKey
+
+	for _, field := range []struct {
+		env    string
+		target *time.Duration
+	}{
+		{envPollInterval, &cfg.PollInterval},
+		{envWebhookMinInterval, &cfg.Webhook.MinObserveInterval},
+	} {
+		raw := lookup(field.env)
+		if raw == "" {
+			continue
+		}
+		parsed, err := time.ParseDuration(raw)
+		if err != nil {
+			return Config{}, false, fmt.Errorf("invalid %s %q: %w", field.env, raw, err)
+		}
+		*field.target = parsed
+	}
+
+	for _, field := range []struct {
+		env    string
+		target *int
+	}{
+		{envLowBattery, &cfg.LowBatteryPercent},
+		{envCriticalBattery, &cfg.CriticalBatteryPercent},
+	} {
+		raw := lookup(field.env)
+		if raw == "" {
+			continue
+		}
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			return Config{}, false, fmt.Errorf("invalid %s %q: %w", field.env, raw, err)
+		}
+		*field.target = parsed
+	}
+
+	for _, field := range []struct {
+		env    string
+		target *string
+	}{
+		{envWebhookBindAddress, &cfg.Webhook.BindAddress},
+		{envWebhookPath, &cfg.Webhook.Path},
+		{envWebhookRuleTitle, &cfg.Webhook.RuleTitle},
+	} {
+		if raw := lookup(field.env); raw != "" {
+			*field.target = raw
+		}
+	}
+
+	return cfg, true, nil
+}
+
+// apiKeyFromEnv resolves where the API key comes from, and fails fast if it
+// cannot be read at all. UNIFI_API_KEY_FILE points at a mounted Secret and is
+// re-read on every poll, so rotating the key takes effect without a restart;
+// UNIFI_API_KEY holds the key in the environment, where it is fixed for the
+// life of the process and rotation means restarting the pod.
+//
+// The file is read once here purely to fail at startup rather than at the
+// first poll: a path that cannot be read is a deployment mistake, and finding
+// out immediately is worth the one read.
+func apiKeyFromEnv(lookup func(string) string) (APIKey, error) {
+	if path := lookup(envAPIKeyFile); path != "" {
+		key := FileAPIKey(path)
+		if _, err := key(); err != nil {
+			return nil, err
+		}
+		return key, nil
+	}
+	if key := lookup(envAPIKey); key != "" {
+		return StaticAPIKey(key), nil
+	}
+	return nil, errors.New("UNIFI_URL is set but neither UNIFI_API_KEY_FILE nor UNIFI_API_KEY is")
+}
+
+// Validate reports why the fast path cannot start. Callers are expected to log
+// the reason and carry on polling: a misconfigured optimization must never take
+// the mechanism of record down with it.
+func (w WebhookConfig) Validate() error {
+	if !w.Enabled {
+		if w.Register {
+			return errors.New("webhook self-registration needs the receiver enabled too")
+		}
+		return nil
+	}
+	if w.Token == "" {
+		return errors.New("the webhook fast path needs a shared secret; set UNIFI_WEBHOOK_TOKEN")
+	}
+	if !strings.HasPrefix(w.Path, "/") {
+		return fmt.Errorf("the webhook path must start with a slash, got %q", w.Path)
+	}
+	if w.MinObserveInterval < 0 {
+		return fmt.Errorf("the minimum observe interval cannot be negative, got %s", w.MinObserveInterval)
+	}
+	if !w.Register {
+		return nil
+	}
+	if w.Username == "" || w.Password == "" {
+		return errors.New("webhook self-registration needs UniFi OS console credentials " +
+			"(UNIFI_USERNAME and UNIFI_PASSWORD); the API key the poller uses does not work on the Alarm Manager API")
+	}
+	return validateCallbackURL(w.PublicURL)
+}

--- a/internal/providers/unifi/config_test.go
+++ b/internal/providers/unifi/config_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"maps"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+const (
+	testConsoleURL = "https://console.example.test"
+	testAPIKey     = "key"
+)
+
+func env(pairs map[string]string) func(string) string {
+	return func(name string) string { return pairs[name] }
+}
+
+// The console URL alone must keep behaving exactly as it did before the fast
+// path existed: an install that upgrades without changing anything polls, and
+// opens no socket and no console session.
+func TestConfigFromEnvLeavesTheFastPathOffByDefault(t *testing.T) {
+	cfg, enabled, err := ConfigFromEnv(env(map[string]string{
+		envURL:    testConsoleURL,
+		envAPIKey: testAPIKey,
+	}))
+	if err != nil || !enabled {
+		t.Fatalf("expected the provider to be enabled, got enabled %v err %v", enabled, err)
+	}
+	if cfg.Webhook.Enabled || cfg.Webhook.Register {
+		t.Errorf("expected the fast path and self-registration off, got %+v", cfg.Webhook)
+	}
+	if cfg.PollInterval != DefaultPollInterval {
+		t.Errorf("expected the default poll interval, got %s", cfg.PollInterval)
+	}
+	if err := cfg.Webhook.Validate(); err != nil {
+		t.Errorf("a default configuration must be valid, got %v", err)
+	}
+}
+
+func TestConfigFromEnvWithoutAConsoleDisablesTheProvider(t *testing.T) {
+	// Even with the webhook switched on: without a console there is nothing to
+	// re-observe, so there is nothing to be fast about.
+	_, enabled, err := ConfigFromEnv(env(map[string]string{envWebhookEnabled: envTrue}))
+	if err != nil || enabled {
+		t.Errorf("expected the provider disabled and no error, got enabled %v err %v", enabled, err)
+	}
+}
+
+func TestConfigFromEnvRequiresAnAPIKeyAlongsideAURL(t *testing.T) {
+	if _, _, err := ConfigFromEnv(env(map[string]string{envURL: testConsoleURL})); err == nil {
+		t.Error("expected a URL without an API key to be an error")
+	}
+}
+
+// The key file wins over the environment, and is re-read on every use — that
+// is what makes rotating a mounted Secret take effect without a restart.
+func TestConfigFromEnvPrefersTheKeyFileAndRereadsIt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "UNIFI_API_KEY")
+	if err := os.WriteFile(path, []byte("first-key\n"), 0o600); err != nil {
+		t.Fatalf("writing the key file: %v", err)
+	}
+
+	cfg, enabled, err := ConfigFromEnv(env(map[string]string{
+		envURL:        testConsoleURL,
+		envAPIKeyFile: path,
+		envAPIKey:     "the-environment-key",
+	}))
+	if err != nil || !enabled {
+		t.Fatalf("expected the provider enabled, got enabled %v err %v", enabled, err)
+	}
+
+	got, err := cfg.APIKey()
+	if err != nil || got != "first-key" {
+		t.Fatalf("expected the file to win over the environment, got %q (%v)", got, err)
+	}
+
+	// Rotation: the kubelet replaces the file in place and the next use picks
+	// it up, with no restart and no re-reading of the configuration.
+	if err := os.WriteFile(path, []byte("rotated-key\n"), 0o600); err != nil {
+		t.Fatalf("rotating the key file: %v", err)
+	}
+	if got, err = cfg.APIKey(); err != nil || got != "rotated-key" {
+		t.Errorf("expected the rotated key to be picked up, got %q (%v)", got, err)
+	}
+}
+
+// An unreadable or empty key file is a deployment mistake, and it must be
+// fatal at startup rather than surfacing as a failed poll later.
+func TestConfigFromEnvRejectsAnUnusableKeyFile(t *testing.T) {
+	empty := filepath.Join(t.TempDir(), "UNIFI_API_KEY")
+	if err := os.WriteFile(empty, []byte("   \n"), 0o600); err != nil {
+		t.Fatalf("writing the key file: %v", err)
+	}
+
+	for name, path := range map[string]string{
+		"missing":    filepath.Join(t.TempDir(), "does-not-exist"),
+		"empty file": empty,
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := ConfigFromEnv(env(map[string]string{envURL: testConsoleURL, envAPIKeyFile: path}))
+			if err == nil {
+				t.Error("expected an unusable key file to be reported at startup")
+			}
+		})
+	}
+}
+
+// Without a file, the environment key is used and is fixed for the process.
+func TestConfigFromEnvFallsBackToTheEnvironmentKey(t *testing.T) {
+	cfg, _, err := ConfigFromEnv(env(map[string]string{envURL: testConsoleURL, envAPIKey: testAPIKey}))
+	if err != nil {
+		t.Fatalf("reading the configuration: %v", err)
+	}
+	if got, err := cfg.APIKey(); err != nil || got != testAPIKey {
+		t.Errorf("expected the environment key, got %q (%v)", got, err)
+	}
+}
+
+func TestConfigFromEnvReadsTheFastPathSettings(t *testing.T) {
+	cfg, enabled, err := ConfigFromEnv(env(map[string]string{
+		envURL:                testConsoleURL,
+		envAPIKey:             testAPIKey,
+		envPollInterval:       "15s",
+		envWebhookEnabled:     envTrue,
+		envWebhookToken:       testToken,
+		envWebhookBindAddress: ":9999",
+		envWebhookPath:        testCustomPath,
+		envWebhookMinInterval: "2s",
+		envWebhookRegister:    envTrue,
+		envWebhookPublicURL:   "http://reactor.example.test:9999/hooks/reactor",
+		envWebhookRuleTitle:   "reactor-fast-path",
+		envUsername:           testConsoleUser,
+		envPassword:           testConsolePassword,
+	}))
+	if err != nil || !enabled {
+		t.Fatalf("expected the provider enabled, got enabled %v err %v", enabled, err)
+	}
+	if cfg.PollInterval != 15*time.Second || cfg.Webhook.MinObserveInterval != 2*time.Second {
+		t.Errorf("expected the configured intervals, got %s and %s", cfg.PollInterval, cfg.Webhook.MinObserveInterval)
+	}
+	if cfg.Webhook.BindAddress != ":9999" || cfg.Webhook.Path != testCustomPath {
+		t.Errorf("expected the configured endpoint, got %s%s", cfg.Webhook.BindAddress, cfg.Webhook.Path)
+	}
+	if cfg.Webhook.RuleTitle != "reactor-fast-path" {
+		t.Errorf("expected the configured rule title, got %q", cfg.Webhook.RuleTitle)
+	}
+	if err := cfg.Webhook.Validate(); err != nil {
+		t.Errorf("expected a valid configuration, got %v", err)
+	}
+}
+
+// Flags that default off must need the exact word, so a plausible-looking
+// value cannot switch on a listening socket or a write to the console.
+func TestConfigFromEnvOnlyTreatsTrueAsTrue(t *testing.T) {
+	for _, value := range []string{"1", "yes", "TRUE", "True", "on", " true"} {
+		cfg, _, err := ConfigFromEnv(env(map[string]string{
+			envURL:            testConsoleURL,
+			envAPIKey:         "key",
+			envWebhookEnabled: value,
+		}))
+		if err != nil {
+			t.Fatalf("reading the configuration: %v", err)
+		}
+		if cfg.Webhook.Enabled {
+			t.Errorf("%q must not enable the fast path", value)
+		}
+	}
+}
+
+func TestConfigFromEnvRejectsUnparseableValues(t *testing.T) {
+	for name, override := range map[string]map[string]string{
+		"poll interval":       {envPollInterval: "half a minute"},
+		"min interval":        {envWebhookMinInterval: "soon"},
+		"low battery":         {envLowBattery: "thirty"},
+		"critical battery":    {envCriticalBattery: "10%"},
+		"poll interval units": {envPollInterval: "30"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			values := map[string]string{envURL: testConsoleURL, envAPIKey: testAPIKey}
+			maps.Copy(values, override)
+			if _, _, err := ConfigFromEnv(env(values)); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+}
+
+func TestWebhookConfigValidate(t *testing.T) {
+	valid := WebhookConfig{
+		Enabled:     true,
+		Path:        DefaultWebhookPath,
+		Token:       testToken,
+		Register:    true,
+		Username:    testConsoleUser,
+		Password:    testConsolePassword,
+		PublicURL:   "http://reactor.example.test:9090/webhooks/unifi",
+		BindAddress: DefaultWebhookBindAddress,
+	}
+	if err := valid.Validate(); err != nil {
+		t.Fatalf("expected a valid configuration, got %v", err)
+	}
+
+	for name, mutate := range map[string]func(*WebhookConfig){
+		"no token":            func(w *WebhookConfig) { w.Token = "" },
+		"relative path":       func(w *WebhookConfig) { w.Path = "webhooks/unifi" },
+		"negative interval":   func(w *WebhookConfig) { w.MinObserveInterval = -time.Second },
+		"no console user":     func(w *WebhookConfig) { w.Username = "" },
+		"no console password": func(w *WebhookConfig) { w.Password = "" },
+		"no public url":       func(w *WebhookConfig) { w.PublicURL = "" },
+		"loopback public url": func(w *WebhookConfig) { w.PublicURL = "http://127.0.0.1:9090/webhooks/unifi" },
+		"registration alone":  func(w *WebhookConfig) { w.Enabled = false },
+	} {
+		t.Run(name, func(t *testing.T) {
+			broken := valid
+			mutate(&broken)
+			if err := broken.Validate(); err == nil {
+				t.Error("expected an error")
+			}
+		})
+	}
+
+	// Console credentials and a public URL only matter to self-registration.
+	receiverOnly := WebhookConfig{Enabled: true, Path: DefaultWebhookPath, Token: testToken}
+	if err := receiverOnly.Validate(); err != nil {
+		t.Errorf("a receiver without self-registration must be valid, got %v", err)
+	}
+}

--- a/internal/providers/unifi/doc.go
+++ b/internal/providers/unifi/doc.go
@@ -14,12 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package unifi will hold the UniFi provider: the WAN state poller (source of
-// truth) and the webhook receiver (fast-path re-observation trigger).
+// Package unifi holds the UniFi provider: the state observer (the mechanism of
+// record) and the webhook fast path in front of it.
 //
-// INTENTIONALLY EMPTY until the v0.0 spike completes: the parser and observer
-// must be written against the real captured payloads in testdata/unifi/ —
-// never against assumed formats. API auth uses the X-API-KEY header, which
-// works on both the Integration API (/proxy/network/integration/v1/...) and
-// the legacy API (/proxy/network/api/s/<site>/...) as of Network 10.5.
+// The two halves are deliberately asymmetric. Client.Observe reads the console
+// and produces every value the engine ever sees; its parsers are written
+// against the real captured payloads in testdata/unifi/, never against assumed
+// formats. Receiver reads nothing at all — a delivery is a hint that an
+// observation is worth doing early, and the observation decides the rest. That
+// is what keeps a dropped, duplicated, replayed or forged delivery from being
+// able to strand the cluster in a state the console does not report.
+//
+// The two halves also authenticate differently. Observation uses the X-API-KEY
+// header, which works on both the Integration API
+// (/proxy/network/integration/v1/...) and the legacy API
+// (/proxy/network/api/s/<site>/...) as of Network 10.5. The Alarm Manager API
+// used for optional self-registration sits at the UniFi OS layer, rejects that
+// header, and needs a cookie session plus a CSRF token — see alarm.go and
+// docs/unifi-alarm-manager-api.md, which is reverse-engineered and version
+// fragile.
 package unifi

--- a/internal/providers/unifi/receiver.go
+++ b/internal/providers/unifi/receiver.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"crypto/subtle"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// Defaults for the webhook fast path.
+const (
+	// DefaultWebhookBindAddress is a port of its own, deliberately not the
+	// metrics or health port: those are exposed to the cluster on different
+	// terms than a port a network appliance is invited to talk to.
+	DefaultWebhookBindAddress = ":9090"
+
+	// DefaultWebhookPath is the path the design spec names.
+	DefaultWebhookPath = "/webhooks/unifi"
+
+	// DefaultMinObserveInterval floors how often a delivery may force an
+	// observation. Deliveries arrive in bursts — a real outage fires several
+	// triggers at once, and a retrying console fires the same one repeatedly —
+	// and the console should not be asked about its own state once per
+	// delivery. It is well under a second so the fast path still is one.
+	DefaultMinObserveInterval = 500 * time.Millisecond
+)
+
+const (
+	// maxDeliveryBytes bounds what the receiver will read from a delivery
+	// before discarding it. Nothing is parsed, so this only exists to stop an
+	// unbounded or slow body from occupying the handler.
+	maxDeliveryBytes = 64 << 10
+
+	authorizationHeader = "Authorization"
+	bearerPrefix        = "Bearer "
+
+	// tokenHeader is an alternative to Authorization, for a rule configured by
+	// hand in the UniFi UI using the Alarm Manager's custom-headers list.
+	tokenHeader = "X-Reactor-Token"
+)
+
+// Receiver is the UniFi webhook fast path: an HTTP endpoint the console's
+// Alarm Manager posts to, whose entire job is to ask the poller to observe
+// again, now, instead of at the next tick.
+//
+// It never reads the delivery body. That is the whole design: polling is the
+// mechanism of record, a delivery is only a hint that something may have
+// changed, and the poll decides what actually did. Because no state is derived
+// from a payload, a delivery that is dropped, duplicated, replayed, delayed or
+// forged costs at most one extra observation of the console, and can never move
+// the cluster into a state the console does not actually report.
+type Receiver struct {
+	// Addr is the address to listen on, e.g. ":9090".
+	Addr string
+	// Path is the URL path deliveries are accepted on.
+	Path string
+	// Token is the shared secret every delivery must present, as either
+	// "Authorization: Bearer <token>" or "X-Reactor-Token: <token>". An empty
+	// token rejects everything rather than accepting everything.
+	Token string
+
+	requests chan struct{}
+	log      logr.Logger
+}
+
+// NewReceiver builds a receiver from the provider configuration. Call
+// Validate on the configuration first; a receiver built from an invalid one
+// simply refuses every delivery.
+func NewReceiver(cfg WebhookConfig) *Receiver {
+	addr := cfg.BindAddress
+	if addr == "" {
+		addr = DefaultWebhookBindAddress
+	}
+	path := cfg.Path
+	if path == "" {
+		path = DefaultWebhookPath
+	}
+	return &Receiver{
+		Addr: addr,
+		Path: path,
+		// A single slot is the point: see request.
+		requests: make(chan struct{}, 1),
+		Token:    cfg.Token,
+		log:      logf.Log.WithName("unifi-webhook"),
+	}
+}
+
+// Requests emits one value per pending re-observation request. Reading from it
+// is how the poller learns a delivery arrived; a nil Receiver's channel is
+// never nil, so the poller never has to special-case the fast path being off.
+func (r *Receiver) Requests() <-chan struct{} { return r.requests }
+
+// request asks for one re-observation. The channel holds a single slot and the
+// send never blocks, so a burst — a retry storm, a duplicate, an outage firing
+// three triggers at once, or a flood from whoever found the endpoint —
+// collapses into one pending observation rather than one per delivery.
+func (r *Receiver) request() bool {
+	select {
+	case r.requests <- struct{}{}:
+		return true
+	default:
+		return false
+	}
+}
+
+// Handler is the receiver's routing, exported so tests can exercise the
+// endpoint without binding a port.
+func (r *Receiver) Handler() http.Handler {
+	mux := http.NewServeMux()
+	// Method-qualified: anything but POST to this path is a 405, and any other
+	// path is a 404, without the handler having to decide.
+	mux.HandleFunc(http.MethodPost+" "+r.Path, r.handleDelivery)
+	return mux
+}
+
+func (r *Receiver) handleDelivery(w http.ResponseWriter, req *http.Request) {
+	if !r.authorized(req) {
+		// The response says nothing about which part was wrong, and nothing
+		// about the console or the cluster behind it.
+		r.log.V(1).Info("Rejected a webhook delivery presenting no valid token")
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	// Read and discard, bounded. Not parsing the payload is what makes a forged
+	// delivery harmless: there is nothing in it Reactor can be told.
+	read, _ := io.Copy(io.Discard, http.MaxBytesReader(w, req.Body, maxDeliveryBytes))
+
+	if r.request() {
+		r.log.V(1).Info("Accepted a webhook delivery; re-observing early", "bytes", read)
+	} else {
+		r.log.V(1).Info("Accepted a webhook delivery; a re-observation is already pending", "bytes", read)
+	}
+
+	// Accepted, not OK: the work this delivery asks for has not happened yet,
+	// and the console is never made to wait for it.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	_, _ = io.WriteString(w, `{"accepted":true}`)
+}
+
+// authorized checks the shared secret in constant time. UniFi's Alarm Manager
+// offers no payload signature, so a shared secret is the strongest thing the
+// console can actually be asked to present.
+func (r *Receiver) authorized(req *http.Request) bool {
+	if r.Token == "" {
+		return false
+	}
+	presented := req.Header.Get(tokenHeader)
+	if presented == "" {
+		if after, found := strings.CutPrefix(req.Header.Get(authorizationHeader), bearerPrefix); found {
+			presented = after
+		}
+	}
+	return subtle.ConstantTimeCompare([]byte(presented), []byte(r.Token)) == 1
+}
+
+// Start implements manager.Runnable; the manager cancels ctx on shutdown.
+//
+// It always returns nil. A fast path that cannot listen is a lost optimization,
+// and returning an error here would stop the manager and take the poller — the
+// mechanism of record — down with it.
+func (r *Receiver) Start(ctx context.Context) error {
+	r.log = logf.FromContext(ctx).WithName("unifi-webhook")
+
+	server := &http.Server{
+		Addr:    r.Addr,
+		Handler: r.Handler(),
+		// A network appliance is not a trusted client: bound how long it may
+		// hold a connection open before completing a request.
+		ReadHeaderTimeout: 5 * time.Second,
+		ReadTimeout:       15 * time.Second,
+		WriteTimeout:      15 * time.Second,
+		IdleTimeout:       60 * time.Second,
+	}
+
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		<-ctx.Done()
+		shutdownCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		defer cancel()
+		_ = server.Shutdown(shutdownCtx)
+	}()
+
+	r.log.Info("Webhook fast path listening", "address", r.Addr, "path", r.Path)
+	if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		r.log.Error(err, "Webhook fast path could not serve; continuing on the poll interval alone",
+			"address", r.Addr)
+		return nil
+	}
+	<-stopped
+	return nil
+}
+
+// NeedLeaderElection reports false so the endpoint answers on every replica.
+// Only the leader polls, so a delivery to a standby is accepted and dropped —
+// which is exactly what a missed delivery already costs: nothing but latency.
+func (r *Receiver) NeedLeaderElection() bool { return false }

--- a/internal/providers/unifi/receiver_test.go
+++ b/internal/providers/unifi/receiver_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// newLocalListener reserves an ephemeral loopback port so a test knows where
+// the receiver will be before it starts.
+func newLocalListener() (net.Listener, error) {
+	return net.Listen("tcp", "127.0.0.1:0")
+}
+
+// waitForListener blocks until the address accepts connections.
+func waitForListener(t *testing.T, addr string) {
+	t.Helper()
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		conn, err := net.DialTimeout("tcp", addr, time.Second)
+		if err == nil {
+			_ = conn.Close()
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("nothing started listening on %s", addr)
+}
+
+const (
+	testToken      = "s3cr3t-shared-token"
+	testCustomPath = "/hooks/reactor"
+)
+
+func testReceiver() *Receiver {
+	return NewReceiver(WebhookConfig{Enabled: true, Token: testToken})
+}
+
+// deliver posts a body to the receiver with the given headers and reports the
+// status and whether a re-observation ended up pending.
+func deliver(t *testing.T, r *Receiver, method, path, body string, headers map[string]string) (int, bool) {
+	t.Helper()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	for name, value := range headers {
+		req.Header.Set(name, value)
+	}
+	rec := httptest.NewRecorder()
+	r.Handler().ServeHTTP(rec, req)
+
+	select {
+	case <-r.Requests():
+		return rec.Code, true
+	default:
+		return rec.Code, false
+	}
+}
+
+func authorized() map[string]string {
+	return map[string]string{authorizationHeader: bearerPrefix + testToken}
+}
+
+func TestReceiverAcceptsAnAuthenticatedDelivery(t *testing.T) {
+	code, requested := deliver(t, testReceiver(), http.MethodPost, DefaultWebhookPath, `{"alarm":"whatever"}`, authorized())
+	if code != http.StatusAccepted {
+		t.Errorf("expected 202 Accepted, got %d", code)
+	}
+	if !requested {
+		t.Error("expected a re-observation to be pending")
+	}
+}
+
+// The alternative header exists for a rule configured by hand in the UniFi UI,
+// where the Alarm Manager's custom-headers list is the available mechanism.
+func TestReceiverAcceptsTheAlternativeTokenHeader(t *testing.T) {
+	code, requested := deliver(t, testReceiver(), http.MethodPost, DefaultWebhookPath, "{}",
+		map[string]string{tokenHeader: testToken})
+	if code != http.StatusAccepted || !requested {
+		t.Errorf("expected an accepted delivery, got status %d, requested %v", code, requested)
+	}
+}
+
+// The payload is never read, so the receiver has no opinion about it. This is
+// the property that makes a forged delivery harmless: there is nothing in one
+// that Reactor can be told, only that it should look at the console again.
+func TestReceiverNeverJudgesTheBody(t *testing.T) {
+	for name, body := range map[string]string{
+		"empty body":   "",
+		"not json":     "<xml>this is not what the console sends</xml>",
+		"truncated":    `{"alarm":`,
+		"json null":    "null",
+		"oversize":     strings.Repeat("x", maxDeliveryBytes*2),
+		"nested state": `{"state":{"wan":"backup"}}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			code, requested := deliver(t, testReceiver(), http.MethodPost, DefaultWebhookPath, body, authorized())
+			if code != http.StatusAccepted || !requested {
+				t.Errorf("expected an accepted delivery, got status %d, requested %v", code, requested)
+			}
+		})
+	}
+}
+
+func TestReceiverRejectsUnauthenticatedDeliveries(t *testing.T) {
+	for name, headers := range map[string]map[string]string{
+		"no credentials":    {},
+		"wrong token":       {authorizationHeader: bearerPrefix + "not-the-token"},
+		"wrong scheme":      {authorizationHeader: "Basic " + testToken},
+		"token prefix only": {authorizationHeader: bearerPrefix + testToken[:8]},
+		"wrong header":      {"X-Api-Key": testToken},
+		"empty bearer":      {authorizationHeader: bearerPrefix},
+	} {
+		t.Run(name, func(t *testing.T) {
+			code, requested := deliver(t, testReceiver(), http.MethodPost, DefaultWebhookPath, "{}", headers)
+			if code != http.StatusUnauthorized {
+				t.Errorf("expected 401 Unauthorized, got %d", code)
+			}
+			if requested {
+				t.Error("an unauthenticated delivery must not cause an observation")
+			}
+		})
+	}
+}
+
+// A receiver with no secret configured must be inert rather than open.
+func TestReceiverWithoutATokenAcceptsNothing(t *testing.T) {
+	open := NewReceiver(WebhookConfig{Enabled: true})
+	for _, headers := range []map[string]string{{}, {authorizationHeader: bearerPrefix}, {tokenHeader: ""}} {
+		code, requested := deliver(t, open, http.MethodPost, DefaultWebhookPath, "{}", headers)
+		if code != http.StatusUnauthorized || requested {
+			t.Errorf("expected 401 and no observation, got status %d, requested %v", code, requested)
+		}
+	}
+}
+
+func TestReceiverRejectsOtherMethodsAndPaths(t *testing.T) {
+	for name, request := range map[string]struct {
+		method, path string
+		want         int
+	}{
+		"GET on the delivery path": {http.MethodGet, DefaultWebhookPath, http.StatusMethodNotAllowed},
+		"PUT on the delivery path": {http.MethodPut, DefaultWebhookPath, http.StatusMethodNotAllowed},
+		"POST elsewhere":           {http.MethodPost, "/", http.StatusNotFound},
+		"POST to a sibling path":   {http.MethodPost, "/webhooks/unifi/extra", http.StatusNotFound},
+	} {
+		t.Run(name, func(t *testing.T) {
+			code, requested := deliver(t, testReceiver(), request.method, request.path, "{}", authorized())
+			if code != request.want {
+				t.Errorf("expected status %d, got %d", request.want, code)
+			}
+			if requested {
+				t.Error("expected no observation to be requested")
+			}
+		})
+	}
+}
+
+// A burst must cost one observation, not one per delivery: a real outage fires
+// several triggers at once, a retrying console repeats them, and someone who
+// found the endpoint can repeat them as fast as they like.
+func TestReceiverCoalescesABurstIntoOneObservation(t *testing.T) {
+	r := testReceiver()
+	for range 500 {
+		req := httptest.NewRequest(http.MethodPost, DefaultWebhookPath, strings.NewReader("{}"))
+		req.Header.Set(authorizationHeader, bearerPrefix+testToken)
+		r.Handler().ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	pending := 0
+	for {
+		select {
+		case <-r.Requests():
+			pending++
+			continue
+		default:
+		}
+		break
+	}
+	if pending != 1 {
+		t.Errorf("expected 500 deliveries to collapse into 1 pending observation, got %d", pending)
+	}
+}
+
+// A custom path must be honoured exactly, and must not leave the default one
+// answering as well.
+func TestReceiverHonoursACustomPath(t *testing.T) {
+	r := NewReceiver(WebhookConfig{Enabled: true, Token: testToken, Path: testCustomPath})
+	if code, requested := deliver(t, r, http.MethodPost, testCustomPath, "{}", authorized()); code != http.StatusAccepted || !requested {
+		t.Errorf("expected the custom path to accept, got status %d, requested %v", code, requested)
+	}
+	if code, _ := deliver(t, r, http.MethodPost, DefaultWebhookPath, "{}", authorized()); code != http.StatusNotFound {
+		t.Errorf("expected the default path to be absent, got status %d", code)
+	}
+}
+
+func TestNewReceiverFallsBackToDefaults(t *testing.T) {
+	r := NewReceiver(WebhookConfig{Enabled: true, Token: testToken})
+	if r.Addr != DefaultWebhookBindAddress || r.Path != DefaultWebhookPath {
+		t.Errorf("expected defaults, got address %q path %q", r.Addr, r.Path)
+	}
+}
+
+// Start must never report an error, however badly it goes: the manager stops
+// on a Runnable error, and stopping the manager would stop the poller.
+func TestReceiverStartReportsNoErrorWhenItCannotListen(t *testing.T) {
+	r := NewReceiver(WebhookConfig{Enabled: true, Token: testToken, BindAddress: "127.0.0.1:-1"})
+	if err := r.Start(context.Background()); err != nil {
+		t.Fatalf("a receiver that cannot listen must not fail the manager: %v", err)
+	}
+}
+
+func TestReceiverStartServesAndShutsDownWithTheContext(t *testing.T) {
+	r := NewReceiver(WebhookConfig{Enabled: true, Token: testToken, BindAddress: "127.0.0.1:0"})
+	// Bind an ephemeral port by hand so the test knows where to reach it.
+	listener, err := newLocalListener()
+	if err != nil {
+		t.Fatalf("reserving a local port: %v", err)
+	}
+	addr := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatalf("releasing the reserved port: %v", err)
+	}
+	r.Addr = addr
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopped := make(chan error, 1)
+	go func() { stopped <- r.Start(ctx) }()
+
+	waitForListener(t, addr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+addr+DefaultWebhookPath, strings.NewReader("{}"))
+	if err != nil {
+		t.Fatalf("building the delivery: %v", err)
+	}
+	req.Header.Set(authorizationHeader, bearerPrefix+testToken)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("delivering over the wire: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Errorf("expected 202 Accepted over the wire, got %d", resp.StatusCode)
+	}
+	select {
+	case <-r.Requests():
+	default:
+		t.Error("expected a re-observation to be pending after a real delivery")
+	}
+
+	cancel()
+	select {
+	case err := <-stopped:
+		if err != nil {
+			t.Errorf("expected a clean shutdown, got %v", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Error("the receiver did not stop when its context was cancelled")
+	}
+}

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -182,3 +182,68 @@ func TestOperationalExtrasAreOptOut(t *testing.T) {
 		t.Error("networkPolicy.enabled did not produce a policy")
 	}
 }
+
+// TestWebhookFastPathIsOptOut is the upgrade guarantee for the fast path: an
+// existing install that does not ask for it gains no listening port, no
+// Service, and no second credential.
+func TestWebhookFastPathIsOptOut(t *testing.T) {
+	defaults := render(t, unifiURL)
+	for _, absent := range []string{"UNIFI_WEBHOOK_ENABLED", "containerPort: 9090", "-webhook"} {
+		if strings.Contains(defaults, absent) {
+			t.Errorf("a default install renders %q; the webhook must be opt-in", absent)
+		}
+	}
+
+	enabled := render(t, unifiURL, "unifi.webhook.enabled=true")
+	for _, present := range []string{"UNIFI_WEBHOOK_ENABLED", "UNIFI_WEBHOOK_TOKEN", "containerPort: 9090"} {
+		if !strings.Contains(enabled, present) {
+			t.Errorf("unifi.webhook.enabled did not render %q", present)
+		}
+	}
+	// A ClusterIP cannot be reached by a console outside the cluster, which is
+	// the point: exposing the receiver stays the operator's explicit decision.
+	if !strings.Contains(enabled, "type: ClusterIP") {
+		t.Error("the webhook Service is not a ClusterIP by default")
+	}
+	// Self-registration writes to the user's gateway, so it needs its own yes.
+	if strings.Contains(enabled, "UNIFI_WEBHOOK_REGISTER") {
+		t.Error("enabling the receiver also enabled self-registration")
+	}
+}
+
+// TestWebhookMisconfigurationsFailAtInstall covers the combinations that
+// cannot work, where rendering something plausible would mean debugging a
+// silent no-op later instead.
+func TestWebhookMisconfigurationsFailAtInstall(t *testing.T) {
+	for name, values := range map[string][]string{
+		"receiver without a console":    {"unifi.webhook.enabled=true"},
+		"registration without receiver": {unifiURL, "unifi.webhook.registration.enabled=true"},
+		"registration without a public URL": {unifiURL, "unifi.webhook.enabled=true",
+			"unifi.webhook.registration.enabled=true"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if renderFails(t, values...) == "" {
+				t.Error("expected the chart to refuse this combination")
+			}
+		})
+	}
+}
+
+// renderFails returns the error output of a render expected to fail, or "" if
+// it unexpectedly succeeded.
+func renderFails(t *testing.T, values ...string) string {
+	t.Helper()
+	if _, err := exec.LookPath("helm"); err != nil {
+		t.Skip("helm is not installed; skipping chart render tests")
+	}
+	args := make([]string, 0, len(values)*2+3)
+	args = append(args, "template", "reactor", chartDir())
+	for _, value := range values {
+		args = append(args, "--set", value)
+	}
+	out, err := exec.Command("helm", args...).CombinedOutput()
+	if err == nil {
+		return ""
+	}
+	return string(out)
+}

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -47,4 +47,19 @@ A UniFi UPS is reported as a switch-type device (`USWDA26`) carrying:
 
 ## Webhooks
 
-`webhooks/` will hold captured Alarm Manager deliveries. `hack/webhook-logger.mjs` dumps incoming requests verbatim to `webhooks/raw/` (gitignored) — review, allowlist, and sanitize before committing anything from there.
+`webhooks/` will hold captured Alarm Manager deliveries. **It is still empty**: capturing one requires a real console configured to post to a real receiver, and that has not been done yet.
+
+Nothing depends on it. The receiver never reads a delivery body — a delivery only ever asks for a re-observation, and the observation decides the state — so there is no parser here waiting for ground truth. These fixtures are for the event triggers that come later, where a payload *is* the data.
+
+Capturing one is two steps, and the second is not optional:
+
+```sh
+node hack/webhook-logger.mjs 8080                     # dumps verbatim to webhooks/raw/ (gitignored)
+
+./hack/sanitize-webhook-capture.sh --paths webhooks/raw/<file>.json
+./hack/sanitize-webhook-capture.sh webhooks/raw/<file>.json <name> alarm.trigger,alarm.title
+```
+
+`--paths` prints every field path in the body; the second command keeps the ones named and discards everything else, along with every header except `content-type`.
+
+Dropping the headers is the point. A delivery arrives with Reactor's own shared secret in an `Authorization` header, so a fixture made by keeping *the request* rather than *these fields of the request* publishes the credential that protects the endpoint. `hack/verify-testdata.sh` rejects leftover credential material in this directory, but as with the API captures, that is the safety net and the script is the mechanism.


### PR DESCRIPTION
Closes #32.

Reaction latency was bounded below by `unifi.pollInterval`. UniFi's Alarm Manager can post to Reactor instead, cutting that to about a second — and Reactor can create that Alarm Manager rule itself rather than asking users to click through the UniFi UI.

**Everything here defaults off.** An existing install that upgrades gains no listening socket, no new credentials, and no writes to its gateway.

## The design constraint, and how it is enforced

Polling stays the mechanism of record. That is enforced by the shape of the code rather than by a convention: **the receiver never reads a delivery body.**

A delivery says only "look now". The observation that follows decides what actually changed. Because no state is derived from a payload, a delivery that is dropped, duplicated, replayed, delayed or forged costs at most one extra observation of the console, and can never move the cluster into a state the console does not report. `TestADeliveryCannotPutStateInTheStore` asserts exactly that: a delivery insisting `wan: backup` arrives while the console keeps reporting the primary uplink, and the store still says primary.

Not parsing the payload also means there is no parser here waiting on ground truth — see the fixtures note below.

## What was built

**Receiver** (`internal/providers/unifi/receiver.go`) — `POST /webhooks/unifi` on its own port, deliberately not the metrics or health port.

- Requires a shared secret, compared in constant time, as `Authorization: Bearer <token>` or `X-Reactor-Token: <token>`. A receiver with no secret configured rejects everything rather than accepting everything. UniFi's Alarm Manager offers no payload signature, so a shared secret is the strongest thing the console can be asked to present.
- Reads and discards a bounded body, returns `202 Accepted` immediately. The console is never made to wait.
- Deliveries coalesce through a single-slot channel, and the poller floors the time between observations (`minObserveInterval`, default 500ms). A burst — a real outage firing three triggers, a retrying console, or a flood from whoever found the endpoint — becomes one observation, not one per delivery.
- A receiver that cannot listen logs the error and returns `nil`. Failing the Runnable would stop the manager and take the poller down with it, which inverts the whole priority.

**Poller** (`internal/controller/unifi_poller.go`) — gains a `Nudge` channel and the interval floor. A nil channel means poll-only, so the fast path being absent needs no special case. `observe` is factored out of the loop; behaviour with no nudge channel is unchanged.

**Debounce interaction** (rebase onto #54) — a delivery may bring an observation forward, but it must not supply the consecutive samples a debounced key needs. Otherwise anyone able to reach the endpoint could push a debounced key through its settling time in a fraction of the intended window, which is the one thing debounce exists to prevent. `StateStore.Proving(provider)` reports whether a value is part-way through its threshold, and the poller refuses deliveries while it is: a delivery may *start* a debounce (that is "look sooner", one observation), and every later one is refused until the value is promoted or abandoned. Verified by removing the guard and watching `TestADeliveryBurstCannotFastForwardADebouncedKey` fail — 200 deliveries promoted the key in 5 observations; with the guard it stays put at 2. `Proving` is provider-agnostic and takes a provider name, exactly like `Get`.

**Self-registration** (`internal/providers/unifi/alarm.go`) — optional, off by default, leader-elected, and it swallows every failure.

**Chart** — values, a `ports` entry, a Service, and `fail` guards for the three configurations that cannot work (webhook without `unifi.url`, registration without the receiver, registration without a `publicURL`).

**`cmd/main.go`** — the UniFi env parsing moved into `unifi.ConfigFromEnv`, which is now unit-tested. `main` was already `nolint:gocyclo` and would have become unreadable otherwise. Existing behaviour is preserved, including which values are fatal.

## Verified against a real console vs. inferred

`docs/unifi-alarm-manager-api.md` now carries this split in full. Summary:

**Observed on a real console (Network 10.5.67), per the existing notes:** the cookie session and the `csrfToken` claim inside the `TOKEN` JWT; the three endpoints used; the arrays-of-arrays `triggers_data` / `actions_data` shape and that a flat array is rejected; the `network:webhook` action and the three Internet trigger IDs; that `auth` variants `none | basic | bearer` exist; that loopback destinations are rejected.

**Inferred, never confirmed:**

- **The field name carrying the bearer value.** Reactor sends `"auth": {"variant": "bearer", "token": "<secret>"}`. The variant list is documented; the key holding the value is a guess. If a console rejects the body, the console's own validation error is logged verbatim — that is how this API was mapped in the first place — and the rule can be created by hand in the UniFi UI instead. The receiver accepts `X-Reactor-Token` precisely so the Alarm Manager's custom-headers list is a working fallback.
- **The manifest and rules-list shapes.** Rather than guess a path through either, Reactor searches the decoded document for the IDs it needs and for a rule carrying its own title. A console that reorganizes its JSON degrades to "not offered" rather than to a decode error.

**Deliberately not implemented: editing and deleting rules.** `DELETE .../alarms/network/<id>` is an assumed verb and `PUT` vs `PATCH` was never established. Reactor creates its rule and then leaves it alone forever — guessing wrong means silently breaking somebody's alerting. A rule whose destination has gone stale is reported in the logs with its ID and left for a human to remove.

## Degrading cleanly when the console misbehaves

Every step checks before it writes, and every failure is logged and abandoned with polling untouched:

| Console does this | Reactor does this |
| --- | --- |
| refuses the login | logs it, no write, keeps polling |
| issues a session cookie that is not a JWT | falls back to the `x-csrf-token` response header |
| issues no CSRF token at all | logs it, no write |
| manifest unreadable | logs it, no write |
| manifest has no `network:webhook` action | logs it, no write |
| manifest has only some requested triggers | asks for those, logs the ones skipped |
| manifest has none of them | logs it, no write |
| already has a rule with Reactor's title | logs its ID, changes nothing |
| rejects the create body | logs the console's own error verbatim |

`AlarmRegistrar.Start` returns `nil` unconditionally, so none of this can stop the manager.

## Exposure

**The receiver is not reachable from a console by default.** Enabling it creates a ClusterIP Service, and the gateway is not in the cluster. Reaching it is a deliberate choice — `LoadBalancer` on a LAN-routable address, `NodePort`, your own Ingress pointed at the Service, or `service.enabled=false` for none of the above. The chart ships no Ingress: TLS, class and annotations vary too much, and the wrong default there publishes an endpoint nobody asked to publish. Documented in the chart README.

With `replicaCount > 1` the endpoint answers on every replica but only the leader polls, so a delivery landing on a standby is accepted and dropped — the same cost as a missed delivery. Noted in the chart README.

## Fixtures

**`testdata/unifi/webhooks/` is still empty**, and the issue's "captured payloads committed" criterion is the one thing here I could not do: capturing a real delivery needs a real console posting to a real receiver, and I was scoped to the mock. I did not fabricate a fixture and label it a capture.

Nothing depends on it. The receiver ignores payloads, so there is no parser waiting on ground truth; these fixtures matter for the event triggers that come later, where a payload *is* the data.

What did land is the tooling so capturing one is two commands. A raw record from `hack/webhook-logger.mjs` contains every header, including the `Authorization` header carrying Reactor's own shared secret — committing one by hand is the same shape of mistake that put a live device key in this repo's history. `hack/sanitize-webhook-capture.sh --paths` prints every field path in the body; the second invocation keeps only the ones named and drops all headers but `content-type`, plus the base64 copy of the body that would otherwise smuggle the payload past every text-based check. `verify-testdata.sh` gained the matching net for that directory.

## How I verified this

- **`make test` and `make lint` pass.** Lint reports 0 issues under the repo's stricter CI config (the goconst, depguard, modernize and logcheck findings are fixed, not suppressed). No `make manifests generate` drift — **no CRD schema change**, so this does not interact with #38 beyond adding one new file under `charts/reactor/templates/`.
- **End-to-end against `hack/mock-unifi`,** which now mocks the alarms API: Reactor logged in, read the manifest, created its rule, and a second start correctly found the existing rule and changed nothing. `POST /alarm-fire` then delivered to the registered URL with the bearer token and got `202`, and the receiver asked for a re-observation. The mock enforces the CSRF header and rejects a flat `triggers_data`, so it fails if Reactor stops sending what the notes describe.
- **`internal/controller/unifi_webhook_test.go`** drives receiver → nudge → poller against the real captured `stat-device-gateway.json`: a delivery re-observes within a second against an hour-long poll interval; a delivery cannot put state in the store; an unauthenticated delivery costs no poll at all; 200 deliveries collapse to about one observation without being lost; a poller with no nudge channel polls exactly as before; and the three debounce cases — a burst cannot fast-forward a debounced key, refusing those deliveries does not wedge the poller (the poll cadence still promotes it), and with no debounce configured a single delivery still promotes immediately.
- **Receiver tests** cover a body that is empty, malformed, oversize, or claiming a WAN failover — all accepted identically, which is the design; wrong token, wrong scheme, prefix-only token, wrong header, no token configured — all 401 with no observation; wrong method and path; 500 deliveries collapsing to one.
- **Alarm tests** run against a fake console for each degradation row in the table above, and assert the arrays-of-arrays create body.
- **`test/chart/chart_test.go`** gains the webhook cases in the suite #51 established: a default install renders no webhook env, port or Service; enabling renders all three plus a ClusterIP; enabling the receiver does not enable self-registration; and each of the three unusable combinations fails at install.
- **Chart rendered** in each configuration: the default install emits zero webhook artifacts; enabling produces the env, port and Service; each of the three `fail` guards fires with its own message. `helm lint` clean.
- Race detector clean across three consecutive full runs. No cluster was touched, and nothing was pointed at a real console.

## LIVE VERIFICATION

Everything below needs hardware, a real console, or a real cluster, and none of it gates this PR.

- **Bearer field name** — enable `unifi.webhook.registration` against a real console; look for `Created the Alarm Manager rule` in the logs. If it instead logs a 400 with the console's validation message, `auth.token` is the wrong key and the message names the right one.
- **Delivery carries the token** — after registration, trigger a real alarm and check the receiver returns `202`, not `401`. A 401 means the console accepted `auth.bearer` but sends it differently than `Authorization: Bearer`.
- **End-to-end latency** — unplug the WAN and measure the gap between the delivery log line and the `state transition` line; confirm it is under a second, and that `network:internet_disconnected` actually fires on a real outage.
- **Manifest ID check against a real catalog** — confirm `jsonHasString` finds `network:webhook` and the three triggers in a real `GET /api/v2/alarms/network/manifest`; a false negative means no rule is created and the logs say the action is not offered.
- **Rules-list shape** — restart Reactor twice against a real console and confirm the second start logs `Alarm Manager rule already exists`. If it creates a second rule, `findRuleID` does not match the real GET representation.
- **Second WAN** — recheck the manifest with two uplinks configured for a genuine failover trigger (the notes suspect `INTERNET_OUTAGE_AND_FAILOVER` exists); if one appears, add it to `DefaultAlarmTriggers`.
- **Capture a real delivery** — run `hack/webhook-logger.mjs`, trigger an alarm, then `hack/sanitize-webhook-capture.sh --paths` and commit an allowlisted fixture to `testdata/unifi/webhooks/`. This is issue #32's open acceptance criterion.
- **Reachability from the console** — on a real cluster, expose the receiver (LoadBalancer/NodePort/Ingress) and confirm the gateway can reach that address; the console rejects loopback, and Reactor cannot verify reachability from its side.
- **Console credentials** — confirm a UniFi OS *local* account works for `POST /api/auth/login` and whether an SSO/Ubiquiti-account login or 2FA breaks it. Untested; 2FA very likely breaks it.
- **Non-`ALL_ITEMS` scope** — the rule is created with `site_id: ALL_ITEMS`; confirm that behaves on a multi-site console.
- **Deletion path** — confirm which verb removes a rule, so the stale-rule case can eventually be more than a log line.
- **Leader failover** — on a multi-replica cluster, confirm a delivery landing on a standby is a no-op and the next poll still corrects state.
- **Debounce with a real console** — with `unifi.debounce.keys` set and the fast path on, confirm a debounced key still takes its configured samples at `pollInterval` and is not hurried by real deliveries during a genuine event.
- **NetworkPolicy** — with `networkPolicy.enabled` and the webhook on, confirm deliveries are dropped until an ingress rule for the receiver port is added; the failure mode is silent (reactions just go back to poll speed), which is why it is documented in both `values.yaml` and the chart README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
