### PR TITLE
test(e2e): cover the reaction flow, restarts, arbitration, and the release lifecycle

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -7,11 +7,23 @@ on:
 permissions: {}
 
 jobs:
-  test-e2e:
+  # Each suite gets its own runner, and so its own throwaway Kind cluster: they
+  # install cluster-wide RBAC and delete CRDs, which cannot be shared.
+  e2e:
     permissions:
       contents: read
-    name: Run on Ubuntu
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Manager
+            target: test-e2e
+          - name: Reaction
+            target: test-reaction
+          - name: Lifecycle
+            target: test-lifecycle
     steps:
       - name: Clone the code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -22,6 +34,11 @@ jobs:
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
           go-version-file: go.mod
+
+      # The reaction and lifecycle suites install the chart rather than the
+      # kustomize manifests, so helm has to be there rather than merely likely.
+      - name: Setup Helm
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
 
       - name: Install the latest version of kind
         run: |
@@ -35,4 +52,4 @@ jobs:
       - name: Running Test e2e
         run: |
           go mod tidy
-          make test-e2e
+          make ${{ matrix.target }}

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,10 @@
 version: "2"
 run:
   allow-parallel-runners: true
+  # The e2e suites are behind this tag, so without it they are the only Go in
+  # the repository nothing checks.
+  build-tags:
+    - e2e
 linters:
   default: none
   enable:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ make build         # compile the manager binary
 make help          # every target
 ```
 
-Both `make test` and `make lint` must pass before a PR is ready. CI runs lint, tests, e2e, and a manifest-drift check. The chart tests in `test/chart/` need `helm` on your PATH to run at all — they render the chart and check, among other things, that its templated CRD has not drifted from `config/crd/bases`.
+Both `make test` and `make lint` must pass before a PR is ready. CI runs lint, tests, three e2e suites, and a manifest-drift check. The e2e suites (`make test-reaction`, `make test-lifecycle`, `make test-e2e`) each create and delete their own Kind cluster; see [Development](docs/development.md#end-to-end-tests) for what each one covers. The chart tests in `test/chart/` need `helm` on your PATH to run at all — they render the chart and check, among other things, that its templated CRD has not drifted from `config/crd/bases`.
 
 **No UniFi hardware is required.** `make dev-mock` serves the captured payloads on `:9443` and lets you drive state transitions by hand:
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,9 @@ test: manifests generate fmt vet verify-testdata setup-envtest ## Run tests.
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
 KIND_CLUSTER ?= unifi-reactor-test-e2e
+# Every e2e suite drives a rehearsed UniFi console inside the cluster and
+# reaches it over this node port mapping.
+KIND_CONFIG ?= test/e2e/kind-config.yaml
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
@@ -87,13 +90,37 @@ setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist
 			echo "Kind cluster '$(KIND_CLUSTER)' already exists. Skipping creation." ;; \
 		*) \
 			echo "Creating Kind cluster '$(KIND_CLUSTER)'..."; \
-			$(KIND) create cluster --name $(KIND_CLUSTER) ;; \
+			$(KIND) create cluster --name $(KIND_CLUSTER) --config $(KIND_CONFIG) ;; \
 	esac
 
 .PHONY: test-e2e
 test-e2e: setup-test-e2e manifests generate fmt vet ## Run the e2e tests. Expected an isolated environment using Kind.
 	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) go test -tags=e2e ./test/e2e/ -v -ginkgo.v
 	$(MAKE) cleanup-test-e2e
+
+# The suites below install the chart, drive a rehearsed console, and assert on
+# what happened to real workloads. Each gets its own throwaway cluster, torn
+# down whether or not the tests passed: they install cluster-wide RBAC and
+# delete CRDs, so nothing they touch may outlive them.
+.PHONY: test-reaction
+test-reaction: KIND_CLUSTER = unifi-reactor-reaction
+test-reaction: setup-test-e2e manifests generate fmt vet ## Run the reaction and arbitration e2e suite.
+	@set -o pipefail; \
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) \
+		go test -tags=e2e ./test/e2e/reaction/ -v -ginkgo.v -timeout 40m; \
+	status=$$?; \
+	$(MAKE) cleanup-test-e2e KIND_CLUSTER=$(KIND_CLUSTER); \
+	exit $$status
+
+.PHONY: test-lifecycle
+test-lifecycle: KIND_CLUSTER = unifi-reactor-lifecycle
+test-lifecycle: setup-test-e2e manifests generate fmt vet ## Run the uninstall and chart-upgrade e2e suite.
+	@set -o pipefail; \
+	KIND=$(KIND) KIND_CLUSTER=$(KIND_CLUSTER) \
+		go test -tags=e2e ./test/e2e/lifecycle/ -v -ginkgo.v -timeout 40m; \
+	status=$$?; \
+	$(MAKE) cleanup-test-e2e KIND_CLUSTER=$(KIND_CLUSTER); \
+	exit $$status
 
 .PHONY: cleanup-test-e2e
 cleanup-test-e2e: ## Tear down the Kind cluster used for e2e tests

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -120,6 +120,11 @@ scaled down would therefore stay down forever, so a `pre-delete` hook Job
 releases every claim first and removes the finalizers that nothing would be
 left to service.
 
+The Job stops the operator before releasing anything. Helm removes the
+release's own resources only once its pre-delete hooks have finished, so a
+controller still running would simply re-claim what the hook released, and
+re-add the finalizer — turning a later `kubectl delete crd` into a hang.
+
 ```sh
 helm uninstall reactor -n reactor-system              # workloads restored
 helm uninstall reactor -n reactor-system --no-hooks   # skip it, leave them as they are

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -435,6 +435,6 @@ networkPolicy:
 | `actions.allowedDestinations` | `[]` | Where outbound actions may go. Empty refuses all of them; see [Outbound actions](#outbound-actions) |
 | `uninstall.releaseClaims` | `true` | Run a pre-delete Job that hands every held workload back before the operator is removed |
 | `uninstall.timeoutSeconds` | `120` | Hard bound on that Job, so a stuck release delays rather than blocks the uninstall |
-| `rbac.clusterWide` | `true` | `false` restricts the operator to the release namespace (cross-namespace `target.namespace` stops working) |
+| `rbac.clusterWide` | `true` | `false` restricts the operator to watching and acting on the release namespace only (cross-namespace `target.namespace` stops working, and Automations elsewhere are not reconciled at all) |
 | `image.repository` | `ghcr.io/robbeverhelst/unifi-reactor` | Manager image |
 | `image.tag` | chart `appVersion` | Image tag |

--- a/charts/reactor/templates/_helpers.tpl
+++ b/charts/reactor/templates/_helpers.tpl
@@ -28,6 +28,19 @@ app.kubernetes.io/name: {{ include "reactor.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
+{{/*
+The namespace the operator may see. Namespace-scoped RBAC grants no cluster-wide
+list, so watching every namespace would leave every informer failing while the
+health probes still report the pod ready. Rendered into both the manager and the
+pre-delete hook so they agree on scope.
+*/}}
+{{- define "reactor.watchNamespaceEnv" -}}
+{{- if not .Values.rbac.clusterWide }}
+- name: WATCH_NAMESPACE
+  value: {{ .Release.Namespace | quote }}
+{{- end }}
+{{- end -}}
+
 {{- define "reactor.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
 {{- default (include "reactor.fullname" .) .Values.serviceAccount.name -}}

--- a/charts/reactor/templates/deployment.yaml
+++ b/charts/reactor/templates/deployment.yaml
@@ -53,6 +53,7 @@ spec:
             - --zap-log-level={{ .Values.log.level }}
             - --zap-encoder={{ .Values.log.format }}
           env:
+            {{- include "reactor.watchNamespaceEnv" . | nindent 12 }}
             {{- if .Values.unifi.url }}
             - name: UNIFI_URL
               value: {{ .Values.unifi.url | quote }}

--- a/charts/reactor/templates/pre-delete-hook.yaml
+++ b/charts/reactor/templates/pre-delete-hook.yaml
@@ -48,6 +48,8 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
             - --release-claims
+          env:
+            {{- include "reactor.watchNamespaceEnv" . | nindent 12 }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/charts/reactor/templates/pre-delete-hook.yaml
+++ b/charts/reactor/templates/pre-delete-hook.yaml
@@ -50,6 +50,14 @@ spec:
             - --release-claims
           env:
             {{- include "reactor.watchNamespaceEnv" . | nindent 12 }}
+            # Helm removes the operator's Deployment only once this hook has
+            # finished, so the hook stops it itself first. A controller still
+            # watching would re-claim every workload the hook just released,
+            # and re-add the finalizer that by then has nothing to service it.
+            - name: MANAGER_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - name: MANAGER_DEPLOYMENT
+              value: {{ include "reactor.fullname" . | quote }}
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -38,6 +38,7 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -146,6 +147,16 @@ func logKubernetesVersion(config *rest.Config) {
 	setupLog.Info("Kubernetes version detected", "version", version)
 }
 
+// watchNamespace is the single namespace Reactor is allowed to see, or "" for
+// the whole cluster. The chart sets it precisely when it grants namespace-
+// scoped RBAC: a cluster-scoped informer under a namespaced Role is forbidden,
+// and controller-runtime answers that by retrying the failed list forever while
+// the health probes keep reporting the pod ready — an operator that looks
+// healthy and reconciles nothing.
+func watchNamespace() string {
+	return strings.TrimSpace(os.Getenv("WATCH_NAMESPACE"))
+}
+
 // runReleaseClaims hands every claimed target back and exits. It talks to the
 // API server directly rather than through a manager's cache, because it has to
 // finish inside an uninstall rather than run for as long as the process lives.
@@ -155,7 +166,11 @@ func runReleaseClaims() error {
 	if err != nil {
 		return err
 	}
-	return controller.ReleaseAllClaims(logf.IntoContext(ctx, ctrl.Log.WithName("release-claims")), c)
+	options := controller.ReleaseOptions{
+		Namespace: watchNamespace(),
+	}
+	return controller.ReleaseAllClaims(
+		logf.IntoContext(ctx, ctrl.Log.WithName("release-claims")), c, options)
 }
 
 // nolint:gocyclo
@@ -283,8 +298,18 @@ func main() {
 	// the action failed.
 	restConfig.WarningHandler = targetAdmissionWarnings{log: ctrl.Log.WithName("target-warning")}
 
+	// Scoped to match the RBAC the operator was actually granted, so a
+	// namespaced install watches what it may read instead of failing every list
+	// at cluster scope.
+	cacheOptions := cache.Options{}
+	if namespace := watchNamespace(); namespace != "" {
+		cacheOptions.DefaultNamespaces = map[string]cache.Config{namespace: {}}
+		setupLog.Info("Watching a single namespace", "namespace", namespace)
+	}
+
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
 		Scheme:                 scheme,
+		Cache:                  cacheOptions,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -166,8 +167,16 @@ func runReleaseClaims() error {
 	if err != nil {
 		return err
 	}
+	// The chart names its own Deployment here so the sweep can stop Reactor
+	// before handing anything back. Helm removes the operator only after its
+	// pre-delete hooks finish, so a controller left running re-claims
+	// everything the sweep just released.
 	options := controller.ReleaseOptions{
 		Namespace: watchNamespace(),
+		Manager: types.NamespacedName{
+			Namespace: os.Getenv("MANAGER_NAMESPACE"),
+			Name:      os.Getenv("MANAGER_DEPLOYMENT"),
+		},
 	}
 	return controller.ReleaseAllClaims(
 		logf.IntoContext(ctx, ctrl.Log.WithName("release-claims")), c, options)

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,6 +38,22 @@ make help     # every target
 
 CI runs lint, tests, e2e, and a manifest-drift check, so `make manifests generate` output must be committed.
 
+## End-to-end tests
+
+Three suites, each in its own throwaway Kind cluster, each its own CI job:
+
+```sh
+make test-e2e        # the manager comes up under the kustomize manifests
+make test-reaction   # reactions, restarts, and arbitration against a real API server
+make test-lifecycle  # helm uninstall and the upgrade from the crds/ packaging
+```
+
+The two new ones install the Helm chart and point it at a rehearsed UniFi console running inside the cluster, then assert on what happened to real workloads: replicas, the `reactor.robbeverhelst.com/*` annotations, `status.targets[]`, and the `Ready` and `Applied` conditions. They cover the things that cannot be reached from a unit test — converging on a state that changed while the operator was down, two Automations arbitrating one workload, and what `helm uninstall` leaves behind.
+
+Each target creates its Kind cluster, runs the suite, and deletes the cluster whether or not it passed. Every `kubectl` and `helm` call inside the suites names its cluster explicitly and refuses to address anything that is not a local Kind context — they install cluster-wide RBAC and delete CRDs, so an unpinned command is not a failed test but an outage.
+
+The suites reach the mock over a fixed node port mapped to the host by `test/e2e/kind-config.yaml`, which is why they create their own clusters rather than reusing one you already have.
+
 `make manifests` also regenerates `charts/reactor/templates/crds.yaml` via `hack/sync-chart-crds.sh`. The CRD is a chart *template* deliberately: Helm installs a chart's `crds/` directory on first install only and never upgrades it, so every later schema change would ship silently broken. Don't hand-edit the chart's copy — the tests in `test/chart/` fail when it drifts from `config/crd/bases`, and they need `helm` on your PATH to run at all.
 
 ## Running against a cluster
@@ -69,7 +85,10 @@ curl -X POST http://localhost:9443/flip                        # WAN primary <->
 curl -X POST 'http://localhost:9443/ups?mode=battery&level=80' # power outage
 curl -X POST 'http://localhost:9443/ups?level=5'               # battery critical
 curl -X POST 'http://localhost:9443/ups?mode=mains&level=100'  # power restored
+curl -X POST 'http://localhost:9443/ups?present=false'         # UPS drops off the console
 ```
+
+`present=false` removes the UPS from the device list rather than reporting a value for it, so the `ups` keys vanish entirely. That is the case an Automation has to distinguish from "the outage ended", and the one the reconciler answers with `StateKeyUnavailable`.
 
 ### Rehearsing a failover that has never been observed
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -278,7 +278,7 @@ Two ways out, and the second is usually better in a homelab you did not want clu
 - `helm upgrade ... --set rbac.clusterWide=true`
 - Move the Automation into the target's namespace and drop `target.namespace`. Automations are namespaced precisely so they can live next to what they act on.
 
-> With `rbac.clusterWide: false`, Automations outside the release namespace are not reconciled at all — the operator has no permission to watch them, so they never get a status. If a resource you created is showing no status whatsoever, check this before anything else, and check the operator log for `failed to list` errors.
+> With `rbac.clusterWide: false`, the operator watches only the release namespace, and Automations outside it are not reconciled at all — they never get a status. If a resource you created is showing no status whatsoever, check this before anything else. The chart passes the scope to the operator as `WATCH_NAMESPACE`; without it a namespaced install would watch every namespace, be refused at every list, and sit there reporting itself healthy while reconciling nothing.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -410,6 +410,8 @@ That strands whatever it was holding. Restore the target by hand using the basel
 
 *`helm uninstall`.* The CRD carries `helm.sh/resource-policy: keep`, so both it and every Automation stored under it *survive* the uninstall — deliberately, because losing people's resources to an uninstall is worse. They simply stop reconciling, and workloads freeze wherever Reactor last put them. No finalizer ever fires, because nothing is being deleted. The chart ships a pre-delete hook that releases every claim before the controller goes away, gated by `uninstall.releaseClaims` (default `true`); if you disabled it, or the hook failed, sweep the annotations manually before removing the chart.
 
+The hook stops the operator before it releases anything. Helm removes the release's own resources only once its pre-delete hooks have finished, so a controller left running would re-claim every workload the hook had just released — and re-add the finalizer, which by then has nothing left to service it. If an uninstall is interrupted after the hook has run but before Helm finishes, the operator is left scaled to zero; `helm upgrade` or `helm rollback` puts it back.
+
 Deleting the CRD afterwards is a deliberate, separate act, and it takes every Automation with it:
 
 ```sh

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -42,6 +42,13 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/ups?level=5'     # drains to critical
 //	curl -X POST 'http://localhost:9443/ups?mode=mains'  # power restored
 //
+// Rehearse the UPS dropping off the console entirely — the ups keys vanish
+// from the state rather than reporting a value, which is what an Automation
+// holding its last known state has to cope with:
+//
+//	curl -X POST 'http://localhost:9443/ups?present=false'
+//	curl -X POST 'http://localhost:9443/ups?present=true'
+//
 // It also mocks enough of the undocumented Alarm Manager API
 // (docs/unifi-alarm-manager-api.md) for Reactor to register its own webhook
 // rule against, and can then fire a delivery at whatever URL that rule names:
@@ -159,6 +166,11 @@ type mock struct {
 	networkVersion string
 	onBatt         bool
 	battLvl        int
+	// noUPS drops the UPS from the device list, as an unadopted or powered-off
+	// one would be. The provider then publishes no ups keys at all rather than
+	// a placeholder value, which is the case that must not be read as "the
+	// outage ended".
+	noUPS bool
 
 	// delivery is the synthetic body /alarm-fire posts. It is a stand-in, not
 	// a capture: no real Alarm Manager delivery has been recorded yet.
@@ -253,11 +265,17 @@ func (m *mock) devices() []any {
 		log.Printf("re-reading the captured devices: %v", err)
 		return nil
 	}
+	visible := devices[:0]
 	for _, d := range devices {
 		device, ok := d.(map[string]any)
 		if !ok {
+			visible = append(visible, d)
 			continue
 		}
+		if _, isUPS := device["vbms_table"]; isUPS && m.noUPS {
+			continue
+		}
+		visible = append(visible, d)
 		if _, isGateway := device["wan1"]; isGateway && m.link == linkBackup {
 			m.failover(device)
 		}
@@ -269,7 +287,7 @@ func (m *mock) devices() []any {
 			}
 		}
 	}
-	return devices
+	return visible
 }
 
 // failover rewrites a captured gateway record the way the current variant says
@@ -428,7 +446,18 @@ func (m *mock) setUPS(w http.ResponseWriter, r *http.Request) {
 		}
 		m.battLvl = level
 	}
+	if raw := r.URL.Query().Get("present"); raw != "" {
+		present, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "present must be a boolean", http.StatusBadRequest)
+			return
+		}
+		m.noUPS = !present
+	}
 	state := map[bool]string{false: "online", true: "on-battery"}[m.onBatt]
+	if m.noUPS {
+		state = "absent"
+	}
 	log.Printf("ups is now %s at %d%%", state, m.battLvl)
 	_, _ = fmt.Fprintf(w, `{"ups":%q,"battery":%d}`+"\n", state, m.battLvl)
 }

--- a/internal/controller/arbitration.go
+++ b/internal/controller/arbitration.go
@@ -179,6 +179,19 @@ func baselineOf(deployment *appsv1.Deployment) (level *int64, recorded bool) {
 	return &parsed, true
 }
 
+// outOfScope reports whether a target could not be read because Reactor is not
+// allowed to see it, in either of the two ways that happens.
+//
+// A cluster-wide install is refused by the API server and gets a Forbidden. A
+// namespaced install never asks: its cache is restricted to the one namespace
+// it may watch, so the cached client rejects the read itself, with an error
+// that carries no status and would otherwise be reported as an unexplained
+// failure to reach the target. Both mean the same thing to the person reading
+// the status, so both get the same sentence.
+func outOfScope(err error) bool {
+	return errors.IsForbidden(err) || strings.Contains(err.Error(), "unknown namespace for the cache")
+}
+
 // targetOutcome is one target's arbitration, from the point of view of the
 // Automation being reconciled.
 type targetOutcome struct {
@@ -221,7 +234,7 @@ func (r *AutomationReconciler) reconcileTarget(
 	var deployment appsv1.Deployment
 	name := types.NamespacedName{Namespace: key.Namespace, Name: key.Name}
 	if err := r.Get(ctx, name, &deployment); err != nil {
-		if errors.IsForbidden(err) {
+		if outOfScope(err) {
 			return outcome, fmt.Errorf(
 				"target %s not reachable with current RBAC (cross-namespace targets need cluster-wide permissions): %w",
 				key, err)

--- a/internal/controller/automation_controller_test.go
+++ b/internal/controller/automation_controller_test.go
@@ -590,7 +590,7 @@ var _ = Describe("Automation Controller", func() {
 			Expect(replicasOf(baseline)).To(Equal(int32(1)))
 
 			By("running the pre-delete release with the power still out")
-			Expect(ReleaseAllClaims(ctx, k8sClient)).To(Succeed())
+			Expect(ReleaseAllClaims(ctx, k8sClient, ReleaseOptions{})).To(Succeed())
 
 			Expect(replicasOf(declared)).To(Equal(int32(2)), "declared onExit value")
 			Expect(replicasOf(baseline)).To(Equal(int32(4)), "recorded baseline")
@@ -607,6 +607,28 @@ var _ = Describe("Automation Controller", func() {
 			}
 		})
 
+		// Namespace-scoped RBAC grants no cluster-wide list, so a sweep that
+		// enumerated every namespace would fail outright and take the uninstall
+		// with it.
+		It("sweeps only the namespace it was given", func() {
+			const target = "uninstall-out-of-scope"
+			createDeployment(target, 2)
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{scaleTo(target, 0)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery})
+			reconcileOnce(target)
+			Expect(replicasOf(target)).To(Equal(int32(0)))
+
+			Expect(ReleaseAllClaims(ctx, k8sClient, ReleaseOptions{Namespace: "kube-system"})).To(Succeed())
+			Expect(replicasOf(target)).To(Equal(int32(0)), "a scoped sweep reached outside its namespace")
+			Expect(annotationsOf(target)).To(HaveKey(annotationBaselineReplicas))
+		})
+
 		It("is a no-op for targets it never claimed", func() {
 			const target = "never-claimed"
 			createDeployment(target, 3)
@@ -617,7 +639,7 @@ var _ = Describe("Automation Controller", func() {
 				Actions: []reactorv1alpha1.Action{scaleTo(target, 0)},
 			})
 
-			Expect(ReleaseAllClaims(ctx, k8sClient)).To(Succeed())
+			Expect(ReleaseAllClaims(ctx, k8sClient, ReleaseOptions{})).To(Succeed())
 			Expect(replicasOf(target)).To(Equal(int32(3)))
 		})
 	})

--- a/internal/controller/automation_controller_test.go
+++ b/internal/controller/automation_controller_test.go
@@ -607,6 +607,36 @@ var _ = Describe("Automation Controller", func() {
 			}
 		})
 
+		// Helm removes the operator's Deployment only after its pre-delete
+		// hooks have run, so the sweep has to stop Reactor itself. A controller
+		// still watching re-claims everything the sweep just released and
+		// re-adds the finalizer, which by then has nothing left to service it.
+		It("stops the operator before handing anything back", func() {
+			const (
+				target  = "uninstall-with-manager"
+				manager = "reactor-manager"
+			)
+			createDeployment(manager, 1)
+			createDeployment(target, 2)
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{scaleTo(target, 0)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery})
+			reconcileOnce(target)
+			Expect(replicasOf(target)).To(Equal(int32(0)))
+
+			Expect(ReleaseAllClaims(ctx, k8sClient, ReleaseOptions{
+				Manager: types.NamespacedName{Namespace: testNamespace, Name: manager},
+			})).To(Succeed())
+
+			Expect(replicasOf(manager)).To(Equal(int32(0)), "the operator was left running during the sweep")
+			Expect(replicasOf(target)).To(Equal(int32(2)))
+		})
+
 		// Namespace-scoped RBAC grants no cluster-wide list, so a sweep that
 		// enumerated every namespace would fail outright and take the uninstall
 		// with it.

--- a/internal/controller/release.go
+++ b/internal/controller/release.go
@@ -43,6 +43,15 @@ const finalizerReleaseClaims = "reactor.robbeverhelst.com/release-claims"
 // target still say what it was before.
 const maxReleaseAttempts = 3
 
+// ReleaseOptions bounds what a release sweep touches.
+type ReleaseOptions struct {
+	// Namespace scopes the sweep, and must be set to whatever the operator was
+	// permitted to watch: listing at cluster scope is forbidden under
+	// namespace-scoped RBAC, which would fail the hook and, with it, the
+	// uninstall. Empty means every namespace.
+	Namespace string
+}
+
 // ReleaseAllClaims hands every target Reactor holds back to whatever the
 // Automations referencing it want once nothing claims it, and removes the
 // finalizer from every Automation.
@@ -58,11 +67,15 @@ const maxReleaseAttempts = 3
 // It is deliberately best-effort: one unreachable target must not be able to
 // block an uninstall, so failures are logged and the next target is tried.
 // Only being unable to enumerate the Automations at all is fatal.
-func ReleaseAllClaims(ctx context.Context, c client.Client) error {
+func ReleaseAllClaims(ctx context.Context, c client.Client, options ReleaseOptions) error {
 	log := logf.FromContext(ctx)
 
+	var scope []client.ListOption
+	if options.Namespace != "" {
+		scope = append(scope, client.InNamespace(options.Namespace))
+	}
 	var list reactorv1alpha1.AutomationList
-	if err := c.List(ctx, &list); err != nil {
+	if err := c.List(ctx, &list, scope...); err != nil {
 		return fmt.Errorf("listing automations: %w", err)
 	}
 

--- a/internal/controller/release.go
+++ b/internal/controller/release.go
@@ -19,10 +19,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -50,6 +52,72 @@ type ReleaseOptions struct {
 	// namespace-scoped RBAC, which would fail the hook and, with it, the
 	// uninstall. Empty means every namespace.
 	Namespace string
+
+	// Manager names the operator's own Deployment, which is stopped before
+	// anything is released. Zero skips that, for a sweep run by hand while
+	// Reactor is already gone.
+	Manager types.NamespacedName
+
+	// ManagerStopTimeout bounds waiting for the operator to stop. Releasing
+	// claims with it still running is worse than not waiting long enough, but
+	// not by so much that an uninstall should hang on it.
+	ManagerStopTimeout time.Duration
+}
+
+// defaultManagerStopTimeout is how long to wait for the operator to stop
+// before releasing anyway.
+const defaultManagerStopTimeout = 60 * time.Second
+
+// stopManager scales the operator down and waits for it to stop running.
+//
+// Handing claims back while the controller is still watching does not work:
+// Helm removes the operator's Deployment only after its pre-delete hooks have
+// finished, so a controller still running simply re-claims every workload this
+// sweep released — and re-adds the finalizer, which by then has nothing left
+// to service it and turns a later `kubectl delete crd` into a hang.
+//
+// Failing to stop it is not fatal. A release that mostly works beats an
+// uninstall that refuses to proceed, and the targets still carry the
+// annotations that say what they were.
+func stopManager(ctx context.Context, c client.Client, options ReleaseOptions) error {
+	if options.Manager.Name == "" || options.Manager.Namespace == "" {
+		return nil
+	}
+	log := logf.FromContext(ctx)
+
+	var deployment appsv1.Deployment
+	if err := c.Get(ctx, options.Manager, &deployment); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("getting the operator deployment %s: %w", options.Manager, err)
+	}
+	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != 0 {
+		patch := client.MergeFrom(deployment.DeepCopy())
+		stopped := int32(0)
+		deployment.Spec.Replicas = &stopped
+		if err := c.Patch(ctx, &deployment, patch); err != nil {
+			return fmt.Errorf("stopping the operator deployment %s: %w", options.Manager, err)
+		}
+	}
+
+	timeout := options.ManagerStopTimeout
+	if timeout <= 0 {
+		timeout = defaultManagerStopTimeout
+	}
+	err := wait.PollUntilContextTimeout(ctx, time.Second, timeout, true,
+		func(ctx context.Context) (bool, error) {
+			var current appsv1.Deployment
+			if err := c.Get(ctx, options.Manager, &current); err != nil {
+				return errors.IsNotFound(err), nil
+			}
+			return current.Status.Replicas == 0, nil
+		})
+	if err != nil {
+		return fmt.Errorf("waiting for the operator %s to stop: %w", options.Manager, err)
+	}
+	log.Info("stopped the operator before releasing its claims", "deployment", options.Manager.String())
+	return nil
 }
 
 // ReleaseAllClaims hands every target Reactor holds back to whatever the
@@ -69,6 +137,10 @@ type ReleaseOptions struct {
 // Only being unable to enumerate the Automations at all is fatal.
 func ReleaseAllClaims(ctx context.Context, c client.Client, options ReleaseOptions) error {
 	log := logf.FromContext(ctx)
+
+	if err := stopManager(ctx, c, options); err != nil {
+		log.Error(err, "could not stop the operator first, releasing anyway")
+	}
 
 	var scope []client.ListOption
 	if options.Namespace != "" {

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -18,9 +18,9 @@ limitations under the License.
 //
 // These are render-time tests: they prove the CRD is part of the release (so
 // `helm upgrade` applies it) rather than a crds/ file Helm would install once
-// and never touch again. Proving the upgrade end to end — install an old
-// chart, upgrade, read the live schema back from the API server — needs a real
-// cluster and belongs with the chart e2e work in #35.
+// and never touch again. The upgrade itself — install the old packaging,
+// adopt the CRD, upgrade, and read the live schema back from the API server —
+// is proven end to end by test/e2e/lifecycle, which needs a real cluster.
 package chart
 
 import (
@@ -164,6 +164,24 @@ func TestCredentialsAreMountedForRotation(t *testing.T) {
 	}
 	if !strings.Contains(manifests, "secretName: \"unifi-reactor-credentials\"") {
 		t.Fatal("the credentials Secret is not mounted")
+	}
+}
+
+// TestNamespacedRBACScopesTheWatch covers the pairing that makes
+// rbac.clusterWide=false usable at all. A namespaced Role grants no
+// cluster-wide list, so an operator left watching every namespace is refused
+// at every list and reconciles nothing — while its health probes, which only
+// ping, keep reporting it ready.
+func TestNamespacedRBACScopesTheWatch(t *testing.T) {
+	scoped := render(t, unifiURL, "rbac.clusterWide=false")
+	if !strings.Contains(scoped, "name: WATCH_NAMESPACE") {
+		t.Fatal("namespace-scoped RBAC did not tell the operator which namespace it may watch")
+	}
+	if strings.Contains(scoped, "kind: ClusterRole") {
+		t.Fatal("rbac.clusterWide=false still rendered cluster-scoped RBAC")
+	}
+	if wide := render(t, unifiURL); strings.Contains(wide, "name: WATCH_NAMESPACE") {
+		t.Fatal("a cluster-wide install was restricted to one namespace")
 	}
 }
 

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -185,6 +185,23 @@ func TestNamespacedRBACScopesTheWatch(t *testing.T) {
 	}
 }
 
+// TestReleaseHookStopsTheOperator is the ordering the uninstall depends on.
+// Helm removes the release's own resources only after its pre-delete hooks
+// finish, so the hook has to stop the operator itself; one left running
+// re-claims everything the hook released and re-adds the finalizer that by
+// then has nothing to service it.
+func TestReleaseHookStopsTheOperator(t *testing.T) {
+	manifests := render(t, unifiURL)
+	for _, wiring := range []string{"name: MANAGER_DEPLOYMENT", "name: MANAGER_NAMESPACE"} {
+		if !strings.Contains(manifests, wiring) {
+			t.Errorf("the pre-delete hook is not told %q, so it cannot stop the operator first", wiring)
+		}
+	}
+	if disabled := render(t, unifiURL, "uninstall.releaseClaims=false"); strings.Contains(disabled, "kind: Job") {
+		t.Error("uninstall.releaseClaims=false still rendered the release hook")
+	}
+}
+
 // TestOperationalExtrasAreOptOut keeps upgrades boring: an existing install
 // that does not ask for them must render exactly what it rendered before.
 func TestOperationalExtrasAreOptOut(t *testing.T) {

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -185,6 +185,57 @@ func TestNamespacedRBACScopesTheWatch(t *testing.T) {
 	}
 }
 
+// TestSecretAccessFollowsTheGrantedScope pins the corner where two independent
+// switches meet. Whether the Secret rule is granted at all is covered by the
+// outbound-action tests; this is about *which* role carries it, because
+// allowing a destination must not quietly widen a namespaced install into
+// cluster-wide read access to every Secret in the cluster.
+func TestSecretAccessFollowsTheGrantedScope(t *testing.T) {
+	const destination = "actions.allowedDestinations={https://ntfy.example.com}"
+
+	namespaced := render(t, unifiURL, "rbac.clusterWide=false", destination)
+	if strings.Contains(namespaced, "kind: ClusterRole") {
+		t.Fatal("allowing a destination widened a namespaced install to cluster-scoped RBAC")
+	}
+	scoped, found := managerRules(namespaced, "kind: Role")
+	if !found {
+		t.Fatal("no manager Role rendered for a namespaced install")
+	}
+	if !strings.Contains(scoped, secretsRule) {
+		t.Error("a namespaced install allowing a destination cannot read the Secret it authenticates with")
+	}
+
+	// The same switch, off, in the mode the outbound-action tests do not cover.
+	if off := render(t, unifiURL, "rbac.clusterWide=false"); strings.Contains(off, secretsRule) {
+		t.Error("a namespaced install that allows no destination was still granted read access to Secrets")
+	}
+
+	// And cluster-wide, the rule belongs to the manager's own ClusterRole
+	// rather than to some other document that happens to mention Secrets.
+	wide, found := managerRules(render(t, unifiURL, destination), "kind: ClusterRole")
+	if !found {
+		t.Fatal("no manager ClusterRole rendered for a cluster-wide install")
+	}
+	if !strings.Contains(wide, secretsRule) {
+		t.Error("the Secret read was granted somewhere other than the manager's ClusterRole")
+	}
+}
+
+// managerRules returns the rule block of the manager's Role or ClusterRole,
+// so an assertion about what it permits cannot be satisfied by a different
+// document in the release that happens to mention the same resource.
+func managerRules(manifests, kind string) (string, bool) {
+	for document := range strings.SplitSeq(manifests, "\n---") {
+		// "rules:" is what tells the role apart from the binding that
+		// references it, which names the same kind and the same object.
+		if strings.Contains(document, kind) && strings.Contains(document, "-manager\n") &&
+			strings.Contains(document, "\nrules:") {
+			return document, true
+		}
+	}
+	return "", false
+}
+
 // TestReleaseHookStopsTheOperator is the ordering the uninstall depends on.
 // Helm removes the release's own resources only after its pre-delete hooks
 // finish, so the hook has to stop the operator itself; one left running

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2026.

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,5 +1,4 @@
 //go:build e2e
-// +build e2e
 
 /*
 Copyright 2026.
@@ -25,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -44,6 +44,13 @@ const metricsServiceName = "unifi-reactor-controller-manager-metrics-service"
 
 // metricsRoleBindingName is the name of the RBAC that will be created to allow get the metrics data
 const metricsRoleBindingName = "unifi-reactor-metrics-binding"
+
+// curlMetricsCommand retries the metrics endpoint so that a curl pod scheduled
+// before the metrics server is listening still succeeds. It is built here
+// rather than inline in the pod override, which is a raw string literal that
+// cannot be broken across lines.
+const curlMetricsCommand = "for i in $(seq 1 30); do curl -v -k -H 'Authorization: Bearer %s' " +
+	"https://%s.%s.svc.cluster.local:8443/metrics && exit 0 || sleep 2; done; exit 1"
 
 var _ = Describe("Manager", Ordered, func() {
 	var controllerPodName string
@@ -225,9 +232,7 @@ var _ = Describe("Manager", Ordered, func() {
 							"name": "curl",
 							"image": "curlimages/curl:latest",
 							"command": ["/bin/sh", "-c"],
-							"args": [
-								"for i in $(seq 1 30); do curl -v -k -H 'Authorization: Bearer %s' https://%s.%s.svc.cluster.local:8443/metrics && exit 0 || sleep 2; done; exit 1"
-							],
+							"args": [%s],
 							"securityContext": {
 								"readOnlyRootFilesystem": true,
 								"allowPrivilegeEscalation": false,
@@ -243,7 +248,8 @@ var _ = Describe("Manager", Ordered, func() {
 						}],
 						"serviceAccountName": "%s"
 					}
-				}`, token, metricsServiceName, namespace, serviceAccountName))
+				}`, strconv.Quote(fmt.Sprintf(curlMetricsCommand, token, metricsServiceName, namespace)),
+					serviceAccountName))
 			_, err = utils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred(), "Failed to create curl-metrics pod")
 

--- a/test/e2e/harness/harness.go
+++ b/test/e2e/harness/harness.go
@@ -1,0 +1,184 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package harness drives a throwaway Kind cluster for the e2e suites.
+//
+// Every kubectl and helm invocation goes through here so that every one of
+// them names its cluster explicitly. An unpinned command inherits whatever
+// context happens to be current, and these suites install an operator with
+// cluster-wide RBAC, uninstall releases, and delete CRDs — on the wrong
+// cluster that is not a failed test, it is an outage. Cluster refuses to
+// address anything that is not a local Kind context.
+package harness
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// kindContextPrefix is the context name Kind gives every cluster it creates.
+// Refusing anything else is the guard that keeps these suites off a real
+// cluster even if KIND_CLUSTER is set to something unexpected.
+const kindContextPrefix = "kind-"
+
+// Cluster is a Kind cluster addressed by an explicit context.
+type Cluster struct {
+	// Name is the Kind cluster name, as `kind create cluster --name` took it.
+	Name string
+	// Context is the kubeconfig context, always passed to every command.
+	Context string
+	// Log receives every command line and its output.
+	Log io.Writer
+}
+
+// NewCluster resolves the cluster the suite may act on from KIND_CLUSTER and
+// verifies it is reachable before any test touches it.
+func NewCluster(log io.Writer) (*Cluster, error) {
+	name := os.Getenv("KIND_CLUSTER")
+	if name == "" {
+		return nil, fmt.Errorf("KIND_CLUSTER is not set; run these suites through the Makefile, " +
+			"which creates a throwaway Kind cluster and names it")
+	}
+	if strings.HasPrefix(name, kindContextPrefix) {
+		// Being handed "kind-foo" instead of "foo" would otherwise silently
+		// address a context named "kind-kind-foo" that does not exist.
+		return nil, fmt.Errorf("KIND_CLUSTER=%q looks like a context name; it must be the Kind cluster name", name)
+	}
+	cluster := &Cluster{Name: name, Context: kindContextPrefix + name, Log: log}
+	if _, err := cluster.Kubectl("cluster-info"); err != nil {
+		return nil, fmt.Errorf("kind cluster %q is not reachable: %w", name, err)
+	}
+	return cluster, nil
+}
+
+// Quiet returns the same cluster with command logging discarded, for polling
+// loops whose output would otherwise bury the test's own narrative.
+func (c *Cluster) Quiet() *Cluster {
+	quiet := *c
+	quiet.Log = io.Discard
+	return &quiet
+}
+
+// Kubectl runs kubectl against this cluster and nothing else.
+func (c *Cluster) Kubectl(args ...string) (string, error) {
+	return Run(c.Log, ProjectDir(), "kubectl", append([]string{"--context", c.Context}, args...)...)
+}
+
+// KubectlInput runs kubectl with stdin, for `apply -f -`.
+func (c *Cluster) KubectlInput(stdin string, args ...string) (string, error) {
+	cmd := exec.Command("kubectl", append([]string{"--context", c.Context}, args...)...)
+	cmd.Stdin = strings.NewReader(stdin)
+	return run(c.Log, ProjectDir(), cmd)
+}
+
+// Helm runs helm against this cluster and nothing else.
+func (c *Cluster) Helm(args ...string) (string, error) {
+	return Run(c.Log, ProjectDir(), "helm", append([]string{"--kube-context", c.Context}, args...)...)
+}
+
+// Apply applies a manifest given as text.
+func (c *Cluster) Apply(manifest string) error {
+	_, err := c.KubectlInput(manifest, "apply", "-f", "-")
+	return err
+}
+
+// Delete removes a manifest given as text, tolerating what is already gone.
+func (c *Cluster) Delete(manifest string) error {
+	_, err := c.KubectlInput(manifest, "delete", "--ignore-not-found", "-f", "-")
+	return err
+}
+
+// GetInto reads one object into a typed value, so assertions are written
+// against the real API types rather than against jsonpath strings.
+func (c *Cluster) GetInto(object any, kind, namespace, name string) error {
+	out, err := c.Kubectl("get", kind, name, "-n", namespace, "-o", "json")
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal([]byte(out), object); err != nil {
+		return fmt.Errorf("decoding %s/%s in %s: %w", kind, name, namespace, err)
+	}
+	return nil
+}
+
+// LoadImage makes a locally built image available to the cluster's nodes.
+func (c *Cluster) LoadImage(image string) error {
+	kind := "kind"
+	if v := os.Getenv("KIND"); v != "" {
+		kind = v
+	}
+	_, err := Run(c.Log, ProjectDir(), kind, "load", "docker-image", image, "--name", c.Name)
+	return err
+}
+
+// Run executes a command in dir and returns its combined output.
+func Run(log io.Writer, dir, name string, args ...string) (string, error) {
+	return run(log, dir, exec.Command(name, args...)) // #nosec G204 -- test harness, arguments are literals
+}
+
+// RunEnv is Run with extra environment entries, for the one caller that
+// cross-compiles.
+func RunEnv(log io.Writer, dir string, env []string, name string, args ...string) (string, error) {
+	cmd := exec.Command(name, args...) // #nosec G204 -- test harness, arguments are literals
+	cmd.Env = append(os.Environ(), env...)
+	return run(log, dir, cmd)
+}
+
+func run(log io.Writer, dir string, cmd *exec.Cmd) (string, error) {
+	cmd.Dir = dir
+	if cmd.Env == nil {
+		cmd.Env = os.Environ()
+	}
+	_, _ = fmt.Fprintf(log, "running: %s\n", strings.Join(cmd.Args, " "))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(out), fmt.Errorf("%s failed: %w\n%s", strings.Join(cmd.Args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ProjectDir is the repository root, found by walking up to the go.mod rather
+// than by editing the working directory's path, so it holds wherever a suite
+// lives.
+func ProjectDir() string {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "."
+		}
+		dir = parent
+	}
+}
+
+// BuildManagerImage builds the operator image exactly as a release would.
+func BuildManagerImage(log io.Writer, image string) error {
+	_, err := Run(log, ProjectDir(), "docker", "build", "-t", image, ".")
+	return err
+}

--- a/test/e2e/harness/mock.go
+++ b/test/e2e/harness/mock.go
@@ -1,0 +1,188 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package harness
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+)
+
+const (
+	// MockImage is the tag the UniFi mock is built and loaded under.
+	MockImage = "example.com/mock-unifi:e2e"
+	// MockPort is the port the mock serves on, in the pod and in the Service.
+	MockPort = 9443
+	// mockNodePort is fixed so the suite can reach the mock from outside the
+	// cluster over the Kind port mapping, without a port-forward to keep alive.
+	mockNodePort = 30943
+	// MockName is the name of the mock's Deployment and Service.
+	MockName = "mock-unifi"
+)
+
+// mockDockerfile packages a statically linked mock next to the captured
+// payloads it serves. It is written into a build context assembled at test
+// time rather than living in the repository, because the repository's
+// .dockerignore keeps testdata out of every build — deliberately, so that
+// captured payloads cannot end up in a shipped image.
+const mockDockerfile = `FROM scratch
+WORKDIR /
+COPY mock-unifi /mock-unifi
+COPY api /testdata/unifi/api
+ENTRYPOINT ["/mock-unifi"]
+`
+
+// BuildMockImage compiles hack/mock-unifi for the cluster's architecture and
+// packages it with the captured payloads from testdata/.
+func BuildMockImage(log io.Writer, dir string) error {
+	if err := os.MkdirAll(filepath.Join(dir, "api"), 0o755); err != nil {
+		return err
+	}
+	// Built for the node's architecture, which is the host's: Kind nodes run
+	// the same platform as the machine hosting them.
+	env := []string{"CGO_ENABLED=0", "GOOS=linux", "GOARCH=" + runtime.GOARCH}
+	binary := filepath.Join(dir, "mock-unifi")
+	if _, err := RunEnv(log, ProjectDir(), env, "go", "build", "-o", binary, "./hack/mock-unifi"); err != nil {
+		return err
+	}
+
+	source := filepath.Join(ProjectDir(), "testdata", "unifi", "api")
+	entries, err := os.ReadDir(source)
+	if err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		payload, err := os.ReadFile(filepath.Join(source, entry.Name())) // #nosec G304 -- committed fixtures
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dir, "api", entry.Name()), payload, 0o600); err != nil {
+			return err
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), []byte(mockDockerfile), 0o600); err != nil {
+		return err
+	}
+	_, err = Run(log, dir, "docker", "build", "-t", MockImage, ".")
+	return err
+}
+
+// MockManifest is the mock's Deployment and Service in one namespace. The
+// Service is a NodePort so the suite can drive rehearsals over Kind's port
+// mapping while the operator reaches the same mock by cluster DNS.
+func MockManifest(namespace string) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: 1
+  selector:
+    matchLabels: {app: %[1]s}
+  template:
+    metadata:
+      labels: {app: %[1]s}
+    spec:
+      containers:
+        - name: mock
+          image: %[3]s
+          imagePullPolicy: Never
+          ports: [{containerPort: %[4]d}]
+          readinessProbe:
+            httpGet: {path: /proxy/network/api/s/default/stat/device, port: %[4]d}
+            periodSeconds: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  type: NodePort
+  selector: {app: %[1]s}
+  ports:
+    - port: %[4]d
+      targetPort: %[4]d
+      nodePort: %[5]d
+`, MockName, namespace, MockImage, MockPort, mockNodePort)
+}
+
+// MockURL is how the operator reaches the mock from inside the cluster.
+func MockURL(namespace string) string {
+	return fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", MockName, namespace, MockPort)
+}
+
+// Mock rehearses console state from outside the cluster.
+type Mock struct {
+	// BaseURL reaches the mock's NodePort through Kind's port mapping.
+	BaseURL string
+	Log     io.Writer
+}
+
+// NewMock addresses the mock over the Kind node's mapped port.
+func NewMock(log io.Writer) *Mock {
+	return &Mock{BaseURL: fmt.Sprintf("http://127.0.0.1:%d", mockNodePort), Log: log}
+}
+
+// WAN puts the gateway on "primary" or "backup", whichever it was on before.
+// The absolute form matters here rather than /flip's toggle: a spec that says
+// "make sure it is on backup" must not depend on where the one before it left
+// the console.
+//
+// The variant is left at the mock's default, which moves every WAN signal at
+// once. Which shape a real failover takes is still unobserved (#34), and these
+// suites are about what Reactor does with a reported state rather than about
+// how the state is derived — the variants are covered where the derivation is,
+// in the provider's own tests.
+func (m *Mock) WAN(uplink string) error { return m.post("/wan?link=" + uplink) }
+
+// UPS drives the power rehearsal: mode=battery|mains, level=0-100,
+// present=false to make the UPS drop off the console entirely.
+func (m *Mock) UPS(query string) error { return m.post("/ups?" + query) }
+
+// Reachable reports whether the mock is answering yet.
+func (m *Mock) Reachable() error {
+	return m.request(http.MethodGet, "/proxy/network/api/s/default/stat/device")
+}
+
+func (m *Mock) post(path string) error { return m.request(http.MethodPost, path) }
+
+func (m *Mock) request(method, path string) error {
+	client := &http.Client{Timeout: 10 * time.Second}
+	req, err := http.NewRequest(method, m.BaseURL+path, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s %s: %s: %s", method, path, resp.Status, body)
+	}
+	_, _ = fmt.Fprintf(m.Log, "mock %s %s -> %s", method, path, body)
+	return nil
+}

--- a/test/e2e/kind-config.yaml
+++ b/test/e2e/kind-config.yaml
@@ -1,0 +1,13 @@
+# The e2e suites drive a rehearsed UniFi console running inside the cluster.
+# Mapping its node port to the host lets them do that over a plain HTTP call,
+# rather than through a `kubectl port-forward` that has to be kept alive for
+# the length of a suite and is a classic source of flakes.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraPortMappings:
+      - containerPort: 30943
+        hostPort: 30943
+        listenAddress: "127.0.0.1"
+        protocol: TCP

--- a/test/e2e/lifecycle/suite_test.go
+++ b/test/e2e/lifecycle/suite_test.go
@@ -1,0 +1,271 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package lifecycle covers what happens to a cluster around a release rather
+// than during one: uninstalling Reactor while it is holding workloads down,
+// and upgrading from the chart packaging that shipped the CRD under crds/.
+//
+// Both are paths nothing else can test. They involve Helm's own ordering
+// guarantees, RBAC that only exists once installed, and a CRD deletion that
+// hangs forever if a finalizer outlives the controller that services it.
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+	"github.com/robbeverhelst/unifi-reactor/test/e2e/harness"
+)
+
+const (
+	managerRepository = "example.com/unifi-reactor"
+	managerTag        = "lifecycle"
+	managerImage      = managerRepository + ":" + managerTag
+
+	// crdName is the CRD every spec here installs, adopts, or deletes.
+	crdName = "automations.reactor.robbeverhelst.com"
+	// release is the Helm release name each spec installs under its own
+	// namespace. It matches the chart name, so the operator's Deployment and
+	// the hook Job are named from it directly.
+	release = "reactor"
+	// releaseJob is the pre-delete hook that hands claimed workloads back.
+	releaseJob = release + "-release-claims"
+
+	annotationBaseline  = "reactor.robbeverhelst.com/baseline-replicas"
+	annotationClaimedBy = "reactor.robbeverhelst.com/claimed-by"
+
+	deploymentKind = "deployment"
+	automationKind = "automation"
+
+	// mockNamespace holds one rehearsed console for the whole suite. It is
+	// shared because the mock is reached on a fixed node port, which only one
+	// Service in the cluster can hold.
+	mockNamespace = "reactor-console"
+
+	// finalizer is what a claim registers, and what must not outlive the
+	// controller that services it.
+	finalizer = "reactor.robbeverhelst.com/release-claims"
+
+	pollInterval = "2s"
+
+	// notifySecret holds the destination an outbound action calls. Naming it
+	// here keeps the Secret, the Automation that references it, and the
+	// assertion about the read in one place.
+	notifySecret = "outbound-destination"
+
+	// set is helm's value flag, repeated on every install and upgrade here.
+	set = "--set"
+)
+
+var (
+	cluster *harness.Cluster
+	mock    *harness.Mock
+)
+
+func TestLifecycle(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "lifecycle suite")
+}
+
+var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(2 * time.Minute)
+	SetDefaultEventuallyPollingInterval(time.Second)
+
+	var err error
+	cluster, err = harness.NewCluster(GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	mock = harness.NewMock(GinkgoWriter)
+
+	By("building and loading the operator image")
+	Expect(harness.BuildManagerImage(GinkgoWriter, managerImage)).To(Succeed())
+	Expect(cluster.LoadImage(managerImage)).To(Succeed())
+
+	By("building and loading the rehearsed UniFi console")
+	context, err := os.MkdirTemp("", "mock-unifi-build")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { _ = os.RemoveAll(context) })
+	Expect(harness.BuildMockImage(GinkgoWriter, context)).To(Succeed())
+	Expect(cluster.LoadImage(harness.MockImage)).To(Succeed())
+
+	By("starting the rehearsed console")
+	_, _ = cluster.Kubectl("create", "namespace", mockNamespace)
+	Expect(cluster.Apply(harness.MockManifest(mockNamespace))).To(Succeed())
+	_, err = cluster.Kubectl("-n", mockNamespace, "rollout", "status",
+		"deployment/"+harness.MockName, "--timeout=120s")
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(mock.Reachable).Should(Succeed())
+})
+
+var _ = AfterSuite(func() {
+	if cluster == nil {
+		return
+	}
+	// Nothing may outlive the suite: every spec here installs cluster-scoped
+	// objects, and a leftover CRD would change what the next run observes.
+	removeCRD()
+	_, _ = cluster.Kubectl("delete", "namespace", mockNamespace, "--wait=false")
+})
+
+// removeCRD takes the Automation CRD back out of the cluster so the next spec
+// starts from one that belongs to no release.
+//
+// It strips finalizers first. A finalizer whose controller is gone makes this
+// hang forever — which is precisely the failure the uninstall specs are here
+// to catch, so teardown must not itself depend on it never happening.
+func removeCRD() {
+	out, err := cluster.Kubectl("get", automationKind, "--all-namespaces", "-o",
+		`jsonpath={range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}`)
+	if err == nil {
+		for ref := range strings.FieldsSeq(out) {
+			namespace, name, found := strings.Cut(ref, "/")
+			if !found {
+				continue
+			}
+			_, _ = cluster.Kubectl("patch", automationKind, name, "-n", namespace,
+				"--type=merge", "-p", `{"metadata":{"finalizers":null}}`)
+		}
+	}
+	_, _ = cluster.Kubectl("delete", "crd", crdName, "--ignore-not-found", "--timeout=120s")
+}
+
+// installOperator brings up a release pointed at the shared rehearsed console,
+// on a known starting state, and returns once the operator is running.
+//
+// Outbound actions are allowed to the console's own address, which is a
+// ClusterIP Service — deliberately, because that is what makes the release
+// render the conditional Secret rule and exercise the credential read that
+// comes with it.
+func installOperator(namespace string, values ...string) {
+	_, _ = cluster.Kubectl("create", "namespace", namespace)
+	Expect(mock.WAN("primary")).To(Succeed())
+	Expect(mock.UPS("mode=mains&level=100&present=true")).To(Succeed())
+
+	_, err := cluster.Kubectl("-n", namespace, "create", "secret", "generic",
+		"unifi-reactor-credentials", "--from-literal=UNIFI_API_KEY=rehearsal")
+	Expect(err).NotTo(HaveOccurred())
+
+	// The destination lives in the Secret rather than in the Automation, so a
+	// Secret that cannot be read produces no request at all. That is what makes
+	// the assertion about it sharp.
+	_, err = cluster.Kubectl("-n", namespace, "create", "secret", "generic", notifySecret,
+		"--from-literal=url="+harness.MockURL(mockNamespace)+"/ups")
+	Expect(err).NotTo(HaveOccurred())
+
+	args := append([]string{"install", release, "charts/reactor", "--namespace", namespace,
+		set, "image.repository=" + managerRepository,
+		set, "image.tag=" + managerTag,
+		set, "image.pullPolicy=Never",
+		set, "unifi.url=" + harness.MockURL(mockNamespace),
+		set, "unifi.pollInterval=" + pollInterval,
+		set, "unifi.insecureSkipVerify=false",
+		set, "actions.allowedDestinations={" + harness.MockURL(mockNamespace) + "}",
+		"--wait", "--timeout=180s"}, values...)
+	_, err = cluster.Helm(args...)
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// workload renders a target Deployment, running the mock's image because it is
+// already on every node.
+func workload(namespace, name string, replicas int) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: %[3]d
+  selector:
+    matchLabels: {app: %[1]s}
+  template:
+    metadata:
+      labels: {app: %[1]s}
+    spec:
+      containers:
+        - name: app
+          image: %[4]s
+          imagePullPolicy: Never
+`, name, namespace, replicas, harness.MockImage)
+}
+
+// wanAutomation scales a target to zero while the gateway is on its backup
+// uplink, and restores whatever it was before once nothing claims it.
+//
+// It also carries an edge action, so one Automation exercises both kinds at
+// once: a desired-state claim that is arbitrated and released, and an outbound
+// call that fires on the transition and owns nothing. The call takes its
+// destination from a Secret, which is the part worth having in a cluster —
+// Reactor reads that Secret with an uncached reader, and whether an uncached
+// read still works when the operator's cache is restricted to one namespace is
+// not a question the unit tests can answer.
+func wanAutomation(namespace, name, target string) string {
+	return fmt.Sprintf(`apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  when:
+    provider: unifi
+    state: {wan: backup}
+  actions:
+    - type: kubernetes.scale
+      target: {kind: Deployment, name: %[3]s}
+      replicas: 0
+    - type: http.request
+      request:
+        secretRef: {name: %[4]s}
+        body: '{"wan":{{ .To | json }}}'
+`, name, namespace, target, notifySecret)
+}
+
+func replicasOf(g Gomega, namespace, name string) int32 {
+	var deployment appsv1.Deployment
+	g.Expect(cluster.GetInto(&deployment, deploymentKind, namespace, name)).To(Succeed())
+	g.Expect(deployment.Spec.Replicas).NotTo(BeNil())
+	return *deployment.Spec.Replicas
+}
+
+func annotationsOf(g Gomega, namespace, name string) map[string]string {
+	var deployment appsv1.Deployment
+	g.Expect(cluster.GetInto(&deployment, deploymentKind, namespace, name)).To(Succeed())
+	return deployment.Annotations
+}
+
+func automationOf(g Gomega, namespace, name string) reactorv1alpha1.Automation {
+	var automation reactorv1alpha1.Automation
+	g.Expect(cluster.GetInto(&automation, automationKind, namespace, name)).To(Succeed())
+	return automation
+}
+
+// TestMain keeps the suite from running against whatever cluster happens to be
+// current when someone runs `go test` by hand.
+func TestMain(m *testing.M) {
+	if os.Getenv("KIND_CLUSTER") == "" {
+		fmt.Fprintln(os.Stderr, "KIND_CLUSTER is not set; run `make test-lifecycle`")
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/test/e2e/lifecycle/uninstall_test.go
+++ b/test/e2e/lifecycle/uninstall_test.go
@@ -1,0 +1,196 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/robbeverhelst/unifi-reactor/test/e2e/harness"
+)
+
+// timeline is what an uninstall looked like from outside, sampled while Helm
+// was running it.
+type timeline struct {
+	// sawJob is whether the release-claims hook was ever observed at all.
+	// Without it the ordering below would be satisfied vacuously.
+	sawJob bool
+	// jobRanWithoutOperator is the violation: the hook still present while the
+	// operator's Deployment — and with it the release's ServiceAccount and
+	// RBAC — had already been removed.
+	jobRanWithoutOperator bool
+	// samples is how many observations the watch managed, for diagnostics when
+	// an assertion about what it saw fails.
+	samples int
+}
+
+// watchUninstall samples the release namespace while Helm works, so the suite
+// can say something about the order Helm did things in rather than only about
+// where it ended up.
+func watchUninstall(namespace string, done <-chan struct{}) <-chan timeline {
+	result := make(chan timeline, 1)
+	go func() {
+		defer GinkgoRecover()
+		var observed timeline
+		quiet := cluster.Quiet()
+		for {
+			select {
+			case <-done:
+				result <- observed
+				return
+			default:
+			}
+			out, _ := quiet.Kubectl("get", "job,deploy", "-n", namespace, "-o", "name")
+			observed.samples++
+			job := strings.Contains(out, "job.batch/"+releaseJob)
+			operator := strings.Contains(out, "deployment.apps/"+release+"\n") ||
+				strings.HasSuffix(out, "deployment.apps/"+release)
+			if job {
+				observed.sawJob = true
+				if !operator {
+					observed.jobRanWithoutOperator = true
+				}
+			}
+			time.Sleep(150 * time.Millisecond)
+		}
+	}()
+	return result
+}
+
+// declareUninstallSpecs describes one uninstall, so the cluster-wide and
+// namespace-scoped RBAC modes are held to exactly the same standard. The
+// namespaced mode is the one at risk: releasing claims has to enumerate
+// Automations, and a namespaced Role does not permit doing that at cluster
+// scope.
+func declareUninstallSpecs(name, namespace string, values ...string) {
+	Describe(name, Ordered, func() {
+		const (
+			app        = "stranded"
+			automation = "wan-shed"
+			baseline   = 3
+		)
+		var uninstallOutput string
+		var observed timeline
+
+		BeforeAll(func() {
+			removeCRD()
+			installOperator(namespace, values...)
+			Expect(cluster.Apply(workload(namespace, app, baseline))).To(Succeed())
+			Expect(cluster.Apply(wanAutomation(namespace, automation, app))).To(Succeed())
+		})
+
+		AfterAll(func() {
+			_, _ = cluster.Helm("uninstall", release, "--namespace", namespace, "--ignore-not-found")
+			removeCRD()
+			_, _ = cluster.Kubectl("delete", "namespace", namespace, "--wait=false")
+		})
+
+		It("holds a workload down, and records the finalizer that will hand it back", func() {
+			Expect(mock.WAN("backup")).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				g.Expect(replicasOf(g, namespace, app)).To(BeEquivalentTo(0))
+			}).Should(Succeed())
+			Expect(annotationsOf(Default, namespace, app)).To(HaveKeyWithValue(annotationBaseline, "3"))
+			Expect(automationOf(Default, namespace, automation).Finalizers).To(ContainElement(finalizer))
+		})
+
+		// The operator reads action credentials with mgr.GetAPIReader(), which
+		// is a client built straight against the API server rather than one
+		// backed by the cache. Restricting that cache to a single namespace
+		// therefore should not reach it — but "should not" is what a cluster
+		// is for, and the namespaced mode of this suite is the only place the
+		// two are combined.
+		It("reads an action's credentials with the cache restricted to one namespace", func() {
+			Eventually(func(g Gomega) {
+				edge := automationOf(g, namespace, automation).Status.EdgeActions
+				g.Expect(edge).To(HaveLen(1), "the edge action did not run on the transition")
+				g.Expect(edge[0].Type).To(Equal("http.request"))
+				g.Expect(edge[0].Status).To(Equal("Success"),
+					"the outbound call failed: %s", edge[0].Reason)
+			}).Should(Succeed())
+
+			By("having taken the destination from the Secret, which it could not have read otherwise")
+			edge := automationOf(Default, namespace, automation).Status.EdgeActions[0]
+			Expect(edge.Destination).To(ContainSubstring(harness.MockName),
+				"the request went somewhere other than the destination the Secret named")
+		})
+
+		It("runs the pre-delete hook while the release it depends on is still there", func() {
+			done := make(chan struct{})
+			watching := watchUninstall(namespace, done)
+
+			var err error
+			uninstallOutput, err = cluster.Helm("uninstall", release, "--namespace", namespace)
+			close(done)
+			observed = <-watching
+
+			Expect(err).NotTo(HaveOccurred(),
+				"the uninstall failed; a pre-delete hook that cannot finish blocks removing the operator")
+			Expect(uninstallOutput).NotTo(ContainSubstring("failed"))
+			Expect(observed.sawJob).To(BeTrue(),
+				"never observed the release-claims Job in %d samples", observed.samples)
+			Expect(observed.jobRanWithoutOperator).To(BeFalse(),
+				"the release's own resources were removed while the pre-delete hook was still running")
+		})
+
+		It("hands the workload back to what it was before Reactor claimed it", func() {
+			// This is also the load-bearing evidence for the ordering above.
+			// The hook runs under the manager's ServiceAccount and needs the
+			// release's RBAC to patch anything at all, so a workload that came
+			// back proves those still existed when the hook ran.
+			Expect(replicasOf(Default, namespace, app)).To(BeEquivalentTo(baseline))
+			annotations := annotationsOf(Default, namespace, app)
+			Expect(annotations).NotTo(HaveKey(annotationBaseline))
+			Expect(annotations).NotTo(HaveKey(annotationClaimedBy))
+		})
+
+		It("leaves the Automations in place, with nothing left to service their finalizers", func() {
+			By("keeping the CRD and the resources stored under it, as the keep policy promises")
+			left := automationOf(Default, namespace, automation)
+			Expect(left.Finalizers).NotTo(ContainElement(finalizer),
+				"a finalizer outlived the controller that services it; deleting this now hangs forever")
+		})
+
+		It("lets the CRD be deleted afterwards rather than hanging on a finalizer", func() {
+			By("removing the operator's own Deployment first, as the uninstall should have")
+			out, err := cluster.Kubectl("get", "deploy", "-n", namespace, "-o", "name")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out).NotTo(ContainSubstring("deployment.apps/" + release))
+
+			deleted := make(chan error, 1)
+			go func() {
+				defer GinkgoRecover()
+				_, err := cluster.Kubectl("delete", "crd", crdName, "--timeout=120s")
+				deleted <- err
+			}()
+			Eventually(deleted, 2*time.Minute).Should(Receive(BeNil()),
+				"deleting the CRD hung, which is the trap a finalizer without a controller creates")
+		})
+	})
+}
+
+func init() {
+	declareUninstallSpecs("Uninstalling with cluster-wide RBAC", "reactor-uninstall")
+	declareUninstallSpecs("Uninstalling with namespace-scoped RBAC", "reactor-uninstall-scoped",
+		set, "rbac.clusterWide=false")
+}

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -1,0 +1,253 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package lifecycle
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/robbeverhelst/unifi-reactor/test/e2e/harness"
+)
+
+// legacyCRD stands in for the schema chart 0.3.0 shipped under crds/. It is
+// deliberately reduced — no spec.reversal, no status.targets — because the
+// point of the upgrade is that the live schema changes, and a schema that
+// already had the new fields could not show that.
+//
+// It is written out rather than derived from the current CRD so that what
+// "old" means here stays fixed while the real schema moves on.
+const legacyCRD = `apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: automations.reactor.robbeverhelst.com
+spec:
+  group: reactor.robbeverhelst.com
+  names:
+    kind: Automation
+    listKind: AutomationList
+    plural: automations
+    singular: automation
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            apiVersion: {type: string}
+            kind: {type: string}
+            metadata: {type: object}
+            spec:
+              type: object
+              required: [actions]
+              properties:
+                when:
+                  type: object
+                  required: [provider, state]
+                  properties:
+                    provider: {type: string}
+                    state:
+                      type: object
+                      additionalProperties: {type: string}
+                actions:
+                  type: array
+                  items:
+                    type: object
+                    required: [type]
+                    properties:
+                      type: {type: string}
+                      replicas: {type: integer, format: int32}
+                      target:
+                        type: object
+                        required: [kind, name]
+                        properties:
+                          kind: {type: string}
+                          name: {type: string}
+                          namespace: {type: string}
+            status:
+              type: object
+              properties:
+                matching: {type: boolean}
+                observedState:
+                  type: object
+                  additionalProperties: {type: string}
+`
+
+// automationWithReversal exercises a field that exists only in the current
+// schema. Against the old one the API server rejects the resource outright —
+// "a valid Automation is rejected", the second symptom in the troubleshooting
+// guide's CRD section, and what an install stuck on the crds/ packaging would
+// hit on every documented example it tried to apply.
+const automationWithReversal = `apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: schema-probe
+  namespace: %s
+spec:
+  when:
+    provider: unifi
+    state: {wan: backup}
+  reversal: None
+  actions:
+    - type: kubernetes.scale
+      target: {kind: Deployment, name: nothing}
+      replicas: 0
+`
+
+// automationUnderOldSchema uses nothing the old schema lacks, so it can be
+// stored before the upgrade and read back after it. Replacing a CRD replaces
+// the schema every stored resource is served through, and "your Automations
+// survive" is the promise the chart's keep policy is built around.
+const automationUnderOldSchema = `apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  when:
+    provider: unifi
+    state: {wan: backup}
+  actions:
+    - type: kubernetes.scale
+      target: {kind: Deployment, name: nothing}
+      replicas: 0
+`
+
+// storedBeforeUpgrade is the Automation written under the old schema and
+// expected to still be there, intact, once the new one is live.
+const storedBeforeUpgrade = "stored-before-upgrade"
+
+// Upgrading from the packaging that shipped the CRD under crds/ is a one-way
+// door every existing install goes through exactly once. It was verified by
+// hand when the packaging changed; this keeps it verified.
+var _ = Describe("Upgrading from a chart that shipped the CRD under crds/", Ordered, func() {
+	const namespace = "reactor-upgrade"
+	var legacyChart string
+
+	BeforeAll(func() {
+		By("starting from a cluster where the CRD is not part of any release")
+		removeCRD()
+		_, _ = cluster.Kubectl("create", "namespace", namespace)
+
+		By("assembling the chart as 0.3.0 packaged it: the CRD in crds/, not in templates/")
+		root, err := os.MkdirTemp("", "legacy-chart")
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { _ = os.RemoveAll(root) })
+		legacyChart = filepath.Join(root, "reactor")
+		_, err = harness.Run(GinkgoWriter, harness.ProjectDir(), "cp", "-R", "charts/reactor", legacyChart)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(os.Remove(filepath.Join(legacyChart, "templates", "crds.yaml"))).To(Succeed())
+		Expect(os.MkdirAll(filepath.Join(legacyChart, "crds"), 0o750)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(legacyChart, "crds", "automations.yaml"),
+			[]byte(legacyCRD), 0o600)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		_, _ = cluster.Helm("uninstall", release, "--namespace", namespace, "--ignore-not-found")
+		removeCRD()
+		_, _ = cluster.Kubectl("delete", "namespace", namespace, "--wait=false")
+	})
+
+	It("installs the old packaging, leaving the CRD owned by nobody", func() {
+		_, err := cluster.Helm("install", release, legacyChart, "--namespace", namespace,
+			set, "image.repository="+managerRepository,
+			set, "image.tag="+managerTag,
+			set, "image.pullPolicy=Never",
+			"--wait", "--timeout=180s")
+		Expect(err).NotTo(HaveOccurred())
+
+		labels, err := cluster.Kubectl("get", "crd", crdName, "-o", "jsonpath={.metadata.labels}")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(labels).NotTo(ContainSubstring("app.kubernetes.io/managed-by"),
+			"a CRD installed from crds/ is applied by Helm but never recorded as part of the release")
+	})
+
+	It("rejects an Automation using a field the old schema does not have", func() {
+		out, err := cluster.KubectlInput(fmt.Sprintf(automationWithReversal, namespace), "apply", "-f", "-")
+		Expect(err).To(HaveOccurred(), "the old schema is not actually the one in force")
+		Expect(out).To(ContainSubstring(`unknown field "spec.reversal"`))
+
+		By("but accepting one the old schema does understand, to be read back after the upgrade")
+		Expect(cluster.Apply(fmt.Sprintf(automationUnderOldSchema, storedBeforeUpgrade, namespace))).To(Succeed())
+	})
+
+	It("refuses the upgrade until the CRD is handed over to the release", func() {
+		out, err := cluster.Helm("upgrade", release, "charts/reactor", "--namespace", namespace,
+			set, "image.repository="+managerRepository,
+			set, "image.tag="+managerTag,
+			set, "image.pullPolicy=Never",
+			"--timeout=180s")
+		Expect(err).To(HaveOccurred(), "the upgrade succeeded where the documented one-time adoption is required")
+		Expect(out).To(ContainSubstring("invalid ownership metadata"),
+			"the upgrade failed for a reason the troubleshooting guide does not describe")
+	})
+
+	It("upgrades once the documented adoption has been done", func() {
+		By("running exactly what the chart README and troubleshooting guide tell people to run")
+		_, err := cluster.Kubectl("label", "crd", crdName,
+			"app.kubernetes.io/managed-by=Helm", "--overwrite")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = cluster.Kubectl("annotate", "crd", crdName,
+			"meta.helm.sh/release-name="+release,
+			"meta.helm.sh/release-namespace="+namespace, "--overwrite")
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = cluster.Helm("upgrade", release, "charts/reactor", "--namespace", namespace,
+			set, "image.repository="+managerRepository,
+			set, "image.tag="+managerTag,
+			set, "image.pullPolicy=Never",
+			"--wait", "--timeout=180s")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("puts the current schema live, not merely in the release", func() {
+		By("asking the API server what it now knows about the type")
+		out, err := cluster.Kubectl("get", "crd", crdName, "-o",
+			"jsonpath={.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.reversal.enum}")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(ContainSubstring("Baseline"), "helm upgrade did not update the CRD's schema")
+
+		By("and by round-tripping a resource that only the current schema accepts")
+		// Retried because the API server rebuilds the handler that validates
+		// and prunes a type a moment after the CRD object itself changes, so
+		// the first write after an upgrade can still meet the old schema.
+		Eventually(func(g Gomega) {
+			g.Expect(cluster.Apply(fmt.Sprintf(automationWithReversal, namespace))).To(Succeed())
+			reversal, err := cluster.Kubectl("get", automationKind, "schema-probe", "-n", namespace,
+				"-o", "jsonpath={.spec.reversal}")
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(reversal).To(Equal("None"),
+				"the same resource the old schema rejected is now stored with the field intact")
+		}).Should(Succeed())
+
+		By("without losing what was already stored under the schema it replaced")
+		stored := automationOf(Default, namespace, storedBeforeUpgrade)
+		Expect(stored.Spec.When).NotTo(BeNil())
+		Expect(stored.Spec.When.State).To(HaveKeyWithValue("wan", "backup"),
+			"replacing the CRD did not preserve an Automation written under the old schema")
+	})
+})

--- a/test/e2e/reaction/arbitration_test.go
+++ b/test/e2e/reaction/arbitration_test.go
@@ -1,0 +1,153 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaction
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Two Automations, one workload, different opinions. The outcome must depend
+// only on which conditions currently hold — never on which of them reconciled
+// last — and an Automation whose condition ends must not raise a workload
+// another one is still holding down.
+var _ = Describe("Arbitrating one workload between two Automations", Ordered, func() {
+	const (
+		shared     = "shared"
+		wanShared  = "wan-shared"
+		upsShared  = "ups-shared"
+		baseline   = 3
+		wanReduced = 1
+	)
+
+	onBackup := map[string]string{keyWAN: wanBackup}
+	onBattery := map[string]string{keyUPS: upsOnBattery}
+	upsClaim := scaleAutomation(upsShared, onBattery, shared, 0)
+
+	BeforeAll(func() {
+		Expect(cluster.Apply(workload(shared, baseline))).To(Succeed())
+		Expect(cluster.Apply(scaleAutomation(wanShared, onBackup, shared, wanReduced))).To(Succeed())
+		Expect(cluster.Apply(upsClaim)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		resetConsole()
+		Expect(cluster.Delete(scaleAutomation(wanShared, onBackup, shared, wanReduced))).To(Succeed())
+		Expect(cluster.Delete(upsClaim)).To(Succeed())
+	})
+
+	It("applies the only claim there is", func() {
+		Expect(mock.WAN(wanBackup)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, shared)).To(BeEquivalentTo(wanReduced))
+		}).Should(Succeed())
+
+		automation := automationOf(Default, wanShared)
+		target := targetStatus(automation, shared)
+		Expect(target.Desired).To(HaveValue(BeEquivalentTo(wanReduced)))
+		Expect(target.Effective).To(HaveValue(BeEquivalentTo(wanReduced)))
+		Expect(target.DeferredBy).To(BeEmpty())
+		Expect(conditionOf(automation, conditionApplied)).To(HaveField("Status", metav1.ConditionTrue))
+	})
+
+	It("resolves a second, more restrictive claim in favour of the more restrictive one", func() {
+		Expect(mock.UPS("mode=battery&level=80")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, shared)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		By("telling the outvoted automation who is holding its target, and why it is not an error")
+		Eventually(func(g Gomega) {
+			automation := automationOf(g, wanShared)
+			target := targetStatus(automation, shared)
+			g.Expect(target).NotTo(BeNil())
+			g.Expect(target.Desired).To(HaveValue(BeEquivalentTo(wanReduced)))
+			g.Expect(target.Effective).To(HaveValue(BeEquivalentTo(0)))
+			g.Expect(target.DeferredBy).To(ConsistOf(claimant(upsShared)))
+
+			applied := conditionOf(automation, conditionApplied)
+			g.Expect(applied).NotTo(BeNil())
+			g.Expect(applied.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(applied.Reason).To(Equal("DeferredToOtherAutomation"))
+		}).Should(Succeed())
+
+		By("and reporting the winning claim as in effect")
+		winner := automationOf(Default, upsShared)
+		Expect(targetStatus(winner, shared).DeferredBy).To(BeEmpty())
+		Expect(conditionOf(winner, conditionApplied)).To(HaveField("Status", metav1.ConditionTrue))
+		Expect(annotationsOf(Default, shared)).To(HaveKeyWithValue(annotationClaimedBy,
+			claimant(upsShared)+","+claimant(wanShared)))
+	})
+
+	It("does not raise the workload when one condition ends while the other still holds", func() {
+		By("recovering the WAN in the middle of the power failure")
+		Expect(mock.WAN(wanPrimary)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			automation := automationOf(g, wanShared)
+			g.Expect(automation.Status.Matching).To(BeFalse())
+			target := targetStatus(automation, shared)
+			g.Expect(target).NotTo(BeNil())
+			g.Expect(target.Desired).To(HaveValue(BeEquivalentTo(baseline)),
+				"an automation that stopped matching wants its target back at the baseline")
+			g.Expect(target.Effective).To(HaveValue(BeEquivalentTo(0)))
+			g.Expect(target.DeferredBy).To(ConsistOf(claimant(upsShared)))
+		}).Should(Succeed())
+
+		Consistently(func(g Gomega) {
+			g.Expect(replicasOf(g, shared)).To(BeEquivalentTo(0))
+		}).Should(Succeed(), "the recovered automation reverted a workload the other one is still claiming")
+
+		By("keeping the baseline recorded, since the target is still claimed")
+		Expect(annotationsOf(Default, shared)).To(HaveKeyWithValue(annotationBaseline, "3"))
+		Expect(annotationsOf(Default, shared)).To(HaveKeyWithValue(annotationClaimedBy, claimant(upsShared)))
+	})
+
+	It("releases the workload once nothing claims it any more", func() {
+		Expect(mock.UPS("mode=mains&level=100")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, shared)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+		Expect(annotationsOf(Default, shared)).NotTo(HaveKey(annotationBaseline))
+		Expect(annotationsOf(Default, shared)).NotTo(HaveKey(annotationClaimedBy))
+	})
+
+	It("hands the workload back when the automation holding it down is deleted mid-outage", func() {
+		By("putting the workload back down on battery power")
+		Expect(mock.UPS("mode=battery&level=80")).To(Succeed())
+		Eventually(func(g Gomega) { g.Expect(replicasOf(g, shared)).To(BeEquivalentTo(0)) }).Should(Succeed())
+
+		By("deleting the automation while its condition still holds")
+		Expect(cluster.Delete(upsClaim)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, shared)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed(), "removing the policy left the workload stranded, which is the failure #39 is about")
+
+		By("and letting the object go rather than leaving a finalizer nothing will service")
+		out, err := cluster.Kubectl("get", automationKind, "-n", appsNamespace, "-o", "name")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).NotTo(ContainSubstring(upsShared))
+		Expect(annotationsOf(Default, shared)).NotTo(HaveKey(annotationBaseline))
+	})
+})

--- a/test/e2e/reaction/reaction_test.go
+++ b/test/e2e/reaction/reaction_test.go
@@ -1,0 +1,178 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaction
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// The reaction specs share one console, so each block leaves it on mains power
+// and the primary uplink for the next one.
+var _ = Describe("Reacting to observed state", Ordered, func() {
+	const (
+		hello    = "hello"
+		wanShed  = "wan-shed"
+		baseline = 2
+	)
+
+	BeforeAll(func() {
+		Expect(cluster.Apply(workload(hello, baseline))).To(Succeed())
+		Expect(cluster.Apply(scaleAutomation(wanShed, map[string]string{keyWAN: wanBackup}, hello, 0))).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(conditionOf(automationOf(g, wanShed), conditionReady)).NotTo(BeNil())
+		}).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		resetConsole()
+		Eventually(func(g Gomega) { g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(baseline)) }).Should(Succeed())
+		Expect(cluster.Delete(scaleAutomation(wanShed, map[string]string{keyWAN: wanBackup}, hello, 0))).To(Succeed())
+	})
+
+	It("leaves a workload alone until the condition it depends on holds", func() {
+		Consistently(func(g Gomega) {
+			g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(baseline))
+			g.Expect(annotationsOf(g, hello)).NotTo(HaveKey(annotationBaseline))
+		}, 6*time.Second).Should(Succeed(), "a workload nothing claims must stay where its owner put it")
+	})
+
+	It("scales the workload down when the WAN fails over", func() {
+		Expect(mock.WAN(wanBackup)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		By("recording on the target what it was before, so it can be restored without Reactor")
+		annotations := annotationsOf(Default, hello)
+		Expect(annotations).To(HaveKeyWithValue(annotationBaseline, "2"))
+		Expect(annotations).To(HaveKeyWithValue(annotationClaimedBy, claimant(wanShed)))
+		Expect(annotations).To(HaveKey(annotationClaimedAt))
+
+		By("reporting the arbitrated outcome in status")
+		automation := automationOf(Default, wanShed)
+		Expect(automation.Status.Matching).To(BeTrue())
+		Expect(automation.Status.ObservedState).To(HaveKeyWithValue(keyWAN, wanBackup))
+		target := targetStatus(automation, hello)
+		Expect(target).NotTo(BeNil())
+		Expect(target.Desired).To(HaveValue(BeEquivalentTo(0)))
+		Expect(target.Effective).To(HaveValue(BeEquivalentTo(0)))
+		Expect(target.DeferredBy).To(BeEmpty())
+		Expect(conditionOf(automation, conditionApplied)).To(HaveField("Status", metav1.ConditionTrue))
+		Expect(conditionOf(automation, conditionReady)).To(HaveField("Status", metav1.ConditionTrue))
+	})
+
+	It("treats every later observation of the same state as a no-op", func() {
+		before := generationOf(Default, hello)
+		Consistently(func(g Gomega) {
+			g.Expect(generationOf(g, hello)).To(Equal(before))
+		}).Should(Succeed(), "repeated observations of an unchanged state rewrote the target")
+	})
+
+	It("puts a workload back where Reactor is holding it when something else moves it", func() {
+		By("scaling the claimed workload by hand, with no console state change at all")
+		_, err := cluster.Kubectl("-n", appsNamespace, "scale", "deployment/"+hello, "--replicas=4")
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(0))
+		}).Should(Succeed(), "a claimed target is reconciled continuously, not only on transitions")
+
+		By("leaving the recorded baseline as it was before Reactor claimed the target")
+		Expect(annotationsOf(Default, hello)).To(HaveKeyWithValue(annotationBaseline, "2"))
+	})
+
+	It("restores the workload when the WAN recovers", func() {
+		Expect(mock.WAN(wanPrimary)).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+
+		By("no longer asserting anything about a target nothing claims")
+		annotations := annotationsOf(Default, hello)
+		Expect(annotations).NotTo(HaveKey(annotationBaseline))
+		Expect(annotations).NotTo(HaveKey(annotationClaimedBy))
+		Expect(annotations).NotTo(HaveKey(annotationClaimedAt))
+
+		automation := automationOf(Default, wanShed)
+		Expect(automation.Status.Matching).To(BeFalse())
+		Expect(targetStatus(automation, hello).Effective).To(BeNil())
+	})
+
+	It("converges on a state that changed while it was down, having never seen the change", func() {
+		restartOperator(func() {
+			By("failing the WAN over with nothing running to witness it")
+			Expect(mock.WAN(wanBackup)).To(Succeed())
+			Consistently(func(g Gomega) {
+				g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(baseline))
+			}, 5*time.Second, time.Second).Should(Succeed(), "something reacted with the operator down")
+		})
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(0))
+		}).Should(Succeed(), "the operator did not re-derive its reaction from the state it found")
+
+		By("having derived that from current state rather than from a transition it observed")
+		logs := operatorLogs()
+		Expect(logs).To(ContainSubstring(`"key":"wan","from":"","to":"backup"`),
+			"the restarted operator did not report the WAN as first seen on backup")
+		Expect(logs).NotTo(ContainSubstring(`"key":"wan","from":"primary","to":"backup"`),
+			"the operator reported an edge it cannot have observed; it was not running when the WAN failed over")
+	})
+
+	It("keeps the baseline it recorded before the restart, not the value it is holding", func() {
+		By("restarting mid-outage, while the workload is scaled to zero")
+		Expect(replicasOf(Default, hello)).To(BeEquivalentTo(0))
+		restartOperator(func() {})
+
+		Eventually(func(g Gomega) {
+			g.Expect(annotationsOf(g, hello)).To(HaveKeyWithValue(annotationBaseline, "2"))
+		}).Should(Succeed())
+		Consistently(func(g Gomega) {
+			g.Expect(annotationsOf(g, hello)).To(HaveKeyWithValue(annotationBaseline, "2"))
+		}, 10*time.Second).Should(Succeed(), "re-claiming after a restart overwrote the baseline with the held value")
+
+		By("so that recovery restores the workload rather than leaving it at zero")
+		Expect(mock.WAN(wanPrimary)).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+	})
+
+	It("restores a workload on recovery it never saw fail, and never saw recover", func() {
+		By("failing the WAN over and letting the operator claim the workload")
+		Expect(mock.WAN(wanBackup)).To(Succeed())
+		Eventually(func(g Gomega) { g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(0)) }).Should(Succeed())
+
+		restartOperator(func() {
+			By("restoring the WAN with nothing running to witness it")
+			Expect(mock.WAN(wanPrimary)).To(Succeed())
+		})
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, hello)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed(), "the workload stayed down after a recovery the operator never observed as an edge")
+		Expect(annotationsOf(Default, hello)).NotTo(HaveKey(annotationBaseline))
+	})
+})

--- a/test/e2e/reaction/suite_test.go
+++ b/test/e2e/reaction/suite_test.go
@@ -1,0 +1,322 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package reaction runs Reactor against a real API server and a rehearsed
+// UniFi console, and asserts on what actually happened to the workloads.
+//
+// It exists because the behaviour that matters most is the behaviour a unit
+// test cannot reach: converging after a restart from state alone, and two
+// Automations arbitrating one workload between them. Both were designed
+// against a mental model of the API server rather than against one.
+package reaction
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+	"github.com/robbeverhelst/unifi-reactor/test/e2e/harness"
+)
+
+const (
+	// The operator image built from this working tree and loaded into Kind.
+	managerRepository = "example.com/unifi-reactor"
+	managerTag        = "e2e"
+	managerImage      = managerRepository + ":" + managerTag
+	// releaseNamespace holds the operator and the rehearsed console.
+	releaseNamespace = "reactor-e2e"
+	// appsNamespace holds the workloads and the Automations acting on them,
+	// which is where they belong: an Automation lives next to what it acts on.
+	appsNamespace = "reactor-e2e-apps"
+	// release is the Helm release name. It matches the chart name, so the
+	// operator's Deployment is simply "reactor".
+	release = "reactor"
+	// pollInterval is how often the operator observes the console. Short
+	// enough to keep the suite quick, long enough to be a real poll.
+	pollInterval = "2s"
+
+	// deploymentKind is how a target is named in kubectl and in status refs.
+	deploymentKind = "deployment"
+	// automationKind is the CRD's singular name.
+	automationKind = "automation"
+
+	annotationBaseline  = "reactor.robbeverhelst.com/baseline-replicas"
+	annotationClaimedBy = "reactor.robbeverhelst.com/claimed-by"
+	annotationClaimedAt = "reactor.robbeverhelst.com/claimed-at"
+
+	conditionReady   = "Ready"
+	conditionApplied = "Applied"
+
+	// The state values the rehearsed console publishes, written the way an
+	// Automation's spec.when.state writes them.
+	keyWAN       = "wan"
+	keyUPS       = "ups"
+	wanPrimary   = "primary"
+	wanBackup    = "backup"
+	upsOnBattery = "on-battery"
+
+	// settleWindow is how long a workload must hold a value for the suite to
+	// accept that nothing is going to move it. It spans several polls and at
+	// least one of the reconciler's periodic re-evaluations.
+	settleWindow = 20 * time.Second
+	// convergeWindow bounds waiting for a reaction that has to come through a
+	// periodic re-evaluation rather than through a state change.
+	convergeWindow = 90 * time.Second
+)
+
+var (
+	cluster *harness.Cluster
+	mock    *harness.Mock
+)
+
+func TestReaction(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "reaction suite")
+}
+
+var _ = BeforeSuite(func() {
+	SetDefaultEventuallyTimeout(convergeWindow)
+	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultConsistentlyDuration(settleWindow)
+	SetDefaultConsistentlyPollingInterval(2 * time.Second)
+
+	var err error
+	cluster, err = harness.NewCluster(GinkgoWriter)
+	Expect(err).NotTo(HaveOccurred())
+	mock = harness.NewMock(GinkgoWriter)
+
+	By("building and loading the operator image")
+	Expect(harness.BuildManagerImage(GinkgoWriter, managerImage)).To(Succeed())
+	Expect(cluster.LoadImage(managerImage)).To(Succeed())
+
+	By("building and loading the rehearsed UniFi console")
+	context, err := os.MkdirTemp("", "mock-unifi-build")
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() { _ = os.RemoveAll(context) })
+	Expect(harness.BuildMockImage(GinkgoWriter, context)).To(Succeed())
+	Expect(cluster.LoadImage(harness.MockImage)).To(Succeed())
+
+	By("creating the namespaces")
+	for _, namespace := range []string{releaseNamespace, appsNamespace} {
+		_, _ = cluster.Kubectl("create", "namespace", namespace)
+	}
+
+	By("starting the rehearsed console")
+	Expect(cluster.Apply(harness.MockManifest(releaseNamespace))).To(Succeed())
+	_, err = cluster.Kubectl("-n", releaseNamespace, "rollout", "status",
+		"deployment/"+harness.MockName, "--timeout=120s")
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(mock.Reachable).Should(Succeed(), "the mock console is not reachable over the Kind port mapping")
+
+	By("starting from a known console state")
+	resetConsole()
+
+	By("installing the chart")
+	_, err = cluster.Kubectl("-n", releaseNamespace, "create", "secret", "generic",
+		"unifi-reactor-credentials", "--from-literal=UNIFI_API_KEY=rehearsal")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = cluster.Helm("install", release, "charts/reactor",
+		"--namespace", releaseNamespace,
+		"--set", "image.repository="+managerRepository,
+		"--set", "image.tag="+managerTag,
+		"--set", "image.pullPolicy=Never",
+		"--set", "unifi.url="+harness.MockURL(releaseNamespace),
+		"--set", "unifi.insecureSkipVerify=false",
+		"--set", "unifi.pollInterval="+pollInterval,
+		// Structured logs, so the suite can assert on what the operator did
+		// and did not observe rather than on a rendered sentence.
+		"--set", "log.format=json",
+		"--wait", "--timeout=180s")
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = AfterSuite(func() {
+	if cluster == nil {
+		return
+	}
+	if CurrentSpecReport().Failed() {
+		logs, _ := cluster.Kubectl("-n", releaseNamespace, "logs", "deployment/"+release, "--tail=200")
+		_, _ = fmt.Fprintf(GinkgoWriter, "operator logs:\n%s\n", logs)
+	}
+	_, _ = cluster.Helm("uninstall", release, "--namespace", releaseNamespace, "--ignore-not-found")
+	for _, namespace := range []string{appsNamespace, releaseNamespace} {
+		_, _ = cluster.Kubectl("delete", "namespace", namespace, "--wait=false")
+	}
+})
+
+// resetConsole returns the rehearsed console to mains power on the primary
+// uplink, so every spec starts from the same place regardless of what the one
+// before it rehearsed.
+func resetConsole() {
+	Expect(mock.WAN(wanPrimary)).To(Succeed())
+	Expect(mock.UPS("mode=mains&level=100&present=true")).To(Succeed())
+}
+
+// workload renders a target Deployment. The pods run the mock's image because
+// it is already on every node: nothing here waits for them to be ready, and an
+// image pull would be the one part of this suite that needs the internet.
+func workload(name string, replicas int) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: %[3]d
+  selector:
+    matchLabels: {app: %[1]s}
+  template:
+    metadata:
+      labels: {app: %[1]s}
+    spec:
+      containers:
+        - name: app
+          image: %[4]s
+          imagePullPolicy: Never
+`, name, appsNamespace, replicas, harness.MockImage)
+}
+
+// scaleAutomation renders an Automation that holds one target at a level while
+// a condition holds. Omitting onExit is the common case and means Baseline:
+// restore whatever the workload was before Reactor first claimed it.
+func scaleAutomation(name string, when map[string]string, target string, replicas int) string {
+	var state strings.Builder
+	for key, value := range when {
+		fmt.Fprintf(&state, "      %s: %q\n", key, value)
+	}
+	return fmt.Sprintf(`apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  when:
+    provider: unifi
+    state:
+%s  actions:
+    - type: kubernetes.scale
+      target: {kind: Deployment, name: %s}
+      replicas: %d
+`, name, appsNamespace, state.String(), target, replicas)
+}
+
+// replicasOf reads what a target is currently scaled to.
+func replicasOf(g Gomega, name string) int32 {
+	var deployment appsv1.Deployment
+	g.Expect(cluster.GetInto(&deployment, deploymentKind, appsNamespace, name)).To(Succeed())
+	g.Expect(deployment.Spec.Replicas).NotTo(BeNil())
+	return *deployment.Spec.Replicas
+}
+
+// annotationsOf reads a target's annotations, which are what a stranded
+// workload carries to explain itself once Reactor is gone.
+func annotationsOf(g Gomega, name string) map[string]string {
+	var deployment appsv1.Deployment
+	g.Expect(cluster.GetInto(&deployment, deploymentKind, appsNamespace, name)).To(Succeed())
+	return deployment.Annotations
+}
+
+// generationOf is how the suite tells a write apart from a no-op: the API
+// server bumps it on every change to spec, and on nothing else.
+func generationOf(g Gomega, name string) int64 {
+	var deployment appsv1.Deployment
+	g.Expect(cluster.GetInto(&deployment, deploymentKind, appsNamespace, name)).To(Succeed())
+	return deployment.Generation
+}
+
+func automationOf(g Gomega, name string) reactorv1alpha1.Automation {
+	var automation reactorv1alpha1.Automation
+	g.Expect(cluster.GetInto(&automation, automationKind, appsNamespace, name)).To(Succeed())
+	return automation
+}
+
+// targetStatus finds the entry describing one target, which is where the
+// arbitrated outcome is reported.
+func targetStatus(automation reactorv1alpha1.Automation, target string) *reactorv1alpha1.TargetStatus {
+	ref := fmt.Sprintf("Deployment/%s/%s", appsNamespace, target)
+	for i := range automation.Status.Targets {
+		if automation.Status.Targets[i].Ref == ref {
+			return &automation.Status.Targets[i]
+		}
+	}
+	return nil
+}
+
+func conditionOf(automation reactorv1alpha1.Automation, conditionType string) *metav1.Condition {
+	for i := range automation.Status.Conditions {
+		if automation.Status.Conditions[i].Type == conditionType {
+			return &automation.Status.Conditions[i]
+		}
+	}
+	return nil
+}
+
+// claimant is how an Automation names itself in another's deferredBy list.
+func claimant(name string) string { return appsNamespace + "/" + name }
+
+// restartOperator takes Reactor away, runs the caller's rehearsal while
+// nothing is watching, and brings it back. This is the shape of the promise
+// the whole design rests on: what the world becomes is decided by the state
+// Reactor finds, not by the changes it happened to witness.
+func restartOperator(whileDown func()) {
+	By("taking the operator down")
+	_, err := cluster.Kubectl("-n", releaseNamespace, "scale", "deployment/"+release, "--replicas=0")
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(func(g Gomega) {
+		out, err := cluster.Kubectl("-n", releaseNamespace, "get", "pods",
+			"-l", "app.kubernetes.io/name=reactor", "-o", "name")
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(out).To(BeEmpty(), "the operator is still running")
+	}).Should(Succeed())
+
+	whileDown()
+
+	By("bringing the operator back")
+	_, err = cluster.Kubectl("-n", releaseNamespace, "scale", "deployment/"+release, "--replicas=1")
+	Expect(err).NotTo(HaveOccurred())
+	_, err = cluster.Kubectl("-n", releaseNamespace, "rollout", "status",
+		"deployment/"+release, "--timeout=180s")
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// operatorLogs returns what the currently running operator has logged. After a
+// restart that is only what it has seen since coming back, which is exactly
+// the question the restart specs ask.
+func operatorLogs() string {
+	logs, err := cluster.Kubectl("-n", releaseNamespace, "logs", "deployment/"+release, "--tail=-1")
+	Expect(err).NotTo(HaveOccurred())
+	return logs
+}
+
+// TestMain keeps the suite from running against whatever cluster happens to be
+// current when someone runs `go test` by hand.
+func TestMain(m *testing.M) {
+	if os.Getenv("KIND_CLUSTER") == "" {
+		fmt.Fprintln(os.Stderr, "KIND_CLUSTER is not set; run `make test-reaction`")
+		os.Exit(1)
+	}
+	os.Exit(m.Run())
+}

--- a/test/e2e/reaction/ups_test.go
+++ b/test/e2e/reaction/ups_test.go
@@ -1,0 +1,142 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaction
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// A power failure is the case the whole "hold, don't guess" rule exists for:
+// the hardware reporting the outage is itself on the failing power, and losing
+// sight of it must never be read as the outage having ended.
+var _ = Describe("Reacting to a power failure", Ordered, func() {
+	const (
+		media    = "media"
+		core     = "core"
+		upsShed  = "ups-shed"
+		critical = "ups-critical"
+		baseline = 3
+	)
+
+	onBattery := map[string]string{keyUPS: upsOnBattery}
+	onCritical := map[string]string{keyUPS: upsOnBattery, "ups.battery": "critical"}
+
+	BeforeAll(func() {
+		Expect(cluster.Apply(workload(media, baseline))).To(Succeed())
+		Expect(cluster.Apply(workload(core, baseline))).To(Succeed())
+		Expect(cluster.Apply(scaleAutomation(upsShed, onBattery, media, 0))).To(Succeed())
+		Expect(cluster.Apply(scaleAutomation(critical, onCritical, core, 1))).To(Succeed())
+	})
+
+	AfterAll(func() {
+		resetConsole()
+		Expect(cluster.Delete(scaleAutomation(upsShed, onBattery, media, 0))).To(Succeed())
+		Expect(cluster.Delete(scaleAutomation(critical, onCritical, core, 1))).To(Succeed())
+	})
+
+	It("sheds on battery power without escalating while the charge is healthy", func() {
+		Expect(mock.UPS("mode=battery&level=80")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, media)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		By("leaving the escalation alone: one of its two keys does not hold")
+		automation := automationOf(Default, critical)
+		Expect(automation.Status.Matching).To(BeFalse())
+		Expect(automation.Status.ObservedState).To(HaveKeyWithValue(keyUPS, upsOnBattery))
+		Expect(automation.Status.ObservedState).To(HaveKeyWithValue("ups.battery", "normal"))
+		Expect(replicasOf(Default, core)).To(BeEquivalentTo(baseline))
+	})
+
+	It("holds its claim when the UPS stops being reported at all", func() {
+		Expect(mock.UPS("present=false")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			ready := conditionOf(automationOf(g, upsShed), conditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(ready.Reason).To(Equal("StateKeyUnavailable"))
+			g.Expect(ready.Message).To(ContainSubstring("ups"))
+		}).Should(Succeed())
+
+		By("still considering itself matched, because losing sight is not evidence the outage ended")
+		Expect(automationOf(Default, upsShed).Status.Matching).To(BeTrue())
+
+		By("and leaving the workload down for as long as it cannot see")
+		Consistently(func(g Gomega) {
+			g.Expect(replicasOf(g, media)).To(BeEquivalentTo(0))
+		}).Should(Succeed(), "the reversal fired on a key that went missing, not on an outage that ended")
+	})
+
+	It("picks the state back up when the UPS is reported again", func() {
+		Expect(mock.UPS("present=true")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			ready := conditionOf(automationOf(g, upsShed), conditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Status).To(Equal(metav1.ConditionTrue))
+		}).Should(Succeed())
+		Expect(replicasOf(Default, media)).To(BeEquivalentTo(0))
+	})
+
+	It("does not escalate while only one of the two keys holds", func() {
+		before := generationOf(Default, core)
+		Expect(mock.UPS("level=25")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(automationOf(g, critical).Status.ObservedState).To(HaveKeyWithValue("ups.battery", "low"))
+		}).Should(Succeed())
+		Consistently(func(g Gomega) {
+			g.Expect(replicasOf(g, core)).To(BeEquivalentTo(baseline))
+			g.Expect(generationOf(g, core)).To(Equal(before))
+		}, 10*time.Second).Should(Succeed(), "a partially matched multi-key condition acted anyway")
+	})
+
+	It("escalates once the battery reaches critical, on both keys together", func() {
+		Expect(mock.UPS("level=5")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, core)).To(BeEquivalentTo(1))
+		}).Should(Succeed())
+
+		automation := automationOf(Default, critical)
+		Expect(automation.Status.Matching).To(BeTrue())
+		Expect(automation.Status.ObservedState).To(HaveKeyWithValue("ups.battery", "critical"))
+		Expect(targetStatus(automation, core).Effective).To(HaveValue(BeEquivalentTo(1)))
+
+		By("without disturbing what the coarser automation is already holding")
+		Expect(replicasOf(Default, media)).To(BeEquivalentTo(0))
+	})
+
+	It("restores both workloads when mains power returns", func() {
+		Expect(mock.UPS("mode=mains&level=100")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, media)).To(BeEquivalentTo(baseline))
+			g.Expect(replicasOf(g, core)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+		Expect(annotationsOf(Default, media)).NotTo(HaveKey(annotationBaseline))
+		Expect(annotationsOf(Default, core)).NotTo(HaveKey(annotationBaseline))
+	})
+})


### PR DESCRIPTION
Closes #35.

`test/e2e` was still the kubebuilder scaffold — it proved the manager starts, not that Reactor reacts. This adds two suites that run against a real API server and a rehearsed console, and it found two v1.0 bugs on the way.

## Two bugs the suites found

**1. `rbac.clusterWide=false` has never worked at all** (`fix(controller): watch only the namespace RBAC actually grants`)

The chart installs a namespaced Role, but the manager still started a cluster-scoped informer for Automations. The API server refuses that list, controller-runtime retries it forever, and the cache never syncs — so **no Automation anywhere is reconciled**, while the health probes, which only ping, keep the pod `Ready`. This is broader than the `ReleaseAllClaims` list problem flagged in the brief; that turned out to be a symptom.

The chart now passes the scope it granted as `WATCH_NAMESPACE`, the manager restricts its cache to it, and the release sweep is scoped the same way.

**2. `helm uninstall` re-claimed everything the pre-delete hook released** (`fix(chart): stop the operator before the pre-delete hook releases claims`)

Helm removes a release's own resources only *after* its pre-delete hooks finish — so the assumption in the brief holds, but it cuts the other way: the operator is still running and still watching while the hook hands workloads back. Removing the finalizer is itself an update, which wakes a reconcile that re-claims every target the hook just released **and re-adds the finalizer**. The uninstall therefore left workloads at zero and turned a later `kubectl delete crd` into a hang — exactly the trap the hook exists to prevent. It affected both RBAC modes.

The sweep now scales the operator's Deployment to zero and waits for it to stop before releasing anything. Failing to stop it is not fatal: a release that mostly works beats an uninstall that refuses to proceed.

Both fixes are separate commits so they can be reviewed — or reverted — independently of the tests. They are unrequested behaviour changes; without them the suites are red rather than green, which is why they are here.

## What the suites cover

`make test-reaction` — one chart install, a rehearsed console in-cluster, real workloads:

- the full cycle: enter, repeated no-op observations (asserted via `metadata.generation`, so a re-write would fail), exit
- **restart with changed state, both directions.** Reactor down, WAN fails over, Reactor up, workload converges — and the operator's own structured logs are asserted to report the WAN as *first seen* on backup (`"from":"","to":"backup"`) and never as a `primary->backup` edge it cannot have observed. The reverse too: down while holding a workload at zero, recovery happens unwitnessed, workload comes back
- restart mid-outage leaves the recorded baseline alone, so recovery restores the workload rather than stranding it at the value Reactor itself was holding
- a claimed target reconciled continuously: scale it by hand with no state change and Reactor puts it back
- a state key vanishing (`?present=false`) reports `StateKeyUnavailable`, holds `matching`, and does **not** fire the reversal
- multi-key matching and escalation only once both keys hold

`make test-reaction` (arbitration, #29's whole point, never run against a real API server):

- one claim applies; a second, more restrictive claim wins
- the outvoted Automation reports `desired`, `effective`, `deferredBy` naming the other, and `Applied=False/DeferredToOtherAutomation` as a healthy outcome
- **the WAN recovering mid-outage does not raise a workload the UPS automation still claims** — asserted to hold for 20s, across polls and periodic re-evaluations
- release once nothing claims it, and release-on-delete mid-outage (§9.1's answer), with the finalizer gone

`make test-lifecycle`:

- uninstall in **both** RBAC modes: the hook runs while the release's RBAC is still there (which is what proves the ordering — the hook patches under the manager's ServiceAccount, so a restored workload could not have happened otherwise), workload back at baseline, annotations gone, Automations survive with no finalizer, `kubectl delete crd` completes
- the chart 0.3.0 upgrade, made permanent: install the `crds/` packaging, confirm the old schema is really live (it *rejects* `spec.reversal`), watch `helm upgrade` refuse with `invalid ownership metadata`, run the documented label/annotate pair verbatim, upgrade, and read the new schema back from the API server

## Safety and CI

Every `kubectl`/`helm` call goes through a harness that names its cluster explicitly and refuses anything that is not a local `kind-` context; the suites install cluster-wide RBAC and delete CRDs, so an unpinned command would not be a failed test. Each `make` target creates its Kind cluster and deletes it whether or not the suite passed.

Three parallel CI jobs (matrix): Manager (the existing scaffold), Reaction (~4.5 min), Lifecycle (~2.5 min). No sleeps, no port-forwards — the mock is reached over a fixed node port mapped by `test/e2e/kind-config.yaml`. Both new suites ran clean repeatedly. `golangci-lint` now runs with the `e2e` build tag, so this code is checked rather than merely compiled.

`make test`, `make lint`, and all three e2e suites pass; `make manifests generate` produces no drift.

## LIVE VERIFICATION

**Still needs real hardware or a real console — not reachable from CI:**

- **The UniFi API contract itself.** Everything here runs against `hack/mock-unifi` serving the captured payloads. That a real UDM still returns `wan1/wan2.is_uplink` and `vbms_table` in these shapes, on the Network version you run, is only ever proven by `hack/capture-unifi.sh` against real hardware.
- **A real WAN failover.** The mock flips a boolean. Whether a genuine failover produces exactly one clean transition — rather than a burst while the gateway re-converges — is a hardware question, and it is what the debounce configuration exists for.
- **A real power outage.** Battery drain through normal → low → critical over minutes, and whether a UPS on failing power keeps answering the console or drops off mid-outage (the case `StateKeyUnavailable` handles). The suite rehearses both; only hardware says which actually happens.
- **Authentication against a real console.** API-key auth, self-signed certs, `insecureSkipVerify`, and credential rotation through the mounted Secret. The mock is plain HTTP and accepts any key.
- **Multiple gateways or UPS devices on one site** — explicitly out of scope for v1alpha1, and the fixtures have one of each.
- **Non-Kind clusters.** kubeadm, k3s, GKE/EKS, and anything with an admission controller or a GitOps agent reconciling the targets back. The GitOps drift interaction (Flux/Argo fighting the replica count and the annotations) is documented but untested.
- **Upgrading from an actual published chart 0.3.0.** The upgrade spec reconstructs that packaging from the current chart plus a hand-written reduced CRD; it proves the mechanism, not that artefact.

**Previously unverifiable, now covered — strike these off:**

- Reactor converges on state that changed while it was down, without ever observing the transition — in both directions, with the log evidence that no edge was seen.
- A restart mid-outage does not overwrite the recorded baseline with the value Reactor is holding, so recovery still restores the workload.
- A claimed target is reconciled continuously, not only on transitions: manual drift is corrected with no state change at all.
- Losing sight of a state key holds the claim instead of firing the reversal.
- Multi-key conditions only act when every key holds.
- Two Automations sharing one workload resolve to the most restrictive claim, independent of reconcile order, with `status.targets[]` and the `Applied` condition reporting who deferred to whom.
- An Automation whose condition ends does not raise a workload another still claims.
- Deleting an Automation mid-outage hands its workload back and clears its finalizer.
- `helm uninstall` runs the pre-delete hook while the release's ServiceAccount and RBAC still exist, restores workloads to their baseline, clears the annotations, leaves no finalizer, and leaves the CRD deletable.
- The same, with `rbac.clusterWide=false` — which, as above, needed both fixes before it could pass.
- `helm upgrade` from the `crds/` packaging fails with `invalid ownership metadata`, the documented adoption pair fixes it, and the upgraded chart puts the current schema live rather than merely shipping it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
