### PR TITLE
feat(observability): Prometheus metrics, alert rules, a dashboard, and systematic Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,6 +456,48 @@ Declaring the vocabulary is also what lets the gauge report `0` for the values a
 
 Both need their operator's CRDs, and both refuse to render without `metrics.enabled` rather than quietly querying series nothing is publishing.
 
+### The other direction: `kubectl describe`
+
+Metrics answer *how often*, across everything. Events answer *what happened*, to this one resource — and they need no Prometheus, no port, and no cluster-admin log access:
+
+```sh
+kubectl -n media describe automation pause-downloads-on-backup-wan
+```
+```text
+Type     Reason                     Age    From        Message
+----     ------                     ----   ----        -------
+Normal   StateEntered               3m12s  automation  wan moved from "primary" to "backup", so the condition started holding
+Normal   TargetScaled               3m12s  automation  Deployment/media/qbittorrent set to 0 replicas
+Normal   EdgeActionSent             3m11s  automation  notification.ntfy delivered to https://ntfy.example.com:443 after 1 attempt(s)
+Normal   DeferredToOtherAutomation  2m40s  automation  a more restrictive claim is in effect: Deployment/media/qbittorrent held by power/shed-on-battery
+Warning  StateKeyUnavailable        1m02s  automation  provider "unifi" stopped reporting ups; holding the last known state rather than treating lost sight of it as the condition ending
+Normal   StateExited                18s    automation  wan moved from "backup" to "primary", so the condition stopped holding
+Normal   TargetReleased             18s    automation  Deployment/media/qbittorrent released; no automation claims it any more
+```
+
+That is the whole failover, in order, including the part where it deliberately did nothing.
+
+`Normal` and `Warning` are used deliberately rather than as a severity dial. Entering a state, scaling a target, releasing one, and **being outvoted by a more restrictive claim** are all `Normal` — the last one especially, because it is how two automations sharing a workload are meant to behave, and reporting it as a fault would train you to ignore Warnings here. `Warning` is reserved for something you have to act on: a held state, a failed action, a retry budget spent, a notification that did not go out.
+
+Volume is bounded by the same rule everywhere: **Events fire on edges, not on states.** A reconcile happens at least every 15s, so anything raised from a steady condition would be an API write every 15 seconds per automation, forever. A target already at the right value produces nothing. A condition that keeps reporting the same reason produces nothing after the first. `ActionFailed` stops at the retry budget, and `RetryBudgetExhausted` replaces it exactly once.
+
+| Reason | Type | Raised when |
+| --- | --- | --- |
+| `StateEntered` / `StateExited` | Normal | the condition started or stopped holding, naming the key that moved |
+| `TargetScaled` / `TargetReleased` | Normal | a write to a target actually happened |
+| `DeferredToOtherAutomation` | Normal | a peer's more restrictive claim is the one in effect |
+| `EdgeActionSent` | Normal | a notification or HTTP request was delivered |
+| `StateKeyUnavailable` | Warning | a provider stopped reporting a key, so state is being held |
+| `ActionFailed` | Warning | a desired-state action could not be applied |
+| `RetryBudgetExhausted` | Warning | Reactor stopped retrying and is waiting for the next state change |
+| `EdgeActionFailed` / `EdgeActionSkipped` | Warning | a notification or HTTP request did not go out |
+| `ReleaseFailed` | Warning | deletion could not hand a target back and let the object go anyway |
+| `EventTriggerRemoved` | Warning | a leftover `spec.trigger` automation that does nothing; delete it |
+
+Events are where a state key with an **open value set** is reported: `isp` is not a metric label, so `isp moved from "carrier-a" to "carrier-b"` lives here and in `status.observedState`. The two halves are complementary on purpose — Prometheus keeps what is bounded, Kubernetes keeps what is specific.
+
+> Events are written to the `events.k8s.io/v1` API and expire on your cluster's retention (an hour by default). They are for the incident you are in, not the audit trail — `status` is the durable record.
+
 ## Compatibility
 
 Everything here was built against one setup, and this table says which one. "Verified" means a real capture or a real cluster; "expected" means the code path is version-independent as far as anyone can tell, which is not the same thing.

--- a/README.md
+++ b/README.md
@@ -404,6 +404,58 @@ Each extra sample costs one `pollInterval` of reaction time, so the default is `
 
 Debouncing happens in the shared state store, so every automation sees the same settled value. Two automations can never disagree about the current state and fight over a workload they share.
 
+## Knowing it is working
+
+Reactor's worst failure is **silent and fails open**. If it stops observing — an expired API key, a rebooted console, a network partition — every automation quietly stops reacting. Nothing in the cluster notices, and the next real outage simply does not get handled. There is no error to find, because nothing errored.
+
+One metric answers that, and it is the reason the rest exist:
+
+```promql
+time() - reactor_last_observation_timestamp_seconds
+```
+
+Metrics are **off by default** and register on the endpoint controller-runtime already serves — there is no second server and no second auth posture:
+
+```sh
+helm upgrade reactor ... \
+  --set metrics.enabled=true \
+  --set metrics.serviceMonitor.enabled=true \
+  --set metrics.rules.enabled=true \
+  --set metrics.dashboard.enabled=true
+```
+
+| Metric | Type | Answers |
+| --- | --- | --- |
+| `reactor_last_observation_timestamp_seconds` | gauge | is Reactor still seeing anything |
+| `reactor_observations_total` | counter | how often polling succeeds and fails |
+| `reactor_state_info` | gauge 0/1 | what each state key holds right now |
+| `reactor_state_transitions_total` | counter | how often failover actually happens |
+| `reactor_automation_matching` / `_ready` | gauge 0/1 | which policies are in force, and which are broken |
+| `reactor_arbitrations_total` | counter | claimed, deferred to a peer, or released |
+| `reactor_actions_total` | counter | action outcomes, by type and **kind** |
+| `reactor_action_duration_seconds` | histogram | slow or hanging actions |
+| `reactor_reaction_latency_seconds` | histogram | observation → action, end to end |
+| `reactor_webhook_deliveries_total` | counter | fast-path deliveries accepted, coalesced, refused |
+| `reactor_provider_signal_disagreements_total` | counter | two independent signals for one fact disagreeing |
+
+Reconcile counts, queue depth and reconcile latency are controller-runtime's own `controller_runtime_*` series on the same endpoint. Reactor does not reimplement them. It also deliberately **does not re-export UniFi telemetry** — a UniFi exporter covers that better, and Reactor's unique vantage point is the decision layer.
+
+`kind` on `reactor_actions_total` is `desired_state` or `edge`, and no alert should be written without it. A failed `kubernetes.scale` means the cluster is not in the state you asked for. A failed notification means nobody was told — [the workload was still scaled](#when-a-notification-fails), and the automation is still `Ready`. The shipped rules alert on those separately for exactly that reason.
+
+### Cardinality, on purpose
+
+`isp` is the first state key whose values are an **open set** — a carrier slug derived from whatever public address your gateway currently holds. So `reactor_state_info` is published only for keys whose provider declares a closed value set, and `isp` is deliberately not one of them. The transition counter is not labelled by `from`/`to` for the same reason. What a key currently holds is always in `status.observedState` and in an `Event`; what Prometheus keeps is bounded at compile time.
+
+Declaring the vocabulary is also what lets the gauge report `0` for the values a key does *not* hold. Without that, the series for a value it used to hold goes stale at `1` rather than dropping, and every graph built on it lies. All values `0` means the key is not currently observable — the metric side of [`StateKeyUnavailable`](docs/troubleshooting.md#2-statekeyunavailable-and-held-state).
+
+### Alerts and the dashboard
+
+`metrics.rules.enabled` ships a `PrometheusRule` — `ReactorObservationStale` first, then failing observations, failing actions, edge actions failing separately, automations stuck not-ready, and reactions getting slow. `ReactorUPSOnBattery` and `ReactorWANOnBackup` are informational: they let your existing alerting learn what your network already knows.
+
+`metrics.dashboard.enabled` ships a grafana-operator `GrafanaDashboard`. It pins no datasource — you pick one from a variable when you open it — so the same JSON works in any Grafana, and it is a plain file at [`charts/reactor/dashboards/reactor.json`](charts/reactor/dashboards/reactor.json) if you would rather import it by hand.
+
+Both need their operator's CRDs, and both refuse to render without `metrics.enabled` rather than quietly querying series nothing is publishing.
+
 ## Compatibility
 
 Everything here was built against one setup, and this table says which one. "Verified" means a real capture or a real cluster; "expected" means the code path is version-independent as far as anyone can tell, which is not the same thing.
@@ -445,6 +497,10 @@ Chart values ([full reference](charts/reactor/README.md)):
 | `unifi.ups.criticalBatteryPercent` | `10` | charge at or below this reports `ups.battery: critical` |
 | `unifi.webhook.enabled` | `false` | webhook fast path (below) |
 | `actions.allowedDestinations` | `[]` | where outbound actions may go. Empty refuses all of them, and withholds the operator's read access to Secrets ([why](#telling-you-what-happened)) |
+| `metrics.enabled` | `false` | serve `/metrics` on `:8443` over HTTPS behind the API server's authn/authz filter ([above](#knowing-it-is-working)) |
+| `metrics.serviceMonitor.enabled` | `false` | scrape it with the Prometheus Operator |
+| `metrics.rules.enabled` | `false` | ship the alert rules, `ReactorObservationStale` first |
+| `metrics.dashboard.enabled` | `false` | ship the overview dashboard as a grafana-operator `GrafanaDashboard` |
 | `rbac.clusterWide` | `true` | when `false`, restricts the operator to its own namespace |
 
 `Automation` resources are namespaced. An action targets its own namespace by default; naming a different one in `target.namespace` requires `rbac.clusterWide: true`.
@@ -494,7 +550,7 @@ And the webhook fast path has been exercised against the mock console, not a rea
 
 - Event triggers for genuinely point-in-time things, like a client connecting — returning as `spec.trigger` in `v1alpha2`, once a real delivery payload has been captured and there is an edge action to run ([why it is not in `v1alpha1`](#stability))
 - More actions: `restart`, CronJob suspend, and the UniFi write actions
-- Prometheus metrics and richer status conditions
+- Richer status conditions, and debounce made visible in status rather than only in the log
 - More providers, driven by demand: NUT, Proxmox, Prometheus alerts, Home Assistant
 
 Non-goals: replacing UniFi Network or UniFi OS, becoming a general-purpose workflow engine like n8n or Argo Workflows, replacing Home Assistant, or executing arbitrary shell commands.

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -399,6 +399,155 @@ networkPolicy:
         - { protocol: TCP, port: 9090 }
 ```
 
+The same applies to `metrics.enabled`: Prometheus has to reach the metrics port,
+and the chart does not widen `networkPolicy.ingress` for that either.
+
+```yaml
+networkPolicy:
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels: { kubernetes.io/metadata.name: monitoring }
+      ports:
+        - { protocol: TCP, port: 8443 }
+```
+
+## Metrics, alerts and a dashboard (optional, off by default)
+
+Reactor's worst failure mode is silent: if it stops observing, every Automation
+quietly stops reacting and nothing in the cluster notices. `metrics.enabled`
+is what makes that visible.
+
+```sh
+helm upgrade reactor ... \
+  --set metrics.enabled=true \
+  --set metrics.serviceMonitor.enabled=true \
+  --set metrics.rules.enabled=true
+```
+
+It is off by default because enabling it opens a port on a running pod and
+creates a Service, and an upgrade should never do either on its own. The
+manifest bundle (`install.yaml`) turns it on; the chart renders exactly the
+same shape, so the only difference between the two paths is the default.
+
+### The auth posture
+
+The endpoint serves **HTTPS on `:8443` behind the API server's authn/authz
+filter**, which is what the kubebuilder scaffold has always done and what
+`install.yaml` ships. A scraper must present a bearer token belonging to a
+ServiceAccount that is allowed to `get` the `/metrics` non-resource URL.
+
+Enabling metrics therefore grants the operator `create` on `tokenreviews` and
+`subjectaccessreviews` — that is how it asks the API server to authenticate and
+authorize each scrape. Both are cluster-scoped, so those rules are a ClusterRole
+in both `rbac.clusterWide` modes.
+
+Both reviews are cluster-scoped resources with no namespaced form, so those
+rules are a **ClusterRole even under `rbac.clusterWide: false`** — the one place
+a namespace-scoped install still creates cluster-scoped RBAC. With metrics off,
+or with `metrics.secure: false`, a namespace-scoped install creates nothing
+cluster-scoped at all. What is granted is delegation — the right to ask the API
+server whether a caller is allowed in — not access to anything that caller
+holds.
+
+The chart creates a `<release>-metrics-reader` ClusterRole and **deliberately
+does not bind it**. It cannot know which ServiceAccount your Prometheus scrapes
+with, and a binding to the wrong one looks granted and is not:
+
+```sh
+kubectl create clusterrolebinding reactor-metrics-reader \
+  --clusterrole=reactor-metrics-reader \
+  --serviceaccount=monitoring:prometheus-k8s
+```
+
+The controller generates a self-signed certificate for the endpoint unless
+`--metrics-cert-path` points at a real one, so the ServiceMonitor ships with
+`insecureSkipVerify: true`. Issue a certificate and set
+`metrics.serviceMonitor.serverName` to turn verification on. Setting
+`metrics.secure: false` serves plain HTTP instead, which only makes sense when
+something else already controls who can reach the pod.
+
+`metrics.serviceMonitor.labels` is optional on purpose: a Prometheus whose
+`serviceMonitorSelector` is `{}` scrapes every ServiceMonitor and needs none of
+them.
+
+### What is measured
+
+The decision layer — what Reactor observed, what matched, what it did, and how
+fast. Raw UniFi telemetry is deliberately **not** re-exported; a UniFi exporter
+covers that better, and duplicating it would only produce two numbers to
+disagree about. Reconcile counts, workqueue depth and reconcile latency come
+from controller-runtime's own `controller_runtime_*` series on the same
+endpoint.
+
+The metric worth alerting on above all others:
+
+```promql
+time() - reactor_last_observation_timestamp_seconds > 90
+```
+
+`reactor_actions_total` carries a `kind` label of `desired_state` or `edge`, and
+no alert should be written without it. A failed `kubernetes.scale` means the
+cluster is not in the state you asked for; a failed notification means nobody
+was told, while the workload was still scaled and the Automation is still
+`Ready`.
+
+### Cardinality
+
+`reactor_state_info{provider,key,value}` is published **only for state keys
+whose value set the provider declares closed** — `wan`, `ups`, `ups.battery`.
+`isp` is not one of them: its values are carrier slugs derived from whatever
+public address your gateway holds, so labelling by them would add one permanent
+time series per carrier ever seen. `reactor_state_transitions_total` is not
+labelled by `from`/`to` for the same reason.
+
+Nothing is lost: what a key currently holds is in the Automation's
+`status.observedState` and in an Event on the resource. Prometheus keeps the
+counts; Kubernetes keeps the detail.
+
+The `namespace`/`name` labels on `reactor_automation_*` are safe for a different
+reason — a series appears only when someone writes another Automation, and a
+deleted one's series are dropped rather than left reporting forever.
+
+### Alert rules
+
+`metrics.rules.enabled` ships a `PrometheusRule` (needs the Prometheus Operator
+CRD). `metrics.rules.observationStaleSeconds` defaults to `90`, three times the
+default `unifi.pollInterval` — **raise it if you raise that**, or a slower poll
+will page you.
+
+| Alert | Severity | Means |
+| --- | --- | --- |
+| `ReactorObservationStale` | critical | Reactor has gone blind; every Automation has silently stopped reacting |
+| `ReactorObservationAbsent` | critical | it is publishing no observations at all, or is not running |
+| `ReactorObservationFailing` | warning | sustained poll errors — the warning before the two above |
+| `ReactorActionFailing` | warning | an Automation matched but could not act on its target |
+| `ReactorEdgeActionFailing` | warning | a notification or HTTP call did not go out; the Automation is unaffected |
+| `ReactorAutomationNotReady` | warning | invalid config, a missing state key, or a failed action |
+| `ReactorReactionSlow` | warning | p95 observation-to-action above `metrics.rules.reactionLatencySeconds` |
+| `ReactorUPSOnBattery` | info | the UPS is running on battery |
+| `ReactorWANOnBackup` | info | the gateway is on its backup uplink |
+
+The last two fire on observed state rather than on a fault: they are how your
+existing alerting learns what your network already knows. Set
+`metrics.rules.informational: false` to leave them out.
+
+### Dashboard
+
+`metrics.dashboard.enabled` ships a grafana-operator `GrafanaDashboard`. It pins
+no datasource — the dashboard carries a `datasource` variable you pick when you
+open it — and no folder or tag specific to any organisation, so the same JSON
+imports into any Grafana unedited. It is a plain file in the chart at
+`dashboards/reactor.json` if you would rather import it by hand.
+
+`metrics.dashboard.instanceSelector` decides which Grafana instances
+grafana-operator installs it into; it defaults to
+`matchLabels: {dashboards: grafana}`, the operator's own convention.
+
+All three of `serviceMonitor`, `rules` and `dashboard` refuse to render without
+`metrics.enabled`, rather than shipping something that queries series nothing is
+publishing — which fails as silence rather than as an error.
+
 ## Values
 
 | Key | Default | Description |
@@ -411,6 +560,25 @@ networkPolicy:
 | `unifi.existingSecret` | `unifi-reactor-credentials` | Secret containing `UNIFI_API_KEY`, mounted and re-read per poll |
 | `log.level` | `info` | `debug`, `info`, `error`, or a V-level number |
 | `log.format` | `console` | `console` or `json` |
+| `metrics.enabled` | `false` | Serve `/metrics`; see [Metrics, alerts and a dashboard](#metrics-alerts-and-a-dashboard-optional-off-by-default) |
+| `metrics.secure` | `true` | HTTPS behind the API server's authn/authz filter; `false` serves plain HTTP |
+| `metrics.port` | `8443` | Port the endpoint listens on inside the pod |
+| `metrics.service.enabled` | `true` | Create a ClusterIP Service for it |
+| `metrics.service.port` | `8443` | Service port |
+| `metrics.reader.create` | `true` | Create an unbound ClusterRole granting `get` on `/metrics` |
+| `metrics.serviceMonitor.enabled` | `false` | Scrape it with the Prometheus Operator |
+| `metrics.serviceMonitor.interval` | `""` | Empty inherits the Prometheus instance's default |
+| `metrics.serviceMonitor.labels` | `{}` | Optional — a `serviceMonitorSelector` of `{}` needs none |
+| `metrics.serviceMonitor.insecureSkipVerify` | `true` | The endpoint's certificate is self-signed unless you issue one |
+| `metrics.serviceMonitor.serverName` | `""` | Set alongside a real certificate to verify it |
+| `metrics.rules.enabled` | `false` | Ship the alert rules as a `PrometheusRule` |
+| `metrics.rules.observationStaleSeconds` | `90` | 3 × `unifi.pollInterval`; raise it if you raise that |
+| `metrics.rules.reactionLatencySeconds` | `60` | p95 observation-to-action above which reacting is too slow |
+| `metrics.rules.informational` | `true` | Include `ReactorUPSOnBattery` and `ReactorWANOnBackup` |
+| `metrics.rules.labels` | `{}` | Extra labels, for a Prometheus that selects on them |
+| `metrics.dashboard.enabled` | `false` | Ship the dashboard as a grafana-operator `GrafanaDashboard` |
+| `metrics.dashboard.instanceSelector` | `{matchLabels: {dashboards: grafana}}` | Which Grafana instances to install it into |
+| `metrics.dashboard.folder` | `""` | Grafana folder; empty means the instance's default |
 | `podDisruptionBudget.enabled` | `false` | see [PodDisruptionBudget](#poddisruptionbudget) before enabling with one replica |
 | `podDisruptionBudget.minAvailable` | `1` | set this or `maxUnavailable`, not both |
 | `networkPolicy.enabled` | `false` | deny all ingress and apply `networkPolicy.egress` |

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -412,6 +412,43 @@ networkPolicy:
         - { protocol: TCP, port: 8443 }
 ```
 
+## Events
+
+Every transition, every write to a target, every action that failed is raised as
+a Kubernetes Event on the Automation, so `kubectl describe automation` tells the
+story of a failover without anyone needing log access:
+
+```sh
+kubectl -n media describe automation pause-qbittorrent-on-backup-wan | tail -20
+```
+
+Nothing to enable. Two things are worth knowing.
+
+**The RBAC changed in this release.** Reactor records through the
+**`events.k8s.io/v1`** API, not the deprecated core one. They share storage but
+are separate API groups for authorization, so the previous rule — which named
+only `apiGroups: [""]` — was refused on every emission. The refusal is logged by
+the event broadcaster inside the controller and surfaced nowhere else, so the
+symptom was an Automation with no Events at all, which reads as nothing having
+happened. Upgrading fixes it; hand-written RBAC copied from an older chart needs
+the same change:
+
+```sh
+kubectl auth can-i create events.events.k8s.io --namespace media \
+  --as system:serviceaccount:reactor-system:reactor
+```
+
+**Events fire on edges, not on states.** A reconcile happens at least every 15
+seconds, so anything raised from a steady condition would be an API write every
+15 seconds per Automation. A target already at the right value produces nothing;
+a condition still reporting the same reason produces nothing after the first;
+`ActionFailed` stops at the retry budget. An old timestamp on a Warning means
+"still true since then", not "stale" — `status.conditions` is what is true now.
+
+`Normal` and `Warning` are used deliberately rather than as a severity dial.
+Being outvoted by a more restrictive claim is `Normal`, because that is how two
+Automations sharing a workload are meant to behave.
+
 ## Metrics, alerts and a dashboard (optional, off by default)
 
 Reactor's worst failure mode is silent: if it stops observing, every Automation

--- a/charts/reactor/dashboards/reactor.json
+++ b/charts/reactor/dashboards/reactor.json
@@ -1,0 +1,398 @@
+{
+  "uid": "unifi-reactor-overview",
+  "title": "UniFi Reactor",
+  "description": "What Reactor observed, what matched, what it did, and how fast. Pick your Prometheus in the datasource variable; nothing here is pinned to a particular instance.",
+  "tags": ["unifi-reactor"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "refresh": "30s",
+  "time": { "from": "now-6h", "to": "now" },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "label": "Prometheus",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {},
+        "hide": 0,
+        "refresh": 1
+      }
+    ]
+  },
+  "annotations": {
+    "list": [
+      {
+        "name": "State transitions",
+        "enable": true,
+        "iconColor": "purple",
+        "datasource": { "type": "prometheus", "uid": "${datasource}" },
+        "expr": "sum by (key) (increase(reactor_state_transitions_total[1m])) > 0",
+        "titleFormat": "{{key}} changed",
+        "textFormat": "A state key moved, so what every Automation matching on it wants may have changed",
+        "step": "60s"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "WAN",
+      "description": "The uplink the gateway is currently using. No data means the key is not observable — see StateKeyUnavailable.",
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "reactor_state_info{key=\"wan\"} == 1",
+          "legendFormat": "{{value}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "textMode": "name",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "primary": { "text": "primary", "color": "green", "index": 0 } } },
+            { "type": "value", "options": { "backup": { "text": "backup", "color": "orange", "index": 1 } } }
+          ],
+          "color": { "mode": "fixed", "fixedColor": "text" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "UPS",
+      "description": "Whether a UniFi UPS is on mains or running on battery. No data means no UPS is adopted, or it dropped off the console.",
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "reactor_state_info{key=\"ups\"} == 1",
+          "legendFormat": "{{value}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "textMode": "name",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "online": { "text": "online", "color": "green", "index": 0 } } },
+            { "type": "value", "options": { "on-battery": { "text": "on battery", "color": "red", "index": 1 } } }
+          ],
+          "color": { "mode": "fixed", "fixedColor": "text" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Battery",
+      "description": "Remaining charge against the configured low and critical thresholds.",
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "reactor_state_info{key=\"ups.battery\"} == 1",
+          "legendFormat": "{{value}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "textMode": "name",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "normal": { "text": "normal", "color": "green", "index": 0 } } },
+            { "type": "value", "options": { "low": { "text": "low", "color": "orange", "index": 1 } } },
+            { "type": "value", "options": { "critical": { "text": "critical", "color": "red", "index": 2 } } }
+          ],
+          "color": { "mode": "fixed", "fixedColor": "text" }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Observation age",
+      "description": "How long since Reactor last saw anything. This is the number that tells you it has gone blind — every Automation silently stops reacting, and nothing else in the cluster notices.",
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "time() - max by (provider) (reactor_last_observation_timestamp_seconds)",
+          "legendFormat": "{{provider}}",
+          "instant": true
+        }
+      ],
+      "options": {
+        "textMode": "auto",
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "color": { "mode": "thresholds" },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 60 },
+              { "color": "red", "value": 90 }
+            ]
+          }
+        },
+        "overrides": []
+      }
+    },
+    {
+      "id": 5,
+      "type": "timeseries",
+      "title": "Reaction latency",
+      "description": "Observation to action completion. The end-to-end number: polling cadence, wake queue, reconcile and the write to the target, all in one.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.5, sum by (le, provider) (rate(reactor_reaction_latency_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p50 {{provider}}"
+        },
+        {
+          "refId": "B",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.95, sum by (le, provider) (rate(reactor_reaction_latency_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p95 {{provider}}"
+        },
+        {
+          "refId": "C",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "histogram_quantile(0.99, sum by (le, provider) (rate(reactor_reaction_latency_seconds_bucket[$__rate_interval])))",
+          "legendFormat": "p99 {{provider}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "fillOpacity": 0, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    },
+    {
+      "id": 6,
+      "type": "timeseries",
+      "title": "Observations",
+      "description": "Poll success and failure rate. Sustained failures are the early warning for the observation going stale.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 4 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider, result) (rate(reactor_observations_total[$__rate_interval]))",
+          "legendFormat": "{{provider}} {{result}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*error.*" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    },
+    {
+      "id": 7,
+      "type": "timeseries",
+      "title": "Actions",
+      "description": "Executions by type and outcome, split by whether the Automation was claiming or reversing.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (type, result, on_exit) (rate(reactor_actions_total[$__rate_interval]))",
+          "legendFormat": "{{type}} {{result}} on_exit={{on_exit}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byRegexp", "options": ".*error.*" },
+            "properties": [{ "id": "color", "value": { "mode": "fixed", "fixedColor": "red" } }]
+          }
+        ]
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    },
+    {
+      "id": 8,
+      "type": "timeseries",
+      "title": "Arbitration outcomes",
+      "description": "How a target resolved each pass: claimed at what this Automation asked for, deferred to a peer's more restrictive claim, or released because nothing claims it any more. A steady rate of deferrals is two Automations sharing a workload working as designed.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (outcome) (rate(reactor_arbitrations_total[$__rate_interval]))",
+          "legendFormat": "{{outcome}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    },
+    {
+      "id": 9,
+      "type": "timeseries",
+      "title": "State transitions",
+      "description": "How often each key actually moves. Not labelled by value on purpose: one key with an open value set would make this unbounded.",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (provider, key) (increase(reactor_state_transitions_total[$__rate_interval]))",
+          "legendFormat": "{{key}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    },
+    {
+      "id": 10,
+      "type": "timeseries",
+      "title": "Automations matching",
+      "description": "Which policies are in force right now. Read alongside the transition annotations: a shed and its recovery are the same line going down and back up.",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 20 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "reactor_automation_matching",
+          "legendFormat": "{{namespace}}/{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "max": 1,
+          "min": 0,
+          "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 20, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    },
+    {
+      "id": 11,
+      "type": "timeseries",
+      "title": "Automations not ready",
+      "description": "Invalid configuration, a provider not reporting a key, or an action that failed. Being outvoted on a shared target is not here — that is Applied, and it is healthy.",
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "reactor_automation_ready == 0",
+          "legendFormat": "{{namespace}}/{{name}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": { "drawStyle": "line", "lineInterpolation": "stepAfter", "fillOpacity": 20, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    },
+    {
+      "id": 12,
+      "type": "timeseries",
+      "title": "Webhook deliveries",
+      "description": "Fast-path deliveries from the console's Alarm Manager. Empty unless unifi.webhook.enabled; losing these costs reaction latency and nothing else.",
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 28 },
+      "datasource": { "type": "prometheus", "uid": "${datasource}" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "type": "prometheus", "uid": "${datasource}" },
+          "expr": "sum by (result) (rate(reactor_webhook_deliveries_total[$__rate_interval]))",
+          "legendFormat": "{{result}}"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps",
+          "custom": { "fillOpacity": 10, "lineWidth": 2, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "options": { "legend": { "displayMode": "list", "placement": "bottom", "showLegend": true } }
+    }
+  ]
+}

--- a/charts/reactor/templates/deployment.yaml
+++ b/charts/reactor/templates/deployment.yaml
@@ -52,6 +52,13 @@ spec:
             - --health-probe-bind-address=:8081
             - --zap-log-level={{ .Values.log.level }}
             - --zap-encoder={{ .Values.log.format }}
+            {{- if .Values.metrics.enabled }}
+            # Left unset, the binary defaults to 0 — no listener at all.
+            - --metrics-bind-address=:{{ .Values.metrics.port }}
+            {{- if not .Values.metrics.secure }}
+            - --metrics-secure=false
+            {{- end }}
+            {{- end }}
           env:
             {{- include "reactor.watchNamespaceEnv" . | nindent 12 }}
             {{- if .Values.unifi.url }}
@@ -134,6 +141,10 @@ spec:
           ports:
             - name: healthz
               containerPort: 8081
+            {{- if .Values.metrics.enabled }}
+            - name: {{ if .Values.metrics.secure }}https{{ else }}http{{ end }}
+              containerPort: {{ .Values.metrics.port }}
+            {{- end }}
             {{- if .Values.unifi.webhook.enabled }}
             - name: webhook
               containerPort: {{ .Values.unifi.webhook.port }}

--- a/charts/reactor/templates/grafanadashboard.yaml
+++ b/charts/reactor/templates/grafanadashboard.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.metrics.dashboard.enabled }}
+{{- if not .Values.metrics.enabled }}
+{{- fail "metrics.dashboard.enabled needs metrics.enabled: every panel would query series nothing is publishing" }}
+{{- end }}
+# Needs grafana-operator's GrafanaDashboard CRD.
+#
+# The JSON is a chart file rather than an inline blob, so it can be linted,
+# diffed and imported by hand: charts/reactor/dashboards/reactor.json. It pins
+# no datasource — the dashboard carries a `datasource` variable you pick on
+# open — and carries no organisation-specific tag or folder, so importing it
+# into any Grafana works without editing it first.
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: {{ include "reactor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+spec:
+  instanceSelector:
+    {{- toYaml .Values.metrics.dashboard.instanceSelector | nindent 4 }}
+  allowCrossNamespaceImport: {{ .Values.metrics.dashboard.allowCrossNamespaceImport }}
+  resyncPeriod: {{ .Values.metrics.dashboard.resyncPeriod | quote }}
+  {{- with .Values.metrics.dashboard.folder }}
+  folder: {{ . | quote }}
+  {{- end }}
+  json: |
+{{ .Files.Get "dashboards/reactor.json" | indent 4 }}
+{{- end }}

--- a/charts/reactor/templates/metrics.yaml
+++ b/charts/reactor/templates/metrics.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.metrics.enabled }}
+{{- $portName := ternary "https" "http" .Values.metrics.secure }}
+# The metrics endpoint, and the permissions that guard it.
+#
+# Reactor publishes what it observed, what matched, what it did and how fast —
+# the decision layer. Raw UniFi telemetry is deliberately not re-exported.
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "reactor.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+  {{- with .Values.metrics.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "reactor.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: {{ $portName }}
+      port: {{ .Values.metrics.service.port }}
+      targetPort: {{ $portName }}
+      protocol: TCP
+{{- if .Values.metrics.secure }}
+---
+# The authn/authz filter in front of the endpoint asks the API server to
+# authenticate the scraper's bearer token and to authorize it.
+#
+# Both reviews are cluster-scoped resources with no namespaced form, so this is
+# a ClusterRole even under rbac.clusterWide: false — the one place a
+# namespace-scoped install still creates cluster-scoped RBAC. It is worth
+# knowing rather than hiding: an install that must create nothing cluster-scoped
+# can set metrics.secure: false and restrict who can reach the port some other
+# way. What is granted here is delegation — the right to ask the API server
+# whether a caller is allowed in — not access to anything the caller holds.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "reactor.fullname" . }}-metrics-auth
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["authentication.k8s.io"]
+    resources: ["tokenreviews"]
+    verbs: ["create"]
+  - apiGroups: ["authorization.k8s.io"]
+    resources: ["subjectaccessreviews"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "reactor.fullname" . }}-metrics-auth
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "reactor.fullname" . }}-metrics-auth
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "reactor.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- if .Values.metrics.reader.create }}
+---
+# Deliberately unbound: this grants nothing until you bind it to whatever
+# ServiceAccount your Prometheus scrapes with. Creating the binding here would
+# mean guessing that name, and guessing wrong opens the endpoint to nobody
+# while looking like it works.
+#
+#   kubectl create clusterrolebinding reactor-metrics-reader \
+#     --clusterrole={{ include "reactor.fullname" . }}-metrics-reader \
+#     --serviceaccount=<prometheus namespace>:<prometheus service account>
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "reactor.fullname" . }}-metrics-reader
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+rules:
+  - nonResourceURLs: ["/metrics"]
+    verbs: ["get"]
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/reactor/templates/prometheusrule.yaml
+++ b/charts/reactor/templates/prometheusrule.yaml
@@ -1,0 +1,145 @@
+{{- if .Values.metrics.rules.enabled }}
+{{- if not .Values.metrics.enabled }}
+{{- fail "metrics.rules.enabled needs metrics.enabled: the rules below alert on series nothing would be publishing" }}
+{{- end }}
+# Needs the Prometheus Operator's PrometheusRule CRD.
+#
+# The first rule is the one that matters. Reactor's failure mode is silent and
+# fail-open: if it stops observing — an expired API key, a rebooted console, a
+# network partition — every Automation quietly stops reacting, and nothing in
+# the cluster notices until the next real outage is not handled.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ include "reactor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+    {{- with .Values.metrics.rules.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ include "reactor.fullname" . }}.health
+      rules:
+        - alert: ReactorObservationStale
+          expr: time() - reactor_last_observation_timestamp_seconds > {{ .Values.metrics.rules.observationStaleSeconds }}
+          for: 2m
+          labels:
+            severity: critical
+          annotations:
+            summary: Reactor has gone blind to {{`{{ $labels.provider }}`}} state
+            description: >-
+              No successful observation for {{`{{ $value | humanizeDuration }}`}}.
+              Every Automation driven by {{`{{ $labels.provider }}`}} has silently stopped
+              reacting and is holding its last known state.
+
+        {{- if .Values.unifi.url }}
+        - alert: ReactorObservationAbsent
+          expr: absent(reactor_last_observation_timestamp_seconds)
+          for: 10m
+          labels:
+            severity: critical
+          annotations:
+            summary: Reactor is publishing no observations at all
+            description: >-
+              The provider is configured but has never reported an observation, or the
+              controller is not running. Nothing is reacting to network or power state.
+        {{- end }}
+
+        - alert: ReactorObservationFailing
+          expr: sum by (provider) (rate(reactor_observations_total{result="error"}[10m])) > 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Reactor keeps failing to observe {{`{{ $labels.provider }}`}}
+            description: >-
+              Observations have been failing for 15 minutes. State is still converging
+              on whichever polls succeed, so this is the warning before
+              ReactorObservationStale rather than an outage on its own.
+
+        # Split by kind rather than by type, because the two fail differently
+        # and an alert that conflated them would be wrong about what broke. A
+        # desired-state action is the thing the Automation is for; an edge
+        # action is the report of it, and a report that did not go out did not
+        # stop the workload being scaled.
+        - alert: ReactorActionFailing
+          expr: increase(reactor_actions_total{kind="desired_state",result="error"}[15m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: A Reactor {{`{{ $labels.type }}`}} action keeps failing
+            description: >-
+              An Automation matched but could not act on its target, so the cluster is
+              not in the state the policy asks for. Retries stop after five consecutive
+              failures; the Automation's Applied condition and its Events carry the error.
+
+        - alert: ReactorEdgeActionFailing
+          expr: increase(reactor_actions_total{kind="edge",result="error"}[15m]) > 0
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: A Reactor {{`{{ $labels.type }}`}} notification is not being delivered
+            description: >-
+              An outbound action did not reach its destination. The Automation itself is
+              unaffected and stays healthy — the workload was still acted on, nobody was
+              told. Usual causes are a destination missing from actions.allowedDestinations,
+              a wrong credential in the referenced Secret, or an endpoint that is down.
+
+        - alert: ReactorAutomationNotReady
+          expr: reactor_automation_ready == 0
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Automation {{`{{ $labels.namespace }}/{{ $labels.name }}`}} is not ready
+            description: >-
+              Invalid configuration, a provider not reporting a key it needs, or an
+              action that failed. kubectl describe automation
+              {{`{{ $labels.name }}`}} -n {{`{{ $labels.namespace }}`}} tells the whole story.
+
+        - alert: ReactorReactionSlow
+          expr: >-
+            histogram_quantile(0.95, sum by (le, provider) (rate(reactor_reaction_latency_seconds_bucket[30m])))
+            > {{ .Values.metrics.rules.reactionLatencySeconds }}
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Reactor is taking {{`{{ $value | humanizeDuration }}`}} to act on what it observes
+            description: >-
+              95th-percentile time from an observation to the action it caused. Well
+              above one poll interval means the reconciler is not keeping up, not that
+              polling is slow.
+
+{{- if and .Values.metrics.rules.informational .Values.unifi.url }}
+    # These fire on observed state rather than on a fault: they are how the
+    # cluster's alerting learns what the network already knows.
+    - name: {{ include "reactor.fullname" . }}.state
+      rules:
+        - alert: ReactorUPSOnBattery
+          expr: reactor_state_info{key="ups",value="on-battery"} == 1
+          for: 1m
+          labels:
+            severity: info
+          annotations:
+            summary: The UPS is running on battery
+            description: >-
+              Mains power is out. Automations matching ups: on-battery are in force;
+              ups.battery reports how much runtime is left.
+
+        - alert: ReactorWANOnBackup
+          expr: reactor_state_info{key="wan",value="backup"} == 1
+          for: 1m
+          labels:
+            severity: info
+          annotations:
+            summary: The WAN is on its backup uplink
+            description: >-
+              The gateway is carrying traffic over the backup uplink, which is usually
+              metered. Automations matching wan: backup are in force.
+{{- end }}
+{{- end }}

--- a/charts/reactor/templates/rbac.yaml
+++ b/charts/reactor/templates/rbac.yaml
@@ -31,11 +31,18 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch", "update", "patch"]
-  # Warning Events on the Automations themselves — notably when deletion gives
-  # up handing a target back. Automations live in the namespaces they act on,
-  # so this has to follow the same scope as the rest of the manager's rules
+  # Events on the Automations themselves: every transition, every write to a
+  # target, every action that failed. Automations live in the namespaces they
+  # act on, so this follows the same scope as the rest of the manager's rules
   # rather than the release namespace only.
-  - apiGroups: [""]
+  #
+  # events.k8s.io, not "". The manager records through the events.k8s.io/v1 API
+  # — the two share storage but are separate API groups for authorization, so a
+  # rule naming only "" is refused on every emission, logged by the broadcaster
+  # and surfaced nowhere: the Automation simply has no Events, which reads as
+  # nothing having happened. Leader election is the one thing here still using
+  # the core/v1 recorder, and its own Role already grants it.
+  - apiGroups: ["events.k8s.io"]
     resources: ["events"]
     verbs: ["create", "patch"]
 {{- if .Values.actions.allowedDestinations }}

--- a/charts/reactor/templates/servicemonitor.yaml
+++ b/charts/reactor/templates/servicemonitor.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if not .Values.metrics.enabled }}
+{{- fail "metrics.serviceMonitor.enabled needs metrics.enabled: there is no endpoint to scrape" }}
+{{- end }}
+# Needs the Prometheus Operator's ServiceMonitor CRD.
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "reactor.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.metrics.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      {{- include "reactor.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: {{ ternary "https" "http" .Values.metrics.secure }}
+      path: /metrics
+      scheme: {{ ternary "https" "http" .Values.metrics.secure }}
+      {{- with .Values.metrics.serviceMonitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.metrics.serviceMonitor.scrapeTimeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+      {{- if .Values.metrics.secure }}
+      # The endpoint authenticates the scraper, so it has to present one.
+      bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+      tlsConfig:
+        insecureSkipVerify: {{ .Values.metrics.serviceMonitor.insecureSkipVerify }}
+        {{- with .Values.metrics.serviceMonitor.serverName }}
+        serverName: {{ . | quote }}
+        {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -146,6 +146,78 @@ log:
   # "console" for human-readable logs, "json" for a log collector.
   format: console
 
+# What Reactor observed, what matched, what it did, and how fast — on the
+# metrics endpoint controller-runtime already serves. Reactor deliberately does
+# not re-export UniFi telemetry; a UniFi exporter covers that better.
+#
+# Off by default, because enabling it opens a port on the pod and creates a
+# Service, and an upgrade must never do either on its own. The manifest bundle
+# (install.yaml) turns it on; everything below renders the same shape in both
+# paths, so the only difference between them is this default.
+metrics:
+  enabled: false
+  # Serve over HTTPS behind the API server's authn/authz filter, so a scraper
+  # must present a bearer token whose ServiceAccount is allowed to GET /metrics.
+  # Set false to serve plain HTTP on the same port instead — only sensible when
+  # something else already restricts who can reach the pod.
+  secure: true
+  port: 8443
+
+  service:
+    enabled: true
+    port: 8443
+    annotations: {}
+
+  # A ClusterRole granting GET on /metrics, created with no binding: nothing
+  # gains access until you bind it to your Prometheus ServiceAccount.
+  reader:
+    create: true
+
+  # Requires the Prometheus Operator's ServiceMonitor CRD.
+  serviceMonitor:
+    enabled: false
+    # Leave empty to inherit the Prometheus instance's defaults.
+    interval: ""
+    scrapeTimeout: ""
+    # Extra labels, for a Prometheus whose serviceMonitorSelector is not empty.
+    # Optional on purpose: a selector of {} scrapes every ServiceMonitor and
+    # needs none of these.
+    labels: {}
+    annotations: {}
+    # The controller generates a self-signed certificate for the metrics server
+    # unless --metrics-cert-path points at a real one, so verification is off by
+    # default. Issue a certificate and set serverName to turn it on.
+    insecureSkipVerify: true
+    serverName: ""
+
+  # Alert rules, as a PrometheusRule. Requires the Prometheus Operator CRD.
+  rules:
+    enabled: false
+    labels: {}
+    # How long without a successful observation counts as blind. Three times
+    # unifi.pollInterval, in seconds — raise this if you raise that.
+    observationStaleSeconds: 90
+    # p95 observation-to-action latency, in seconds, above which reacting is
+    # taking longer than it should. Comfortably above one poll interval.
+    reactionLatencySeconds: 60
+    # Informational rules that fire on observed state rather than on a fault —
+    # the UPS running on battery, the WAN on its backup uplink. They name UniFi
+    # state keys, so they are only rendered when unifi.url is set.
+    informational: true
+
+  # The overview dashboard, as a grafana-operator GrafanaDashboard. The same
+  # JSON is in the chart at dashboards/reactor.json if you import by hand.
+  dashboard:
+    enabled: false
+    # Which Grafana instances grafana-operator should install it into.
+    instanceSelector:
+      matchLabels:
+        dashboards: grafana
+    # Grafana folder to file it under. Empty means the instance's default.
+    folder: ""
+    allowCrossNamespaceImport: false
+    resyncPeriod: 10m
+
 uninstall:
   # Before the operator is removed, hand every workload it is holding back to
   # what your Automations want once nothing claims them. Helm does not delete

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/robbeverhelst/unifi-reactor/internal/actions"
 	"github.com/robbeverhelst/unifi-reactor/internal/controller"
 	"github.com/robbeverhelst/unifi-reactor/internal/engine"
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 	"github.com/robbeverhelst/unifi-reactor/internal/providers/unifi"
 	// +kubebuilder:scaffold:imports
 )
@@ -427,6 +428,12 @@ func setupUniFi(mgr ctrl.Manager, cfg unifi.Config, store *engine.StateStore, wa
 	unifiClient := unifi.NewClient(cfg.URL, cfg.APIKey, cfg.Site, cfg.InsecureSkipVerify)
 	unifiClient.LowBatteryPercent = cfg.LowBatteryPercent
 	unifiClient.CriticalBatteryPercent = cfg.CriticalBatteryPercent
+
+	// What this provider's keys can hold, so reactor_state_info can report 0 for
+	// the values a key does not currently have instead of leaving a stale series
+	// at 1. Handed over as opaque data: the metrics package never learns what any
+	// of it means, only how many series there can be.
+	metrics.SetVocabulary(unifi.ProviderName, unifi.StateVocabulary())
 
 	// What the console is running, logged once at startup. It is added before
 	// the poller so that when a moved field makes an observation come back

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,13 +7,6 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
   - secrets
   verbs:
   - get
@@ -27,6 +20,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - reactor.robbeverhelst.com
   resources:

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -225,6 +225,15 @@ The UniFi provider breaks this rule exactly once, and the shape of the exception
 
 **Omit unobservable keys entirely**, as described above.
 
+**Declare the closed value sets, and leave the open ones out.** `StateVocabulary()`
+in `state.go` returns key → values for every key whose values you can enumerate.
+It is what lets `reactor_state_info` report `0` for the values a key does not
+currently hold instead of leaving a stale series at `1`, and — more importantly —
+it is what keeps a key with an *open* value set from ever becoming a metric
+label. The UniFi provider leaves `isp` out for exactly that reason: one time
+series per carrier ever geolocated is how a Prometheus instance gets hurt. If
+you break the closed-set rule for a key, break it here too.
+
 **Key names are a compatibility promise.** They appear in user YAML. Renaming one breaks every Automation using it. Choose as if you cannot rename — because you cannot.
 
 ## Fixtures: capture, allowlist, commit
@@ -251,14 +260,14 @@ Three layers, all runnable with `make test` and none needing hardware:
 
 ## Checklist
 
-- [ ] `internal/providers/<name>/state.go` — `ProviderName` plus unexported key and value constants
+- [ ] `internal/providers/<name>/state.go` — `ProviderName`, unexported key and value constants, and `StateVocabulary()` for the keys whose values are a closed set
 - [ ] `internal/providers/<name>/client.go` — `Observe(ctx) (map[string]string, error)`, transport split from derivation
 - [ ] `internal/providers/<name>/config.go` — `ConfigFromEnv(lookup)`, so the environment mapping is tested rather than reviewed
 - [ ] `hack/capture-<name>.sh` — allowlist-first capture, placeholders for anything identifying
 - [ ] `testdata/<name>/` fixtures plus a README recording hardware, version, and inferred mappings
 - [ ] `hack/verify-testdata.sh` extended with the new provider's secret-bearing fields
 - [ ] `internal/controller/<name>_poller.go` — `Runnable`, `NeedLeaderElection() true`, non-blocking wake
-- [ ] `cmd/main.go` — construct only when configured, log clearly when disabled, share `store` and `wake`; anything optional fails soft while the poller is added regardless
+- [ ] `cmd/main.go` — construct only when configured, log clearly when disabled, share `store` and `wake`, call `metrics.SetVocabulary`; anything optional fails soft while the poller is added regardless
 - [ ] `charts/reactor/values.yaml` and `templates/deployment.yaml` — config values and env, credentials mounted as a directory and pointed at by a `*_FILE` variable
 - [ ] Tests at all three layers
 - [ ] Docs: the state-key table in `README.md` and `charts/reactor/README.md`

--- a/docs/development.md
+++ b/docs/development.md
@@ -196,6 +196,35 @@ This is allowlist rather than denylist for a reason: `stat/device` returns whole
 
 `hack/webhook-logger.mjs` dumps incoming webhook deliveries verbatim to `testdata/unifi/webhooks/raw/` (gitignored) when capturing from a real Alarm Manager. Apply the same allowlist discipline before committing any of it.
 
+## Metrics
+
+`make dev-deploy` leaves the metrics endpoint off, the same as a chart install.
+Turn it on and read it without a Prometheus:
+
+```sh
+make dev-deploy DEV_CONTEXT=kind-reactor \
+  UNIFI_URL=http://<your-host>:9443 UNIFI_API_KEY=mock \
+  HELM_EXTRA_ARGS="--set metrics.enabled=true --set metrics.secure=false"
+
+kubectl -n reactor-system port-forward deploy/reactor 8443:8443
+curl -s localhost:8443/metrics | grep '^reactor_'
+```
+
+`metrics.secure=false` is a development convenience: the real posture is HTTPS
+behind the API server's authn/authz filter, and a scrape needs a bearer token.
+
+Driving `make dev-mock` is the fastest way to see the decision-layer series
+move. `POST /flip` produces a `reactor_state_transitions_total` increment, a
+`reactor_state_info` flip, an action, and a `reactor_reaction_latency_seconds`
+observation, in that order.
+
+New metrics go in `internal/metrics/`, never in a controller or a provider —
+the definitions live in one file so the label decisions are reviewable in one
+place. Read the package comment before adding a label: the rule is that a label
+whose value set comes from the outside world does not go in. `reactor_state_info`
+enforces that structurally, by publishing only the keys whose provider declared
+a closed value set via `StateVocabulary`.
+
 ## Releasing
 
 Releases are cut entirely by CI from a tag; nothing is published from a developer machine.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -6,9 +6,12 @@ Reactor observes state and reconciles against it, so almost every problem is one
 
 ## Start here
 
-Three commands answer most questions:
+Four questions answer most problems, and the first one is the one nothing else can tell you:
 
 ```sh
+# 0. Is it still observing at all? (needs metrics.enabled — see §13)
+#    time() - reactor_last_observation_timestamp_seconds
+
 # 1. What does Reactor think is true?
 kubectl -n reactor-system logs deploy/reactor | grep -E 'state (observed|transition)'
 # INFO state transition provider=unifi key=wan from=primary to=backup
@@ -545,7 +548,79 @@ A destination is only ever reported as `scheme://host:port`. That is not a trunc
 
 ---
 
-## 13. Still stuck
+## 13. Reactor is running but nothing is reacting
+
+The failure this whole page cannot help with: Reactor is up, healthy, logging
+nothing unusual, and has silently stopped observing. Every Automation holds its
+last known state, no error is raised, and the next real outage is simply not
+handled. There is nothing to grep for, because nothing went wrong loudly.
+
+One number answers it, and it is why `metrics.enabled` exists:
+
+```promql
+time() - reactor_last_observation_timestamp_seconds
+```
+
+Above three poll intervals, Reactor is blind. `ReactorObservationStale` is that
+query with a threshold on it, and it is the alert to wire up before any other.
+
+Without metrics enabled, the same question by hand — the last line is the
+answer, and its timestamp is what matters:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor --timestamps   | grep -E 'state (observed|transition)' | tail -1
+```
+
+`state observed` needs `log.level=debug`; `state transition` only appears when
+something changed, so on a quiet network it can be hours old and still healthy.
+That ambiguity is exactly what the metric removes.
+
+### Turning the endpoint on
+
+```sh
+helm upgrade reactor ... --set metrics.enabled=true
+```
+
+It serves HTTPS on `:8443` behind the API server's authn/authz filter, so a
+scrape needs a token. Check it by hand from inside the cluster:
+
+```sh
+kubectl -n reactor-system exec deploy/reactor --   wget -qO- --no-check-certificate https://127.0.0.1:8443/metrics
+# 401 — expected: the endpoint authenticates every scrape, including this one
+```
+
+| What you see | Cause |
+| --- | --- |
+| `connection refused` | `metrics.enabled` is not set, so the binary is not listening at all |
+| Prometheus reports the target as `down` with a 401 or 403 | its ServiceAccount is not bound to the `<release>-metrics-reader` ClusterRole. The chart creates that role and deliberately does not bind it |
+| target `down` with a TLS error | the endpoint's certificate is self-signed unless you issue one; the shipped ServiceMonitor sets `insecureSkipVerify` |
+| the target is not discovered at all | `metrics.serviceMonitor.enabled` is off, or your Prometheus selects on labels the ServiceMonitor does not carry — see `metrics.serviceMonitor.labels` |
+| the target scrapes but there are no series | a `networkPolicy` with the default `ingress: []` denies the scrape; the chart does not widen it for you |
+
+### A state key you expected has no series
+
+`reactor_state_info` is published **only for keys whose value set is closed**.
+`isp` is deliberately absent: its values are carrier names, an open set, and one
+series per carrier ever seen is how a Prometheus instance gets hurt. Read `isp`
+off the Automation's `status.observedState` or its Events instead.
+
+A key that *is* declared but shows `0` for every value has not been observed —
+no UPS adopted, or the hardware dropped off. That is the metric side of
+[`StateKeyUnavailable`](#2-statekeyunavailable-and-held-state), and it is a
+different statement from "observed, and it is not that value".
+
+### `reactor_provider_signal_disagreements_total` is climbing
+
+Two independent signals for the same fact stopped agreeing. Nothing stops and
+no state is withheld — see
+[§10](#10-wan-and-isp-disagree-about-a-failover) for what each `signal` label
+means and why these are reported rather than resolved. The counter exists so a
+wrong `wan` derivation announces itself on a graph instead of waiting for
+somebody to read the logs during an outage.
+
+---
+
+## 14. Still stuck
 
 Collect these and open an issue — the [bug report template](https://github.com/robbeverhelst/unifi-reactor/issues/new/choose) asks for exactly this, and without it nothing is reproducible:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -77,6 +77,58 @@ Delete it. Event triggers never ran on any version, so nothing is lost, and noth
 
 ---
 
+## Reading the Event stream
+
+`kubectl describe automation <name>` ends with an Event list, and for most
+questions it is faster than anything else on this page — it needs no log
+access, and it is already in chronological order:
+
+```sh
+kubectl -n media describe automation pause-downloads-on-backup-wan | tail -20
+```
+
+| Reason | Type | Means |
+| --- | --- | --- |
+| `StateEntered` / `StateExited` | Normal | the condition started or stopped holding; the message names the key that moved |
+| `TargetScaled` / `TargetReleased` | Normal | a write to a target actually happened |
+| `DeferredToOtherAutomation` | Normal | a peer's more restrictive claim won — [§7](#7-two-automations-fighting-over-one-target) |
+| `EdgeActionSent` | Normal | a notification or HTTP request was delivered |
+| `StateKeyUnavailable` | Warning | a key vanished and state is being held — [§2](#2-statekeyunavailable-and-held-state) |
+| `ActionFailed` | Warning | a desired-state action could not be applied — [§5](#5-rbac-refuses-a-cross-namespace-target) |
+| `RetryBudgetExhausted` | Warning | Reactor stopped retrying and is waiting for the next state change |
+| `EdgeActionFailed` / `EdgeActionSkipped` | Warning | a notification or HTTP request did not go out — [§12](#12-a-notification-or-http-request-did-not-arrive) |
+| `ReleaseFailed` | Warning | deletion could not hand a target back and let the object go anyway — [§8](#8-a-workload-is-stuck-down-after-an-automation-was-deleted) |
+| `EventTriggerRemoved` | Warning | a leftover `spec.trigger` automation that does nothing; delete it |
+
+**Being outvoted is `Normal`, not a Warning.** Two Automations sharing a
+workload and one of them losing is the arbitration working as designed.
+
+**Events fire on edges, not on states.** A condition that has been held for an
+hour raised one Event when it started, not one every fifteen seconds — so an
+old timestamp on a Warning means "still true since then", not "stale". Read the
+Age column with that in mind, and read `status.conditions` for what is true
+*now*.
+
+**No Events at all** on an Automation that is clearly doing things has one
+likely cause: the operator's RBAC does not grant `create` and `patch` on
+`events` in the **`events.k8s.io`** API group. A rule naming only the core
+group (`""`) is refused on every emission, and the refusal is logged by the
+event broadcaster and surfaced nowhere else:
+
+```sh
+kubectl auth can-i create events.events.k8s.io \
+  --namespace media \
+  --as system:serviceaccount:reactor-system:reactor
+```
+
+Charts from this release on grant it. An operator installed from an older chart,
+or with hand-written RBAC copied from one, will be silent.
+
+**They expire.** Events live on your cluster's retention, an hour by default.
+They are for the incident you are in; `status` is the durable record.
+
+---
+
 ## 1. Nothing happens when the state changes
 
 Work down this list; it is ordered by likelihood.

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/go-logr/logr v1.4.3
 	github.com/onsi/ginkgo/v2 v2.27.4
 	github.com/onsi/gomega v1.39.0
+	github.com/prometheus/client_golang v1.23.2
 	k8s.io/api v0.36.0
 	k8s.io/apimachinery v0.36.0
 	k8s.io/client-go v0.36.0
@@ -41,12 +42,12 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/internal/controller/arbitration.go
+++ b/internal/controller/arbitration.go
@@ -33,6 +33,7 @@ import (
 
 	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
 	"github.com/robbeverhelst/unifi-reactor/internal/engine"
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 )
 
 const (
@@ -279,6 +280,7 @@ func (r *AutomationReconciler) reconcileTarget(
 		if outcome.desired != nil && *outcome.desired != value {
 			outcome.deferredBy = withoutClaimant(resolution.Winners, claimantOf(self))
 		}
+		metrics.ArbitrationResolved(outcomeOf(outcome))
 		changed, err := claimTarget(ctx, r.Client, &deployment, resolution, claims)
 		outcome.changed = changed
 		return outcome, err
@@ -291,6 +293,7 @@ func (r *AutomationReconciler) reconcileTarget(
 			value := int32(release.Level)
 			level = &value
 		}
+		metrics.ArbitrationResolved(metrics.OutcomeReleased)
 		changed, err := releaseTarget(ctx, r.Client, &deployment, level)
 		outcome.changed = changed
 		if changed {
@@ -308,11 +311,7 @@ func (r *AutomationReconciler) reconcileTarget(
 // timeoutFor bounds one attempt at a target, taken from the action this
 // Automation reaches it through.
 func timeoutFor(self *reactorv1alpha1.Automation, key targetKey, matching bool) time.Duration {
-	actions := self.Spec.Actions
-	if !matching {
-		actions = self.Spec.OnExit
-	}
-	for _, action := range actions {
+	for _, action := range actionsFor(self, matching) {
 		if !isDesiredState(action.Type) || action.TimeoutSeconds == nil {
 			continue
 		}
@@ -321,6 +320,41 @@ func timeoutFor(self *reactorv1alpha1.Automation, key targetKey, matching bool) 
 		}
 	}
 	return defaultActionTimeout
+}
+
+// actionTypeFor names the desired-state action this Automation reaches a target
+// through, so an execution is counted under the type that performed it rather
+// than under whichever type happens to be the only one implemented.
+func actionTypeFor(self *reactorv1alpha1.Automation, key targetKey, matching bool) string {
+	for _, action := range actionsFor(self, matching) {
+		if !isDesiredState(action.Type) {
+			continue
+		}
+		if k, ok := targetKeyFor(self, action); ok && k == key {
+			return action.Type
+		}
+	}
+	// Reached only through a target this Automation names on the other side of
+	// the transition, e.g. a reversal to baseline with no onExit entry.
+	return actionKubernetesScale
+}
+
+// actionsFor is the side of an Automation currently in play: what it asks for
+// while its condition holds, and what it wants back once it does not.
+func actionsFor(self *reactorv1alpha1.Automation, matching bool) []reactorv1alpha1.Action {
+	if matching {
+		return self.Spec.Actions
+	}
+	return self.Spec.OnExit
+}
+
+// outcomeOf reports how a claimed target resolved from this Automation's point
+// of view: it got what it wanted, or a more restrictive peer is holding it.
+func outcomeOf(outcome targetOutcome) string {
+	if len(outcome.deferredBy) > 0 {
+		return metrics.OutcomeDeferred
+	}
+	return metrics.OutcomeClaimed
 }
 
 // selfLevel is what the Automation being reconciled wants for a target, which

--- a/internal/controller/automation_controller.go
+++ b/internal/controller/automation_controller.go
@@ -39,6 +39,7 @@ import (
 	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
 	"github.com/robbeverhelst/unifi-reactor/internal/actions"
 	"github.com/robbeverhelst/unifi-reactor/internal/engine"
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 	"github.com/robbeverhelst/unifi-reactor/internal/providers/unifi"
 )
 
@@ -186,6 +187,10 @@ type evaluation struct {
 	missing []string
 	// known is false when the provider has never reported anything.
 	known bool
+	// observedAt is when the state this assessment was made against was
+	// observed, so a reaction can be measured from the observation that caused
+	// it rather than from the reconcile that noticed.
+	observedAt time.Time
 }
 
 // evaluate assesses an Automation's condition against the current observation.
@@ -202,6 +207,7 @@ func (r *AutomationReconciler) evaluate(automation *reactorv1alpha1.Automation) 
 		return assessment
 	}
 	assessment.known = true
+	assessment.observedAt = observation.ObservedAt
 
 	for key, want := range automation.Spec.When.State {
 		got, present := observation.State[key]
@@ -233,7 +239,12 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	var automation reactorv1alpha1.Automation
 	if err := r.Get(ctx, req.NamespacedName, &automation); err != nil {
-		return ctrl.Result{}, client.IgnoreNotFound(err)
+		if err = client.IgnoreNotFound(err); err == nil {
+			// Gone for good: drop its series rather than leave a deleted policy
+			// reporting a condition it no longer has.
+			metrics.ForgetAutomation(req.Namespace, req.Name)
+		}
+		return ctrl.Result{}, err
 	}
 
 	if !automation.DeletionTimestamp.IsZero() {
@@ -278,7 +289,7 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if inForce && !assessment.known {
 		r.setCondition(&automation, conditionReady, metav1.ConditionFalse, "ProviderStateUnavailable",
 			fmt.Sprintf("no state observed yet for provider %q", automation.Spec.When.Provider))
-		if err := r.Status().Update(ctx, &automation); err != nil {
+		if err := r.updateStatus(ctx, &automation); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: reevaluateInterval}, nil
@@ -294,7 +305,7 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.setCondition(&automation, conditionReady, metav1.ConditionFalse, "StateKeyUnavailable",
 			fmt.Sprintf("provider %q is not reporting %s; holding last known state",
 				automation.Spec.When.Provider, strings.Join(assessment.missing, ", ")))
-		if err := r.Status().Update(ctx, &automation); err != nil {
+		if err := r.updateStatus(ctx, &automation); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: reevaluateInterval}, nil
@@ -329,6 +340,7 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		automation.Status.LastExecution = &reactorv1alpha1.ExecutionStatus{
 			Time: metav1.Now(), OnExit: !claiming, Status: executionSuccess,
 		}
+		metrics.ReactionCompleted(automation.Spec.When.Provider, assessment.observedAt)
 	}
 	if readable {
 		automation.Status.ObservedState = assessment.observed
@@ -353,7 +365,7 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.setCondition(&automation, conditionApplied, metav1.ConditionFalse, reasonSuspended,
 			"suspended, so this automation's targets are arbitrated as if it did not exist")
 	}
-	if err := r.Status().Update(ctx, &automation); err != nil {
+	if err := r.updateStatus(ctx, &automation); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -368,7 +380,7 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if matching != wasMatching && inForce {
 		if results := r.runEdgeActions(ctx, &automation, matching); len(results) > 0 {
 			automation.Status.EdgeActions = results
-			if err := r.Status().Update(ctx, &automation); err != nil {
+			if err := r.updateStatus(ctx, &automation); err != nil {
 				// Logged rather than returned: the actions have already been
 				// sent, and requeueing would re-send them on the next pass.
 				log.Error(err, "recording edge action results failed",
@@ -410,14 +422,14 @@ func (r *AutomationReconciler) recordApplyFailure(
 				attempts, applyErr))
 		log.Error(applyErr, "giving up on target after repeated failures",
 			"automation", automation.Name, "attempts", attempts)
-		if err := r.Status().Update(ctx, automation); err != nil {
+		if err := r.updateStatus(ctx, automation); err != nil {
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{RequeueAfter: reevaluateInterval}, nil
 	}
 
 	r.setCondition(automation, conditionApplied, metav1.ConditionFalse, reasonActionFailed, applyErr.Error())
-	if err := r.Status().Update(ctx, automation); err != nil {
+	if err := r.updateStatus(ctx, automation); err != nil {
 		return ctrl.Result{}, err
 	}
 	return ctrl.Result{RequeueAfter: retryBackoff(attempts)}, nil
@@ -446,7 +458,7 @@ func (r *AutomationReconciler) finalize(
 		if attempts < maxReleaseAttempts {
 			automation.Status.ReleaseAttempts = attempts
 			r.setCondition(automation, conditionApplied, metav1.ConditionFalse, "ReleaseFailed", err.Error())
-			if statusErr := r.Status().Update(ctx, automation); statusErr != nil {
+			if statusErr := r.updateStatus(ctx, automation); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
 			return ctrl.Result{RequeueAfter: time.Duration(attempts) * releaseRetryInterval}, nil
@@ -476,7 +488,10 @@ func (r *AutomationReconciler) reconcileTargets(
 ) ([]targetOutcome, error) {
 	var outcomes []targetOutcome
 	for _, key := range targetsOf(automation) {
+		started := time.Now()
 		outcome, err := r.reconcileTarget(ctx, key, automation, matching)
+		metrics.ActionExecuted(actionTypeFor(automation, key, matching), metrics.KindDesiredState,
+			!matching, err, time.Since(started))
 		outcomes = append(outcomes, outcome)
 		if err != nil {
 			return outcomes, err

--- a/internal/controller/automation_controller.go
+++ b/internal/controller/automation_controller.go
@@ -173,7 +173,11 @@ type AutomationReconciler struct {
 // +kubebuilder:rbac:groups=reactor.robbeverhelst.com,resources=automations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=reactor.robbeverhelst.com,resources=automations/finalizers,verbs=update
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
-// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// mgr.GetEventRecorder returns the events.k8s.io/v1 recorder, not the deprecated
+// core/v1 one. They share storage but are separate API groups for authorization,
+// and a rule naming only "" fails every emission with a Forbidden the broadcaster
+// logs and nothing else surfaces — the Automation just has no Events.
+// +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get
 
 // evaluation is one Automation's condition assessed against current state.
@@ -263,10 +267,8 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		// error-backoff loop nobody can act on.
 		log.Info("automation has no spec.when and will never act; spec.trigger was removed from v1alpha1, delete it",
 			"automation", claimantOf(&automation))
-		if r.Recorder != nil {
-			r.Recorder.Eventf(&automation, nil, corev1.EventTypeWarning, reasonTriggerRemoved, "Reconcile",
-				"spec.trigger was removed from v1alpha1 and was never implemented; this automation does nothing, delete it")
-		}
+		r.event(&automation, corev1.EventTypeWarning, reasonTriggerRemoved, actionReconcile,
+			"spec.trigger was removed from v1alpha1 and was never implemented; this automation does nothing, delete it")
 		return ctrl.Result{}, nil
 	}
 
@@ -302,7 +304,11 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// failure. Hold the current matching state instead and say so in status.
 	if inForce && len(assessment.missing) > 0 {
 		automation.Status.ObservedState = assessment.observed
-		r.setCondition(&automation, conditionReady, metav1.ConditionFalse, "StateKeyUnavailable",
+		r.eventOnNewReason(&automation, conditionReady, corev1.EventTypeWarning,
+			reasonStateKeyUnavailable, actionEvaluate,
+			"provider %q stopped reporting %s; holding the last known state rather than treating lost sight of it as the condition ending",
+			automation.Spec.When.Provider, strings.Join(assessment.missing, ", "))
+		r.setCondition(&automation, conditionReady, metav1.ConditionFalse, reasonStateKeyUnavailable,
 			fmt.Sprintf("provider %q is not reporting %s; holding last known state",
 				automation.Spec.When.Provider, strings.Join(assessment.missing, ", ")))
 		if err := r.updateStatus(ctx, &automation); err != nil {
@@ -342,6 +348,10 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 		metrics.ReactionCompleted(automation.Spec.When.Provider, assessment.observedAt)
 	}
+	// Raised before the failure branch below, because reconcileTargets stops at
+	// the first failure and the targets it wrote before that one were still
+	// written.
+	r.eventsForTargets(&automation, outcomes)
 	if readable {
 		automation.Status.ObservedState = assessment.observed
 	}
@@ -350,6 +360,11 @@ func (r *AutomationReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	if applyErr != nil {
 		return r.recordApplyFailure(ctx, &automation, applyErr, claiming)
 	}
+	// After the failure branch: a transition whose targets could not be written
+	// is not committed, so announcing it here would report a failover that has
+	// not happened yet. It is announced on the retry that succeeds — the same
+	// ordering rule the edge actions below follow.
+	r.reportTransition(&automation, matching != wasMatching, matching)
 
 	if inForce {
 		r.setCondition(&automation, conditionReady, metav1.ConditionTrue, "Reconciled",
@@ -411,13 +426,25 @@ func (r *AutomationReconciler) recordApplyFailure(
 		Time: metav1.Now(), OnExit: !claiming, Status: executionFailed,
 		Reason: applyErr.Error(), Attempts: attempts,
 	}
+	// Bounded by the retry budget rather than raised every pass: past it,
+	// Reactor has stopped trying and has nothing new to report until the state
+	// changes, so a fifteen-second heartbeat would be noise on top of silence.
+	if attempts <= maxActionAttempts {
+		r.eventOnNewReason(automation, conditionReady, corev1.EventTypeWarning,
+			reasonActionFailed, actionExecute,
+			"attempt %d of %d failed: %v", attempts, maxActionAttempts, applyErr)
+	}
 	r.setCondition(automation, conditionReady, metav1.ConditionFalse, reasonActionFailed, applyErr.Error())
 
 	// Retry is bounded here rather than by returning the error and inheriting
 	// controller-runtime's requeue, so that giving up is a decision with a
 	// visible reason instead of an unbounded backoff nobody can see the end of.
 	if attempts >= maxActionAttempts {
-		r.setCondition(automation, conditionApplied, metav1.ConditionFalse, "RetryBudgetExhausted",
+		r.eventOnNewReason(automation, conditionApplied, corev1.EventTypeWarning,
+			reasonRetryBudgetExhausted, actionExecute,
+			"gave up after %d attempts; waiting for the next state change rather than retrying forever: %v",
+			attempts, applyErr)
+		r.setCondition(automation, conditionApplied, metav1.ConditionFalse, reasonRetryBudgetExhausted,
 			fmt.Sprintf("giving up after %d attempts, will try again on the next state change: %v",
 				attempts, applyErr))
 		log.Error(applyErr, "giving up on target after repeated failures",
@@ -457,7 +484,7 @@ func (r *AutomationReconciler) finalize(
 		attempts := automation.Status.ReleaseAttempts + 1
 		if attempts < maxReleaseAttempts {
 			automation.Status.ReleaseAttempts = attempts
-			r.setCondition(automation, conditionApplied, metav1.ConditionFalse, "ReleaseFailed", err.Error())
+			r.setCondition(automation, conditionApplied, metav1.ConditionFalse, reasonReleaseFailed, err.Error())
 			if statusErr := r.updateStatus(ctx, automation); statusErr != nil {
 				return ctrl.Result{}, statusErr
 			}
@@ -468,10 +495,8 @@ func (r *AutomationReconciler) finalize(
 		// was before — but a resource stuck terminating forever is not.
 		log.Error(err, "giving up releasing targets, removing finalizer anyway",
 			"automation", claimantOf(automation), "attempts", attempts)
-		if r.Recorder != nil {
-			r.Recorder.Eventf(automation, nil, corev1.EventTypeWarning, "ReleaseFailed", "Release",
-				"could not hand targets back after %d attempts, deleting anyway: %v", attempts, err)
-		}
+		r.event(automation, corev1.EventTypeWarning, reasonReleaseFailed, actionRelease,
+			"could not hand targets back after %d attempts, deleting anyway: %v", attempts, err)
 	}
 
 	controllerutil.RemoveFinalizer(automation, finalizerReleaseClaims)
@@ -541,7 +566,10 @@ func (r *AutomationReconciler) setAppliedCondition(
 		}
 	}
 	if len(deferred) > 0 {
-		r.setCondition(automation, conditionApplied, metav1.ConditionFalse, "DeferredToOtherAutomation",
+		r.eventOnNewReason(automation, conditionApplied, corev1.EventTypeNormal,
+			reasonDeferred, actionExecute,
+			"a more restrictive claim is in effect: %s", strings.Join(deferred, "; "))
+		r.setCondition(automation, conditionApplied, metav1.ConditionFalse, reasonDeferred,
 			strings.Join(deferred, "; "))
 		return
 	}

--- a/internal/controller/edge_actions.go
+++ b/internal/controller/edge_actions.go
@@ -152,28 +152,17 @@ func (r *AutomationReconciler) reportEdgeAction(
 	case executionSuccess:
 		log.Info("edge action sent", "automation", claimantOf(automation),
 			"action", entry.Type, "destination", entry.Destination, "attempts", entry.Attempts)
-		r.event(automation, corev1.EventTypeNormal, reasonEdgeActionSent,
+		r.event(automation, corev1.EventTypeNormal, reasonEdgeActionSent, actionEdge,
 			"%s delivered to %s after %d attempt(s)", entry.Type, entry.Destination, entry.Attempts)
 	case executionFailed:
 		log.Info("edge action failed", "automation", claimantOf(automation),
 			"action", entry.Type, "destination", entry.Destination, "reason", entry.Reason)
-		r.event(automation, corev1.EventTypeWarning, reasonEdgeActionFailed,
+		r.event(automation, corev1.EventTypeWarning, reasonEdgeActionFailed, actionEdge,
 			"%s was not delivered: %s", entry.Type, entry.Reason)
 	default:
-		r.event(automation, corev1.EventTypeWarning, reasonEdgeActionSkipped,
+		r.event(automation, corev1.EventTypeWarning, reasonEdgeActionSkipped, actionEdge,
 			"%s did not run: %s", entry.Type, entry.Reason)
 	}
-}
-
-func (r *AutomationReconciler) event(
-	automation *reactorv1alpha1.Automation,
-	eventType, reason, note string,
-	args ...any,
-) {
-	if r.Recorder == nil {
-		return
-	}
-	r.Recorder.Eventf(automation, nil, eventType, reason, "EdgeAction", note, args...)
 }
 
 // runEdgeAction resolves one action into a request and sends it.

--- a/internal/controller/edge_actions.go
+++ b/internal/controller/edge_actions.go
@@ -32,6 +32,7 @@ import (
 
 	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
 	"github.com/robbeverhelst/unifi-reactor/internal/actions"
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 )
 
 const (
@@ -116,8 +117,14 @@ func (r *AutomationReconciler) runEdgeActions(
 		if ctx.Err() != nil {
 			entry.Status = executionSkipped
 			entry.Reason = "ran out of time for the remaining actions on this transition"
+			metrics.ActionSkipped(action.Type, metrics.KindEdge, !matching)
 		} else {
+			started := time.Now()
 			result, err := r.runEdgeAction(ctx, automation, action, data)
+			// Counted as an edge action, which is what keeps a failure here from
+			// reading as an Automation that could not do its job: this did not
+			// happen, and the desired-state action beside it still did.
+			metrics.ActionExecuted(action.Type, metrics.KindEdge, !matching, err, time.Since(started))
 			entry.Destination = result.Origin
 			entry.Attempts = result.Attempts
 			entry.Status = executionSuccess

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+)
+
+// Event reasons. Together these are meant to make `kubectl describe automation`
+// tell the whole story of a failover without anyone needing log access — which
+// is cluster-admin, and which nobody has at 3am on a phone.
+//
+// Normal and Warning are used deliberately, not as a severity dial. A held
+// state, a deferred claim and a reversal are all Warning-free: they are the
+// design working. Warning is reserved for something an operator has to act on.
+const (
+	// reasonStateEntered and reasonStateExited bracket the interesting part of
+	// every incident: the moment this Automation's condition started holding,
+	// and the moment it stopped.
+	reasonStateEntered = "StateEntered"
+	reasonStateExited  = "StateExited"
+	// reasonTargetScaled and reasonTargetReleased record a write that actually
+	// happened. Reconciling a target that is already where it should be is the
+	// common case and produces nothing.
+	reasonTargetScaled   = "TargetScaled"
+	reasonTargetReleased = "TargetReleased"
+	// reasonDeferred is Normal on purpose. Being outvoted by a more restrictive
+	// claim is how two Automations sharing a workload are meant to behave, and
+	// reporting it as a fault would train people to ignore it.
+	reasonDeferred = "DeferredToOtherAutomation"
+	// reasonStateKeyUnavailable is a Warning because holding state indefinitely
+	// is not a resting place: the hardware publishing a key has gone, and
+	// somebody has to decide whether it is coming back.
+	reasonStateKeyUnavailable = "StateKeyUnavailable"
+	// reasonRetryBudgetExhausted is raised once, when Reactor stops retrying a
+	// target and starts waiting for the next state change instead.
+	reasonRetryBudgetExhausted = "RetryBudgetExhausted"
+	// reasonReleaseFailed is raised when deletion gives up handing targets back.
+	reasonReleaseFailed = "ReleaseFailed"
+)
+
+// The events.k8s.io "action" field: what the controller was doing, as a coarse
+// verb. It is a separate axis from reason, and it is what makes an Event stream
+// filterable by phase rather than only by outcome.
+const (
+	actionEvaluate  = "Evaluate"
+	actionExecute   = "Execute"
+	actionRelease   = "Release"
+	actionEdge      = "EdgeAction"
+	actionReconcile = "Reconcile"
+)
+
+// event raises one Event against an Automation, tolerating an unset recorder so
+// that tests and any caller running without one behave identically to one that
+// simply has nothing to say.
+func (r *AutomationReconciler) event(
+	automation *reactorv1alpha1.Automation,
+	eventType, reason, action, note string,
+	args ...any,
+) {
+	if r.Recorder == nil {
+		return
+	}
+	r.Recorder.Eventf(automation, nil, eventType, reason, action, note, args...)
+}
+
+// eventOnNewReason raises an Event only when the named condition is not already
+// reporting this reason.
+//
+// Reconcile runs at least every reevaluateInterval, so anything raised
+// unconditionally from a steady state — a key that has been missing for an hour,
+// a claim that has been deferred all week — would be one API write every fifteen
+// seconds, per Automation, forever. The condition already persists exactly the
+// edge that matters, so it is used as the memory rather than inventing a second
+// one that a restart would lose.
+//
+// It must be called BEFORE the matching setCondition, while the condition still
+// holds the previous reason. Calling it after is not a compile error and would
+// silently emit nothing, which is why the two are never more than a line apart.
+func (r *AutomationReconciler) eventOnNewReason(
+	automation *reactorv1alpha1.Automation,
+	conditionType, eventType, reason, action, note string,
+	args ...any,
+) {
+	if existing := meta.FindStatusCondition(automation.Status.Conditions, conditionType); existing != nil &&
+		existing.Reason == reason {
+		return
+	}
+	r.event(automation, eventType, reason, action, note, args...)
+}
+
+// reportTransition announces this Automation's condition starting or stopping
+// holding, naming the state change that did it.
+//
+// This is the pair of Events an incident is read through, so the transition is
+// spelled out in the note rather than left to be looked up: a key with an open
+// value set — isp — is deliberately not a metric label, and this is where its
+// values live instead.
+//
+// The transitioned guard lives here rather than at the call site so Reconcile
+// gains no branch for reporting: it is already at the edge of what gocyclo
+// allows, and observability has no business being what pushes it over.
+func (r *AutomationReconciler) reportTransition(
+	automation *reactorv1alpha1.Automation,
+	transitioned, matching bool,
+) {
+	if !transitioned {
+		return
+	}
+
+	reason, verb := reasonStateExited, "stopped holding"
+	if matching {
+		reason, verb = reasonStateEntered, "started holding"
+	}
+
+	transition := automation.Status.LastTransition
+	if transition == nil || transition.Key == "" {
+		r.event(automation, corev1.EventTypeNormal, reason, actionEvaluate,
+			"the condition %s against observed %s state", verb, automation.Spec.When.Provider)
+		return
+	}
+	r.event(automation, corev1.EventTypeNormal, reason, actionEvaluate,
+		"%s moved from %q to %q, so the condition %s",
+		transition.Key, transition.From, transition.To, verb)
+}
+
+// eventsForTargets announces the writes this reconcile actually made. Only
+// changed outcomes produce one: a target already at the value it should be is
+// the steady state, and reporting it every fifteen seconds would bury the two
+// that matter.
+func (r *AutomationReconciler) eventsForTargets(automation *reactorv1alpha1.Automation, outcomes []targetOutcome) {
+	for _, outcome := range outcomes {
+		if !outcome.changed {
+			continue
+		}
+		if outcome.effective == nil {
+			r.event(automation, corev1.EventTypeNormal, reasonTargetReleased, actionRelease,
+				"%s released; no automation claims it any more", outcome.ref)
+			continue
+		}
+		r.event(automation, corev1.EventTypeNormal, reasonTargetScaled, actionExecute,
+			"%s set to %d replicas", outcome.ref, *outcome.effective)
+	}
+}

--- a/internal/controller/events_test.go
+++ b/internal/controller/events_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	eventsv1client "k8s.io/client-go/kubernetes/typed/events/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/events"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+)
+
+// recordedEvent is one emission captured from a fake recorder.
+type recordedEvent struct {
+	Type   string
+	Reason string
+	Action string
+	Note   string
+}
+
+// fakeRecorder captures emissions instead of writing them to an API server.
+type fakeRecorder struct {
+	mu     sync.Mutex
+	events []recordedEvent
+}
+
+func (f *fakeRecorder) Eventf(
+	_ runtime.Object, _ runtime.Object,
+	eventtype, reason, action, note string, args ...any,
+) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.events = append(f.events, recordedEvent{
+		Type: eventtype, Reason: reason, Action: action, Note: fmt.Sprintf(note, args...),
+	})
+}
+
+func (f *fakeRecorder) reasons() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, 0, len(f.events))
+	for _, e := range f.events {
+		out = append(out, e.Reason)
+	}
+	return out
+}
+
+func (f *fakeRecorder) find(reason string) (recordedEvent, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, e := range f.events {
+		if e.Reason == reason {
+			return e, true
+		}
+	}
+	return recordedEvent{}, false
+}
+
+func automationWithCondition(conditionType, reason string) *reactorv1alpha1.Automation {
+	automation := &reactorv1alpha1.Automation{
+		ObjectMeta: metav1.ObjectMeta{Name: "pause-on-backup-wan", Namespace: "media"},
+		Spec: reactorv1alpha1.AutomationSpec{
+			When: &reactorv1alpha1.StateTrigger{Provider: providerUniFi, State: map[string]string{keyWAN: wanBackup}},
+		},
+	}
+	if conditionType != "" {
+		automation.Status.Conditions = []metav1.Condition{{
+			Type: conditionType, Status: metav1.ConditionFalse, Reason: reason,
+			LastTransitionTime: metav1.Now(),
+		}}
+	}
+	return automation
+}
+
+// TestARepeatedConditionRaisesOneEvent is the volume guard. Reconcile runs at
+// least every reevaluateInterval, so an Event raised unconditionally from a
+// steady state — a key that has been missing for an hour — would be an API
+// write every fifteen seconds per Automation, forever.
+func TestARepeatedConditionRaisesOneEvent(t *testing.T) {
+	recorder := &fakeRecorder{}
+	r := &AutomationReconciler{Recorder: recorder}
+
+	fresh := automationWithCondition(conditionReady, "Reconciled")
+	r.eventOnNewReason(fresh, conditionReady, corev1.EventTypeWarning,
+		reasonStateKeyUnavailable, actionEvaluate, "ups went away")
+
+	held := automationWithCondition(conditionReady, reasonStateKeyUnavailable)
+	for range 10 {
+		r.eventOnNewReason(held, conditionReady, corev1.EventTypeWarning,
+			reasonStateKeyUnavailable, actionEvaluate, "ups went away")
+	}
+
+	if got := recorder.reasons(); len(got) != 1 {
+		t.Fatalf("expected one Event on entering the state, got %d: %v", len(got), got)
+	}
+}
+
+// TestAnEventIsRaisedAgainAfterRecovery pairs with the test above: suppressing
+// repeats must not suppress a second occurrence. A key that vanishes, comes
+// back and vanishes again is two incidents, not one.
+func TestAnEventIsRaisedAgainAfterRecovery(t *testing.T) {
+	recorder := &fakeRecorder{}
+	r := &AutomationReconciler{Recorder: recorder}
+
+	automation := automationWithCondition(conditionReady, reasonStateKeyUnavailable)
+	r.eventOnNewReason(automation, conditionReady, corev1.EventTypeWarning,
+		reasonStateKeyUnavailable, actionEvaluate, "ups went away")
+	if got := recorder.reasons(); len(got) != 0 {
+		t.Fatalf("expected silence while the condition already reported this, got %v", got)
+	}
+
+	r.setCondition(automation, conditionReady, metav1.ConditionTrue, "Reconciled", "recovered")
+	r.eventOnNewReason(automation, conditionReady, corev1.EventTypeWarning,
+		reasonStateKeyUnavailable, actionEvaluate, "ups went away again")
+	if got := recorder.reasons(); len(got) != 1 {
+		t.Fatalf("a second occurrence was suppressed: %v", got)
+	}
+}
+
+// TestTheTransitionEventNamesTheStateChange is why these exist at all: the
+// Event stream has to answer "what happened" without anyone reading logs. It is
+// also where a state key with an open value set — isp — is reported, since that
+// is deliberately not a metric label.
+func TestTheTransitionEventNamesTheStateChange(t *testing.T) {
+	recorder := &fakeRecorder{}
+	r := &AutomationReconciler{Recorder: recorder}
+
+	automation := automationWithCondition("", "")
+	automation.Status.LastTransition = &reactorv1alpha1.StateTransition{
+		Key: "isp", From: "carrier-a", To: "carrier-b", Time: metav1.Now(),
+	}
+
+	r.reportTransition(automation, true, true)
+	entered, ok := recorder.find(reasonStateEntered)
+	if !ok {
+		t.Fatalf("no %s Event: %v", reasonStateEntered, recorder.reasons())
+	}
+	if entered.Type != corev1.EventTypeNormal {
+		t.Errorf("entering a state is reported as %q; it is not a fault", entered.Type)
+	}
+	for _, want := range []string{"isp", "carrier-a", "carrier-b"} {
+		if !strings.Contains(entered.Note, want) {
+			t.Errorf("the Event does not name %q: %s", want, entered.Note)
+		}
+	}
+
+	r.reportTransition(automation, true, false)
+	if _, ok := recorder.find(reasonStateExited); !ok {
+		t.Errorf("no %s Event: %v", reasonStateExited, recorder.reasons())
+	}
+}
+
+// TestOnlyChangedTargetsRaiseAnEvent keeps the steady state quiet. Targets are
+// reconciled every pass, not only on transitions, so reporting each one would
+// bury the two writes that actually happened.
+func TestOnlyChangedTargetsRaiseAnEvent(t *testing.T) {
+	recorder := &fakeRecorder{}
+	r := &AutomationReconciler{Recorder: recorder}
+	automation := automationWithCondition("", "")
+
+	zero, one := int32(0), int32(1)
+	r.eventsForTargets(automation, []targetOutcome{
+		{ref: "Deployment/media/unchanged", effective: &one, changed: false},
+		{ref: "Deployment/media/qbittorrent", effective: &zero, changed: true},
+		{ref: "Deployment/media/sonarr", effective: nil, changed: true},
+	})
+
+	got := recorder.reasons()
+	if len(got) != 2 {
+		t.Fatalf("expected one Event per write that happened, got %d: %v", len(got), got)
+	}
+	scaled, ok := recorder.find(reasonTargetScaled)
+	if !ok || !strings.Contains(scaled.Note, "qbittorrent") || !strings.Contains(scaled.Note, "0 replicas") {
+		t.Errorf("the scale Event does not say what was written: %+v", scaled)
+	}
+	released, ok := recorder.find(reasonTargetReleased)
+	if !ok || !strings.Contains(released.Note, "sonarr") {
+		t.Errorf("a released target was not reported: %+v", released)
+	}
+}
+
+// TestBeingOutvotedIsNotAWarning protects a design decision from being eroded
+// by whoever next touches this. Two Automations sharing a workload and one
+// losing is the arbitration working; reporting it as a Warning would teach
+// people to ignore Warnings on Automations.
+func TestBeingOutvotedIsNotAWarning(t *testing.T) {
+	recorder := &fakeRecorder{}
+	r := &AutomationReconciler{Recorder: recorder}
+
+	automation := automationWithCondition(conditionApplied, "InEffect")
+	one := int32(1)
+	r.setAppliedCondition(automation, []targetOutcome{{
+		ref: "Deployment/media/qbittorrent", desired: &one, effective: new(int32),
+		deferredBy: []string{"power/shed-on-battery"},
+	}})
+
+	deferred, ok := recorder.find(reasonDeferred)
+	if !ok {
+		t.Fatalf("no %s Event: %v", reasonDeferred, recorder.reasons())
+	}
+	if deferred.Type != corev1.EventTypeNormal {
+		t.Errorf("being outvoted is reported as %q; it is how sharing a target is meant to work", deferred.Type)
+	}
+	if !strings.Contains(deferred.Note, "power/shed-on-battery") {
+		t.Errorf("the Event does not name who is holding the target: %s", deferred.Note)
+	}
+}
+
+// TestARecorderlessReconcilerIsSilent covers the path every unit test in this
+// package takes, and any deployment where the recorder could not be built.
+func TestARecorderlessReconcilerIsSilent(t *testing.T) {
+	r := &AutomationReconciler{}
+	automation := automationWithCondition("", "")
+	// Would panic on a nil recorder if the guard were ever dropped.
+	r.event(automation, corev1.EventTypeNormal, reasonStateEntered, actionEvaluate, "nothing to record to")
+	r.reportTransition(automation, true, true)
+	r.eventsForTargets(automation, []targetOutcome{{ref: "Deployment/media/x", changed: true}})
+}
+
+// TestEventsAreWrittenToTheEventsAPIGroup pins down what RBAC has to grant,
+// which is not what it looks like.
+//
+// mgr.GetEventRecorder returns the events.k8s.io/v1 recorder, not the
+// deprecated core/v1 one, and those are separate API groups for authorization
+// even though they share storage. A rule granting only apiGroups: [""] on
+// events therefore fails every emission with a Forbidden that is logged by the
+// broadcaster and nowhere else — the Automation simply has no Events, which
+// looks exactly like nothing having happened.
+//
+// This test fails if controller-runtime ever moves back, which would make the
+// chart's rule over-broad rather than broken.
+func TestEventsAreWrittenToTheEventsAPIGroup(t *testing.T) {
+	paths := make(chan string, 8)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		select {
+		case paths <- req.URL.Path:
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = w.Write([]byte(`{"kind":"Event","apiVersion":"events.k8s.io/v1","metadata":{"name":"e"}}`))
+	}))
+	defer server.Close()
+
+	client, err := eventsv1client.NewForConfig(&rest.Config{Host: server.URL})
+	if err != nil {
+		t.Fatalf("building the events client: %v", err)
+	}
+
+	// Constructed exactly as controller-runtime constructs it in
+	// pkg/cluster: an events.k8s.io broadcaster over the EventsV1 client.
+	broadcaster := events.NewBroadcaster(&events.EventSinkImpl{Interface: client})
+	if err := broadcaster.StartRecordingToSinkWithContext(t.Context()); err != nil {
+		t.Fatalf("starting the broadcaster: %v", err)
+	}
+	defer broadcaster.Shutdown()
+
+	recorder := broadcaster.NewRecorder(clientgoscheme.Scheme, "automation")
+	recorder.Eventf(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "stand-in", Namespace: "media"}},
+		nil, corev1.EventTypeWarning, reasonStateKeyUnavailable, actionEvaluate, "note")
+
+	select {
+	case path := <-paths:
+		if !strings.HasPrefix(path, "/apis/events.k8s.io/v1/") {
+			t.Fatalf("Events are written to %q; RBAC must grant that API group, not the one assumed", path)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("the broadcaster never wrote the Event")
+	}
+}

--- a/internal/controller/metrics.go
+++ b/internal/controller/metrics.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
+)
+
+// updateStatus writes an Automation's status and publishes the same facts to
+// the metrics registry.
+//
+// The two travel together deliberately. Reactor's status block and its metrics
+// answer the same question from opposite ends — one per resource, one across
+// the fleet — and the cheapest way to keep them from ever disagreeing is to
+// give them one call site rather than two. Every path that reports a decision
+// goes through here.
+func (r *AutomationReconciler) updateStatus(ctx context.Context, automation *reactorv1alpha1.Automation) error {
+	metrics.AutomationEvaluated(automation.Namespace, automation.Name,
+		automation.Status.Matching,
+		meta.IsStatusConditionTrue(automation.Status.Conditions, conditionReady))
+	return r.Status().Update(ctx, automation)
+}

--- a/internal/controller/unifi_poller.go
+++ b/internal/controller/unifi_poller.go
@@ -27,6 +27,7 @@ import (
 	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
 	"github.com/robbeverhelst/unifi-reactor/internal/engine"
 	"github.com/robbeverhelst/unifi-reactor/internal/events"
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 	"github.com/robbeverhelst/unifi-reactor/internal/providers/unifi"
 )
 
@@ -124,13 +125,21 @@ func (p *UniFiPoller) observe(ctx context.Context) {
 	log := logf.FromContext(ctx)
 	state, err := p.Client.Observe(ctx)
 	if err != nil {
+		metrics.ObservationFailed(unifi.ProviderName)
 		log.Error(err, "state observation failed")
 		return
 	}
-	observation := events.Observation{Provider: unifi.ProviderName, State: state, ObservedAt: time.Now()}
+	observedAt := time.Now()
+	observation := events.Observation{Provider: unifi.ProviderName, State: state, ObservedAt: observedAt}
 	transitions := p.Store.Observe(observation)
+	// Exported from the store rather than from the reading above, so what is
+	// graphed is what Automations act on: a value still proving itself against
+	// its debounce threshold has been reported to nobody.
+	reported, _ := p.Store.Get(unifi.ProviderName)
+	metrics.ObservationSucceeded(unifi.ProviderName, reported.State, observedAt)
 	log.V(1).Info("state observed", "state", state)
 	for _, t := range transitions {
+		metrics.TransitionObserved(t.Provider, t.Key)
 		log.Info("state transition", "provider", t.Provider, "key", t.Key, "from", t.From, "to", t.To)
 	}
 	if len(transitions) > 0 {

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,0 +1,375 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package metrics publishes what Reactor observed, what matched, what it did,
+// and how fast — the decision layer, which is the only thing Reactor knows that
+// nothing else in a cluster does. Raw vendor telemetry is deliberately not
+// re-exported; a vendor exporter already covers that ground better.
+//
+// Everything registers on controller-runtime's own registry, so the series
+// appear on the metrics endpoint the manager already serves. There is no second
+// server, no second port, and no second auth posture to reason about.
+//
+// # What is a label here, and what is not
+//
+// Every label on this page is a deliberate decision, because a label whose
+// value set is open turns one metric into an unbounded number of time series
+// that a Prometheus instance keeps for its whole retention period.
+//
+//   - provider, key: bounded by what is compiled in. A handful of each. Note
+//     that key stops being bounded if per-device or per-client keys ever land
+//     (device.<name>, client.<name>); that is the point at which those keys
+//     have to become opt-in rather than the point at which this is revisited.
+//   - value: bounded ONLY for keys whose provider declares a closed value set,
+//     via SetVocabulary. A key with an open value set — isp, whose values are
+//     carrier names derived from whatever public address the gateway holds —
+//     is never labelled by value, because one such key is enough to blow up an
+//     instance. Its transitions are still counted, and its current value is
+//     still in the Automation's status and in a Kubernetes Event.
+//   - namespace, name of an Automation: unbounded in principle, self-limiting
+//     in practice — a new series appears only when a human writes another
+//     policy object, never on its own. What makes that safe is ForgetAutomation:
+//     a deleted Automation's series are dropped rather than left reporting
+//     matching forever.
+//   - A target reference, a claimant, a state VALUE for an open key, and any
+//     error string are NOT labels. "How often" is this package's question;
+//     "which one" is answered by status and by Events, which cost nothing to
+//     keep and are attached to the object they describe.
+//
+// Reconcile counts, queue depth and reconcile latency are not defined here:
+// controller-runtime already exports controller_runtime_reconcile_* on the same
+// endpoint, and a second implementation would only be a second thing to trust.
+package metrics
+
+import (
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+// Label values, spelled once so a query written against one call site keeps
+// working when another is added.
+const (
+	// ResultSuccess and ResultError are the outcome of an observation or an
+	// action attempt; ResultSkipped is an action that never ran.
+	ResultSuccess = "success"
+	ResultError   = "error"
+	ResultSkipped = "skipped"
+
+	// KindDesiredState and KindEdge are the two shapes an action has, and they
+	// fail differently enough that no alert should be written without saying
+	// which it means.
+	//
+	// A desired-state action is what the Automation is for: it declares a level
+	// for a target, it is arbitrated, it is retried across reconciles, and a
+	// failure makes the Automation not Ready. An edge action reports an
+	// occurrence that has already happened; it is attempted once per transition,
+	// its retry policy is decided per type, and a failure is recorded without
+	// making the Automation not Ready — a notification that did not go out did
+	// not stop the workload being scaled.
+	//
+	// The label is redundant with type today, and deliberately so: type is an
+	// open list that grows, kind is the distinction an alert actually means, and
+	// an alert written as type!~"kubernetes.*" silently breaks the day a second
+	// desired-state type lands.
+	KindDesiredState = "desired_state"
+	KindEdge         = "edge"
+
+	// OutcomeClaimed is a target held at the value this Automation asked for,
+	// OutcomeDeferred one held at a peer's more restrictive value, and
+	// OutcomeReleased one handed back because nothing claims it any more.
+	OutcomeClaimed  = "claimed"
+	OutcomeDeferred = "deferred"
+	OutcomeReleased = "released"
+
+	// DeliveryAccepted is a delivery that caused a re-observation,
+	// DeliveryCoalesced one that arrived while another was already pending, and
+	// DeliveryRejected one that presented no valid token.
+	DeliveryAccepted  = "accepted"
+	DeliveryCoalesced = "coalesced"
+	DeliveryRejected  = "rejected"
+)
+
+// Label names, spelled once. Repeating them is where a typo turns into a
+// series that simply never appears.
+const (
+	labelProvider  = "provider"
+	labelKey       = "key"
+	labelValue     = "value"
+	labelResult    = "result"
+	labelType      = "type"
+	labelKind      = "kind"
+	labelOnExit    = "on_exit"
+	labelOutcome   = "outcome"
+	labelNamespace = "namespace"
+	labelName      = "name"
+	labelSignal    = "signal"
+)
+
+var (
+	// lastObservation is the highest-value series here: `time() - this` is the
+	// only signal that Reactor has gone blind, which is the failure mode the
+	// whole design is otherwise silent about.
+	lastObservation = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "reactor_last_observation_timestamp_seconds",
+		Help: "Unix timestamp of the last successful observation, per provider. " +
+			"time() minus this value is how long Reactor has been unable to see.",
+	}, []string{labelProvider})
+
+	observations = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "reactor_observations_total",
+		Help: "Observations attempted, by provider and outcome.",
+	}, []string{labelProvider, labelResult})
+
+	// stateInfo is published only for keys whose value set the provider
+	// declares closed. See the package comment.
+	stateInfo = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "reactor_state_info",
+		Help: "1 for the value a state key currently holds, 0 for every other value its provider declares. " +
+			"All values 0 means the key is not currently observable. " +
+			"Keys with an open value set are deliberately absent.",
+	}, []string{labelProvider, labelKey, labelValue})
+
+	// transitions is not labelled by from/to: one key with an open value set
+	// would make from x to unbounded, and which values a key moved between is
+	// already recorded in the Automation's status and in a Kubernetes Event.
+	transitions = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "reactor_state_transitions_total",
+		Help: "State transitions reported by the store, by provider and key.",
+	}, []string{labelProvider, labelKey})
+
+	automationMatching = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "reactor_automation_matching",
+		Help: "1 while an Automation's condition holds, 0 while it does not.",
+	}, []string{labelNamespace, labelName})
+
+	automationReady = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "reactor_automation_ready",
+		Help: "1 while an Automation reports Ready=True, 0 otherwise. " +
+			"An Automation that is outvoted on a target is still Ready.",
+	}, []string{labelNamespace, labelName})
+
+	arbitrations = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "reactor_arbitrations_total",
+		Help: "Arbitrated target outcomes: claimed, deferred to a more restrictive peer, or released.",
+	}, []string{labelOutcome})
+
+	actions = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "reactor_actions_total",
+		Help: "Action executions, by type and kind, outcome, and whether the Automation was reversing " +
+			"rather than claiming. A failed edge action does not make its Automation unhealthy.",
+	}, []string{labelType, labelKind, labelResult, labelOnExit})
+
+	actionDuration = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "reactor_action_duration_seconds",
+		Help: "Time one action attempt took, by type. Bounded above by the action's timeoutSeconds. " +
+			"For an edge action this covers every retry it was allowed.",
+		// Spans a fast local patch to the default 30s action timeout.
+		Buckets: []float64{0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30},
+	}, []string{labelType})
+
+	// providerSignals counts the moments a provider's independent signals fail
+	// to agree. The signal label is a closed set the provider spells out, never
+	// the values that disagreed: those come from the outside world.
+	providerSignals = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "reactor_provider_signal_disagreements_total",
+		Help: "Times two independent signals for the same fact disagreed. Nothing stops; the log line " +
+			"carries the detail, and a rising count is how a wrong derivation announces itself.",
+	}, []string{labelProvider, labelSignal})
+
+	// reactionLatency is the metric that would have caught the v0.3.0 latency
+	// bug the week it shipped, instead of by hand-reading log timestamps.
+	reactionLatency = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "reactor_reaction_latency_seconds",
+		Help: "Time from the observation that changed a condition to the action it caused completing.",
+		// Spans the webhook fast path (sub-second) to several poll intervals.
+		Buckets: []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120},
+	}, []string{labelProvider})
+
+	webhookDeliveries = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "reactor_webhook_deliveries_total",
+		Help: "Webhook fast-path deliveries, by outcome. Losing these costs reaction latency and nothing else.",
+	}, []string{labelResult})
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(
+		lastObservation,
+		observations,
+		stateInfo,
+		transitions,
+		automationMatching,
+		automationReady,
+		arbitrations,
+		actions,
+		actionDuration,
+		providerSignals,
+		reactionLatency,
+		webhookDeliveries,
+	)
+}
+
+// vocabulary holds the closed value sets providers have declared, and which of
+// their keys have been observed at least once.
+//
+// Values are published lazily, per key, on first observation. A provider that
+// declares ups but runs on a site with no UPS adopted therefore publishes no
+// ups series at all — the same "omit what you cannot see" rule the state model
+// itself follows — rather than a row of zeroes that reads like an observation.
+var vocabulary = struct {
+	sync.Mutex
+	declared map[string]map[string][]string
+	seen     map[string]map[string]bool
+}{
+	declared: map[string]map[string][]string{},
+	seen:     map[string]map[string]bool{},
+}
+
+// SetVocabulary declares a provider's closed value sets, which is what lets
+// reactor_state_info report 0 for the values a key does not currently hold
+// rather than leaving stale series behind at 1.
+//
+// The map is opaque data: this package never learns what a key or a value
+// means, only how many of them there can be. A key the provider cannot
+// enumerate the values of is simply left out, and is then never labelled by
+// value anywhere.
+func SetVocabulary(provider string, declared map[string][]string) {
+	vocabulary.Lock()
+	defer vocabulary.Unlock()
+	vocabulary.declared[provider] = declared
+	if _, ok := vocabulary.seen[provider]; !ok {
+		vocabulary.seen[provider] = map[string]bool{}
+	}
+}
+
+// ObservationSucceeded records one successful observation and the state it
+// reported. Pass the store's reported state rather than the raw reading, so
+// what is graphed is what Automations actually acted on — a value still proving
+// itself against a debounce threshold has not been reported to anyone.
+func ObservationSucceeded(provider string, state map[string]string, at time.Time) {
+	observations.WithLabelValues(provider, ResultSuccess).Inc()
+	lastObservation.WithLabelValues(provider).Set(float64(at.Unix()))
+	publishState(provider, state)
+}
+
+// ObservationFailed records an observation that could not be made. The
+// timestamp gauge is deliberately left where it was: how long Reactor has been
+// blind is the question, and a failed attempt does not answer it.
+func ObservationFailed(provider string) {
+	observations.WithLabelValues(provider, ResultError).Inc()
+}
+
+func publishState(provider string, state map[string]string) {
+	vocabulary.Lock()
+	defer vocabulary.Unlock()
+
+	declared, ok := vocabulary.declared[provider]
+	if !ok {
+		return
+	}
+	seen := vocabulary.seen[provider]
+	for key, values := range declared {
+		got, present := state[key]
+		if !present && !seen[key] {
+			// Never observed, so nothing is claimed about it either way.
+			continue
+		}
+		seen[key] = true
+		for _, value := range values {
+			active := 0.0
+			if present && value == got {
+				active = 1
+			}
+			stateInfo.WithLabelValues(provider, key, value).Set(active)
+		}
+	}
+}
+
+// TransitionObserved records one key changing value.
+func TransitionObserved(provider, key string) {
+	transitions.WithLabelValues(provider, key).Inc()
+}
+
+// AutomationEvaluated publishes an Automation's current condition. It is called
+// wherever status is written, so the two can never disagree.
+func AutomationEvaluated(namespace, name string, matching, ready bool) {
+	automationMatching.WithLabelValues(namespace, name).Set(boolValue(matching))
+	automationReady.WithLabelValues(namespace, name).Set(boolValue(ready))
+}
+
+// ForgetAutomation drops a deleted Automation's series. Without it a deleted
+// policy would keep reporting matching until the process restarts, and the
+// namespace/name labels would be an unbounded set rather than a self-limiting
+// one.
+func ForgetAutomation(namespace, name string) {
+	automationMatching.DeleteLabelValues(namespace, name)
+	automationReady.DeleteLabelValues(namespace, name)
+}
+
+// ArbitrationResolved records what happened to one target this reconcile.
+func ArbitrationResolved(outcome string) {
+	arbitrations.WithLabelValues(outcome).Inc()
+}
+
+// ActionExecuted records one action attempt that ran: its outcome, how long it
+// took, and whether the Automation was reversing rather than claiming.
+func ActionExecuted(actionType, kind string, onExit bool, err error, took time.Duration) {
+	result := ResultSuccess
+	if err != nil {
+		result = ResultError
+	}
+	actions.WithLabelValues(actionType, kind, result, strconv.FormatBool(onExit)).Inc()
+	actionDuration.WithLabelValues(actionType).Observe(took.Seconds())
+}
+
+// ActionSkipped records an action that never ran, so it is neither a success
+// nor a failure and contributes no duration to reason about.
+func ActionSkipped(actionType, kind string, onExit bool) {
+	actions.WithLabelValues(actionType, kind, ResultSkipped, strconv.FormatBool(onExit)).Inc()
+}
+
+// SignalsDisagreed records two independent signals for the same fact failing to
+// agree. signal names which comparison, from a closed set the provider spells
+// out; the values that disagreed stay in the log line, because they come from
+// the outside world and would be unbounded here.
+func SignalsDisagreed(provider, signal string) {
+	providerSignals.WithLabelValues(provider, signal).Inc()
+}
+
+// ReactionCompleted records how long it took to get from the observation that
+// changed a condition to the action it caused. A zero observedAt is ignored:
+// nothing was observed, so there is no latency to attribute.
+func ReactionCompleted(provider string, observedAt time.Time) {
+	if observedAt.IsZero() {
+		return
+	}
+	reactionLatency.WithLabelValues(provider).Observe(time.Since(observedAt).Seconds())
+}
+
+// WebhookDelivery records one fast-path delivery.
+func WebhookDelivery(result string) {
+	webhookDeliveries.WithLabelValues(result).Inc()
+}
+
+func boolValue(b bool) float64 {
+	if b {
+		return 1
+	}
+	return 0
+}

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -1,0 +1,215 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+const (
+	testProvider = "testprovider"
+
+	keyLink    = "link"
+	keyPower   = "power"
+	keyCarrier = "carrier"
+
+	linkPrimary = "primary"
+	linkBackup  = "backup"
+	powerOnline = "online"
+	powerBatt   = "on-battery"
+)
+
+// testVocabulary mirrors the shape of a real provider's: closed value sets for
+// the keys that have them, and nothing at all for the key whose values are an
+// open set.
+func testVocabulary() map[string][]string {
+	return map[string][]string{
+		keyLink:  {linkPrimary, linkBackup},
+		keyPower: {powerOnline, powerBatt},
+	}
+}
+
+// reset clears the package-level state so each test starts from a process that
+// has just booted.
+func reset(t *testing.T) {
+	t.Helper()
+	stateInfo.Reset()
+	transitions.Reset()
+	automationMatching.Reset()
+	automationReady.Reset()
+	lastObservation.Reset()
+	reactionLatency.Reset()
+
+	vocabulary.Lock()
+	defer vocabulary.Unlock()
+	vocabulary.declared = map[string]map[string][]string{}
+	vocabulary.seen = map[string]map[string]bool{}
+}
+
+// stateValue reads one published series. Reading creates it if it is absent, so
+// every test that cares about which series exist asserts the count first.
+func stateValue(t *testing.T, key, value string) float64 {
+	t.Helper()
+	return testutil.ToFloat64(stateInfo.WithLabelValues(testProvider, key, value))
+}
+
+// TestOnlyDeclaredValuesBecomeSeries is the cardinality guard, and the reason
+// the vocabulary exists at all: a key whose values are an open set — a carrier
+// name, a hostname, anything derived from the outside world — must never reach
+// a label, or one observation per new value becomes one time series per new
+// value, kept for a whole retention period.
+func TestOnlyDeclaredValuesBecomeSeries(t *testing.T) {
+	reset(t)
+	SetVocabulary(testProvider, testVocabulary())
+
+	// The undeclared key takes a different value on every observation, which is
+	// exactly the shape that blows an instance up if it is ever labelled.
+	for _, carrier := range []string{"carrier-a", "carrier-b", "carrier-c", "unknown"} {
+		ObservationSucceeded(testProvider, map[string]string{
+			keyLink:    linkPrimary,
+			keyPower:   powerOnline,
+			keyCarrier: carrier,
+		}, time.Now())
+	}
+
+	// Four observations, four distinct undeclared values, and still exactly the
+	// two declared keys times their two declared values.
+	if got := testutil.CollectAndCount(stateInfo); got != 4 {
+		t.Fatalf("expected exactly the 4 declared values to be series, got %d", got)
+	}
+}
+
+// TestActiveValueIsOneAndTheRestAreZero covers why the vocabulary is needed at
+// all rather than just publishing the current value: without the zeroes, the
+// series for a value a key no longer holds goes stale at 1 instead of dropping,
+// and every graph built on it lies.
+func TestActiveValueIsOneAndTheRestAreZero(t *testing.T) {
+	reset(t)
+	SetVocabulary(testProvider, testVocabulary())
+
+	ObservationSucceeded(testProvider, map[string]string{keyLink: linkPrimary, keyPower: powerOnline}, time.Now())
+	if got := stateValue(t, keyLink, linkPrimary); got != 1 {
+		t.Errorf("the value the key holds reports %v, want 1", got)
+	}
+	if got := stateValue(t, keyLink, linkBackup); got != 0 {
+		t.Errorf("a value the key does not hold reports %v, want 0", got)
+	}
+
+	ObservationSucceeded(testProvider, map[string]string{keyLink: linkBackup, keyPower: powerBatt}, time.Now())
+	if got := stateValue(t, keyLink, linkPrimary); got != 0 {
+		t.Errorf("the previous value stayed at %v after a transition, want 0", got)
+	}
+	if got := stateValue(t, keyLink, linkBackup); got != 1 {
+		t.Errorf("the new value reports %v, want 1", got)
+	}
+	if got := stateValue(t, keyPower, powerBatt); got != 1 {
+		t.Errorf("the second key did not follow: %v, want 1", got)
+	}
+}
+
+// TestAnUnobservedKeyPublishesNothing keeps the metric honest about hardware
+// that is not there. A provider declares its whole vocabulary even on a site
+// with no UPS adopted; a row of zeroes would read as "observed, none of these",
+// which is a different claim from "cannot see it".
+func TestAnUnobservedKeyPublishesNothing(t *testing.T) {
+	reset(t)
+	SetVocabulary(testProvider, testVocabulary())
+
+	ObservationSucceeded(testProvider, map[string]string{keyLink: linkPrimary}, time.Now())
+
+	if got := testutil.CollectAndCount(stateInfo); got != 2 {
+		t.Fatalf("expected only the observed key's 2 values, got %d series", got)
+	}
+}
+
+// TestAVanishedKeyDropsToZero is the metric side of StateKeyUnavailable: the
+// hardware reporting a key dropped off the controller, so nothing should still
+// be reporting the value it last held as the one it currently holds.
+func TestAVanishedKeyDropsToZero(t *testing.T) {
+	reset(t)
+	SetVocabulary(testProvider, testVocabulary())
+
+	ObservationSucceeded(testProvider, map[string]string{keyLink: linkPrimary, keyPower: powerBatt}, time.Now())
+	ObservationSucceeded(testProvider, map[string]string{keyLink: linkPrimary}, time.Now())
+
+	if got := stateValue(t, keyPower, powerBatt); got != 0 {
+		t.Errorf("a key that vanished still reports %v, want 0", got)
+	}
+	if got := stateValue(t, keyLink, linkPrimary); got != 1 {
+		t.Errorf("the key still being observed reports %v, want 1", got)
+	}
+}
+
+// TestObservationFailureLeavesTheTimestampAlone protects the one metric the
+// whole staleness alert rests on. A failed poll must not look like a fresh
+// observation: how long Reactor has been blind is measured from the last time
+// it could actually see.
+func TestObservationFailureLeavesTheTimestampAlone(t *testing.T) {
+	reset(t)
+
+	at := time.Unix(1_700_000_000, 0)
+	ObservationSucceeded(testProvider, nil, at)
+	ObservationFailed(testProvider)
+
+	if got := testutil.ToFloat64(lastObservation.WithLabelValues(testProvider)); got != float64(at.Unix()) {
+		t.Fatalf("a failed observation moved the freshness gauge to %v", got)
+	}
+}
+
+// TestForgettingAnAutomationDropsItsSeries is what keeps namespace/name a
+// self-limiting label set rather than an unbounded one: a deleted policy stops
+// being reported instead of reporting a condition it no longer has forever.
+func TestForgettingAnAutomationDropsItsSeries(t *testing.T) {
+	reset(t)
+
+	AutomationEvaluated("media", "pause-on-backup-wan", true, true)
+	if got := testutil.CollectAndCount(automationMatching); got != 1 {
+		t.Fatalf("expected 1 series, got %d", got)
+	}
+
+	ForgetAutomation("media", "pause-on-backup-wan")
+	if got := testutil.CollectAndCount(automationMatching); got != 0 {
+		t.Fatalf("a deleted Automation still reports %d series", got)
+	}
+}
+
+// TestReactionLatencyIgnoresAnUnobservedTime stops an Automation that acts on
+// state it never saw from recording decades of latency into the histogram.
+func TestReactionLatencyIgnoresAnUnobservedTime(t *testing.T) {
+	reset(t)
+
+	ReactionCompleted(testProvider, time.Time{})
+	if got := testutil.CollectAndCount(reactionLatency); got != 0 {
+		t.Fatalf("a zero observation time was recorded as a reaction, giving %d series", got)
+	}
+}
+
+// TestStateIsNotPublishedForAnUndeclaredProvider keeps a provider that has not
+// declared a vocabulary from publishing value-labelled series by accident,
+// which is the failure mode this whole mechanism exists to make impossible.
+func TestStateIsNotPublishedForAnUndeclaredProvider(t *testing.T) {
+	reset(t)
+
+	ObservationSucceeded("undeclared", map[string]string{keyLink: linkPrimary}, time.Now())
+
+	if got := testutil.CollectAndCount(stateInfo); got != 0 {
+		t.Fatalf("a provider with no declared vocabulary published %d series", got)
+	}
+}

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -28,6 +28,8 @@ import (
 	"time"
 
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 )
 
 // Default battery thresholds, as percentages of remaining charge.
@@ -318,6 +320,7 @@ func (c *Client) wanFrom(ctx context.Context, d deviceRecord) string {
 	var wan string
 	switch {
 	case claimed.value != "" && named.value != "" && claimed.value != named.value:
+		metrics.SignalsDisagreed(ProviderName, signalWANUplinkDisagrees)
 		log.Info("The gateway's WAN signals disagree about which uplink is live; "+
 			"trusting is_uplink, which is the signal this mapping has always used",
 			"byIsUplink", claimed.value, "byUplinkName", named.value, "uplink", d.Uplink.Name)
@@ -325,6 +328,7 @@ func (c *Client) wanFrom(ctx context.Context, d deviceRecord) string {
 	case claimed.value != "":
 		wan = claimed.value
 	case named.value != "":
+		metrics.SignalsDisagreed(ProviderName, signalWANUplinkUnclaimed)
 		log.Info("is_uplink does not name a single live WAN port; "+
 			"deriving the live uplink from the gateway's uplink interface instead",
 			"byUplinkName", named.value, "uplink", d.Uplink.Name, "bothPortsClaimedUplink", claimed.ambiguous)
@@ -333,6 +337,7 @@ func (c *Client) wanFrom(ctx context.Context, d deviceRecord) string {
 		// Both ports claim the uplink and nothing resolves it. Reporting the
 		// backup is what this provider has always done here; it is a guess,
 		// and saying so is the only honest thing available.
+		metrics.SignalsDisagreed(ProviderName, signalWANUplinkAmbiguous)
 		log.Info("Both WAN ports report is_uplink and nothing resolves which is live; "+
 			"reporting the backup uplink, which may be wrong",
 			"wan", wanBackup)
@@ -363,6 +368,7 @@ func (c *Client) checkLastWANStatus(ctx context.Context, d deviceRecord, wan str
 	if !ok || status == wanStatusOnline {
 		return
 	}
+	metrics.SignalsDisagreed(ProviderName, signalWANNotOnline)
 	logf.FromContext(ctx).WithName("unifi-wan").Info(
 		"The uplink believed to be live does not report itself as online",
 		"wan", wan, "statusKey", key, "status", status, "lastWANStatus", fmt.Sprint(d.LastWANStatus))
@@ -396,11 +402,13 @@ func (c *Client) crossCheckOverTime(ctx context.Context, wan, isp string) {
 	}
 	log := logf.FromContext(ctx).WithName("unifi-wan")
 	if wanMoved {
+		metrics.SignalsDisagreed(ProviderName, signalWANMovedWithoutISP)
 		log.Info("The gateway changed uplink but the ISP behind it did not change; "+
 			"one of the two signals is wrong and the wan mapping is the unverified one",
 			"wanFrom", was.wan, "wanTo", wan, "isp", isp)
 		return
 	}
+	metrics.SignalsDisagreed(ProviderName, signalISPMovedWithoutWAN)
 	log.Info("The ISP behind the uplink changed but the gateway still reports the same uplink; "+
 		"if this was a failover, the wan mapping missed it",
 		"wan", wan, "ispFrom", was.isp, "ispTo", isp)

--- a/internal/providers/unifi/receiver.go
+++ b/internal/providers/unifi/receiver.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/go-logr/logr"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 )
 
 // Defaults for the webhook fast path.
@@ -139,6 +141,7 @@ func (r *Receiver) handleDelivery(w http.ResponseWriter, req *http.Request) {
 	if !r.authorized(req) {
 		// The response says nothing about which part was wrong, and nothing
 		// about the console or the cluster behind it.
+		metrics.WebhookDelivery(metrics.DeliveryRejected)
 		r.log.V(1).Info("Rejected a webhook delivery presenting no valid token")
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
@@ -149,8 +152,10 @@ func (r *Receiver) handleDelivery(w http.ResponseWriter, req *http.Request) {
 	read, _ := io.Copy(io.Discard, http.MaxBytesReader(w, req.Body, maxDeliveryBytes))
 
 	if r.request() {
+		metrics.WebhookDelivery(metrics.DeliveryAccepted)
 		r.log.V(1).Info("Accepted a webhook delivery; re-observing early", "bytes", read)
 	} else {
+		metrics.WebhookDelivery(metrics.DeliveryCoalesced)
 		r.log.V(1).Info("Accepted a webhook delivery; a re-observation is already pending", "bytes", read)
 	}
 

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -57,3 +57,38 @@ const (
 	batteryLow      = "low"
 	batteryCritical = "critical"
 )
+
+// The comparisons this provider makes between two independent signals for the
+// same fact, named so a disagreement can be counted without the values that
+// disagreed — which come from the outside world — becoming a metric label.
+const (
+	signalWANUplinkDisagrees = "wan-uplink-disagrees"
+	signalWANUplinkUnclaimed = "wan-uplink-unclaimed"
+	signalWANUplinkAmbiguous = "wan-uplink-ambiguous"
+	signalWANNotOnline       = "wan-not-online"
+	signalWANMovedWithoutISP = "wan-moved-without-isp"
+	signalISPMovedWithoutWAN = "isp-moved-without-wan"
+)
+
+// StateVocabulary is the closed value set of every key this provider publishes
+// one for.
+//
+// It exists so that an exported gauge can report 0 for the values a key does
+// not currently hold rather than leaving a stale series sitting at 1 — which
+// needs the full list of values, and this file is already exactly that list.
+// Nothing outside this package may spell a key or a value, so the list is
+// handed out as opaque data.
+//
+// isp is deliberately absent. Its values are carrier names derived from
+// whatever public address the gateway currently holds, so the set is open by
+// construction — the one exception to the closed-vocabulary rule argued in
+// docs/adding-a-provider.md — and an open set is the one thing that must never
+// become a metric label. Its transitions are still counted, and its current
+// value is still in every referencing Automation's status.
+func StateVocabulary() map[string][]string {
+	return map[string][]string{
+		stateKeyWAN:        {wanPrimary, wanBackup},
+		stateKeyUPS:        {upsOnline, upsOnBattery},
+		stateKeyUPSBattery: {batteryNormal, batteryLow, batteryCritical},
+	}
+}

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -24,9 +24,11 @@ limitations under the License.
 package chart
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -43,6 +45,9 @@ const (
 	// allowlist and the permission it implies appear in the rendered release.
 	envAllowedDestinations = "REACTOR_ACTION_ALLOWED_DESTINATIONS"
 	secretsRule            = `resources: ["secrets"]`
+	// tokenReviews is how the metrics endpoint's authn/authz filter appears in
+	// the rendered RBAC.
+	tokenReviews = "tokenreviews"
 )
 
 func chartDir() string { return filepath.Join("..", "..", "charts", "reactor") }
@@ -371,5 +376,180 @@ func TestOutboundActionsWorkWithoutAConsole(t *testing.T) {
 	manifests := render(t, "actions.allowedDestinations={https://ntfy.example.com}")
 	if !strings.Contains(manifests, envAllowedDestinations) {
 		t.Fatal("the allowlist is only rendered when a UniFi console is configured")
+	}
+}
+
+// TestMetricsAreOptIn is the upgrade guarantee for the metrics endpoint: an
+// existing install that does not ask for it gains no listening port, no
+// Service, and no new permission. The manifest bundle turns it on; the chart
+// makes it a choice, because opening a port on a running operator is not
+// something an upgrade should do on its own.
+func TestMetricsAreOptIn(t *testing.T) {
+	defaults := render(t, unifiURL)
+	for _, absent := range []string{
+		"--metrics-bind-address",
+		"containerPort: 8443",
+		"-metrics",
+		tokenReviews,
+		"kind: ServiceMonitor",
+		"kind: PrometheusRule",
+		"kind: GrafanaDashboard",
+	} {
+		if strings.Contains(defaults, absent) {
+			t.Errorf("a default install renders %q; metrics must be opt-in", absent)
+		}
+	}
+
+	enabled := render(t, unifiURL, "metrics.enabled=true")
+	for _, present := range []string{
+		"--metrics-bind-address=:8443",
+		"containerPort: 8443",
+		"kind: Service",
+		tokenReviews,
+		"subjectaccessreviews",
+	} {
+		if !strings.Contains(enabled, present) {
+			t.Errorf("metrics.enabled did not render %q", present)
+		}
+	}
+	// HTTPS behind the API server's authn/authz filter is the default posture,
+	// matching what install.yaml has always done.
+	if strings.Contains(enabled, "--metrics-secure=false") {
+		t.Error("the metrics endpoint is served insecurely by default")
+	}
+	// Reading /metrics is granted by a ClusterRole with no binding: the chart
+	// cannot know which ServiceAccount Prometheus scrapes with, and guessing
+	// would produce a permission that looks granted and is not.
+	if !strings.Contains(enabled, "nonResourceURLs: [\"/metrics\"]") {
+		t.Error("no metrics-reader ClusterRole was rendered")
+	}
+	// One mention is the ClusterRole's own metadata.name; a second would be a
+	// roleRef, meaning the chart guessed who scrapes.
+	if got := strings.Count(enabled, "name: reactor-metrics-reader"); got != 1 {
+		t.Errorf("metrics-reader is named %d times; binding it is the operator's choice, not the chart's", got)
+	}
+}
+
+// TestMonitoringExtrasNeedTheEndpoint stops a release rendering a
+// ServiceMonitor, alert rules or a dashboard that all query series nothing is
+// publishing — which fails as silence rather than as an error.
+func TestMonitoringExtrasNeedTheEndpoint(t *testing.T) {
+	for name, value := range map[string]string{
+		"service monitor": "metrics.serviceMonitor.enabled=true",
+		"alert rules":     "metrics.rules.enabled=true",
+		"dashboard":       "metrics.dashboard.enabled=true",
+	} {
+		t.Run(name, func(t *testing.T) {
+			if renderFails(t, unifiURL, value) == "" {
+				t.Error("expected the chart to refuse this without metrics.enabled")
+			}
+		})
+	}
+}
+
+// TestAlertRulesCoverTheSilentFailure checks the one rule the whole feature
+// exists for. Reactor fails open: when it stops observing, every Automation
+// quietly stops reacting and nothing else in the cluster notices.
+func TestAlertRulesCoverTheSilentFailure(t *testing.T) {
+	manifests := render(t, unifiURL, "metrics.enabled=true", "metrics.rules.enabled=true")
+	for _, alert := range []string{
+		"ReactorObservationStale",
+		"ReactorObservationAbsent",
+		"ReactorObservationFailing",
+		"ReactorActionFailing",
+		"ReactorEdgeActionFailing",
+		"ReactorAutomationNotReady",
+		"ReactorReactionSlow",
+		"ReactorUPSOnBattery",
+		"ReactorWANOnBackup",
+	} {
+		if !strings.Contains(manifests, alert) {
+			t.Errorf("alert %s is missing", alert)
+		}
+	}
+	if !strings.Contains(manifests, "time() - reactor_last_observation_timestamp_seconds > 90") {
+		t.Error("the staleness threshold did not reach the rule")
+	}
+	// Prometheus templating must survive Helm rendering rather than being
+	// evaluated by it — an annotation reading "$labels.provider" as an empty
+	// string is the classic way this ships broken.
+	if !strings.Contains(manifests, "{{ $labels.provider }}") {
+		t.Error("Prometheus label templating was rendered away by Helm")
+	}
+	// A failed notification is not a failed Automation, and no alert may imply
+	// it is: the two are separated by the kind label.
+	if !strings.Contains(manifests, `kind="edge"`) || !strings.Contains(manifests, `kind="desired_state"`) {
+		t.Error("the action alerts do not distinguish edge actions from desired-state ones")
+	}
+}
+
+// TestDashboardCarriesNothingSiteSpecific is the leak guard. A dashboard JSON
+// is exactly where a datasource UID, an org-specific folder, or somebody's
+// Grafana address ends up without anyone noticing.
+func TestDashboardCarriesNothingSiteSpecific(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join(chartDir(), "dashboards", "reactor.json"))
+	if err != nil {
+		t.Fatalf("reading the dashboard: %v", err)
+	}
+
+	var dashboard map[string]any
+	if err := json.Unmarshal(raw, &dashboard); err != nil {
+		t.Fatalf("the dashboard is not valid JSON: %v", err)
+	}
+	// Every datasource reference must go through the dashboard's own variable,
+	// so importing it into any Grafana works without editing it first.
+	for _, uid := range regexp.MustCompile(`"uid"\s*:\s*"([^"]*)"`).FindAllStringSubmatch(string(raw), -1) {
+		if uid[1] != "${datasource}" && uid[1] != "unifi-reactor-overview" {
+			t.Errorf("the dashboard pins a datasource uid %q", uid[1])
+		}
+	}
+	for _, leak := range []string{"192.168.", "10.0.", "grafana.com/orgs", "http://localhost", ".local"} {
+		if strings.Contains(string(raw), leak) {
+			t.Errorf("the dashboard contains %q, which is somebody's infrastructure", leak)
+		}
+	}
+
+	// And it has to survive being carried through a Helm template into a CR.
+	manifests := render(t, unifiURL, "metrics.enabled=true", "metrics.dashboard.enabled=true")
+	if !strings.Contains(manifests, "kind: GrafanaDashboard") {
+		t.Fatal("metrics.dashboard.enabled did not render a GrafanaDashboard")
+	}
+	// Grafana legend formats are {{key}}, which Helm would happily evaluate to
+	// nothing if the JSON were ever passed through tpl.
+	if !strings.Contains(manifests, "{{provider}}") {
+		t.Error("the dashboard's legend templating was rendered away by Helm")
+	}
+}
+
+// TestNamespacedInstallsStayNamespacedWithoutSecureMetrics states the one place
+// rbac.clusterWide=false still produces cluster-scoped RBAC, and the escape
+// hatch from it.
+//
+// The authn/authz filter reviews tokens and access through TokenReview and
+// SubjectAccessReview, which are cluster-scoped with no namespaced form. That is
+// a real consequence of asking for a protected endpoint, and it should be a
+// stated behaviour rather than something an operator discovers in an audit.
+func TestNamespacedInstallsStayNamespacedWithoutSecureMetrics(t *testing.T) {
+	namespaced := []string{unifiURL, "rbac.clusterWide=false"}
+
+	if got := strings.Count(render(t, namespaced...), "\nkind: Cluster"); got != 0 {
+		t.Errorf("a namespace-scoped install created %d cluster-scoped RBAC objects", got)
+	}
+	insecure := append(append([]string{}, namespaced...), "metrics.enabled=true", "metrics.secure=false")
+	if got := strings.Count(render(t, insecure...), "\nkind: Cluster"); got != 0 {
+		t.Errorf("an unprotected endpoint still created %d cluster-scoped RBAC objects", got)
+	}
+
+	secure := append(append([]string{}, namespaced...), "metrics.enabled=true")
+	manifests := render(t, secure...)
+	for _, expected := range []string{tokenReviews, "subjectaccessreviews"} {
+		if !strings.Contains(manifests, expected) {
+			t.Errorf("the authn/authz filter is not granted %s, so every scrape would be refused", expected)
+		}
+	}
+	// The manager's own rules stay a Role: only the review delegation is
+	// cluster-scoped, and it grants nothing about the objects Reactor acts on.
+	if strings.Contains(manifests, "kind: ClusterRole\nmetadata:\n  name: reactor-manager") {
+		t.Error("enabling metrics widened the manager's own RBAC back to cluster scope")
 	}
 }

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -521,6 +521,28 @@ func TestDashboardCarriesNothingSiteSpecific(t *testing.T) {
 	}
 }
 
+// TestEventsAreGrantedOnTheRightAPIGroup guards a rule that fails silently when
+// it is wrong. The manager records through events.k8s.io/v1; a rule naming only
+// the core group is refused on every emission, logged by the broadcaster and
+// surfaced nowhere, so the Automation simply has no Events.
+func TestEventsAreGrantedOnTheRightAPIGroup(t *testing.T) {
+	// Both RBAC modes: the manager's rules render as a ClusterRole in one and a
+	// Role in the other, and the events rule travels with them either way.
+	for _, mode := range []string{"rbac.clusterWide=true", "rbac.clusterWide=false"} {
+		t.Run(mode, func(t *testing.T) {
+			manifests := render(t, unifiURL, mode)
+			if !strings.Contains(manifests, `apiGroups: ["events.k8s.io"]`) {
+				t.Fatal("the manager is not granted events on events.k8s.io, so every Event it raises is refused")
+			}
+			// Leader election still uses the deprecated core/v1 recorder, and its
+			// own Role grants that in the release namespace. Exactly one rule each.
+			if got := strings.Count(manifests, `resources: ["events"]`); got != 2 {
+				t.Errorf("expected one events rule for the manager and one for leader election, found %d", got)
+			}
+		})
+	}
+}
+
 // TestNamespacedInstallsStayNamespacedWithoutSecureMetrics states the one place
 // rbac.clusterWide=false still produces cluster-scoped RBAC, and the escape
 // hatch from it.


### PR DESCRIPTION
Closes #40, refs #28.

Both issues ask the same question — *what is the operator actually doing?* — from opposite ends, so they are designed as one thing. Prometheus answers **how often, across everything**; Events answer **what happened, to this one resource**. Where they overlap, one of them gives way on purpose.

## The problem being solved

Reactor's worst failure is silent and fails open. If it stops observing — expired API key, rebooted console, network partition — every Automation quietly stops reacting. Nothing errors, nothing logs, and the next real outage simply is not handled. One number says so:

```promql
time() - reactor_last_observation_timestamp_seconds
```

Everything else exists to make that number worth putting a dashboard around.

## Commit 1 — metrics, alerts, dashboard

Registered on controller-runtime's own registry, so they appear on the endpoint the manager already serves. No second server, no second auth posture. `controller_runtime_reconcile_*` is **not** reimplemented, and raw UniFi telemetry is **not** re-exported — a UniFi exporter covers that better, and Reactor's unique vantage point is the decision layer.

| Metric | Type | Labels |
| --- | --- | --- |
| `reactor_last_observation_timestamp_seconds` | gauge | `provider` |
| `reactor_observations_total` | counter | `provider`, `result` |
| `reactor_state_info` | gauge 0/1 | `provider`, `key`, `value` |
| `reactor_state_transitions_total` | counter | `provider`, `key` |
| `reactor_automation_matching` / `_ready` | gauge 0/1 | `namespace`, `name` |
| `reactor_arbitrations_total` | counter | `outcome` |
| `reactor_actions_total` | counter | `type`, `kind`, `result`, `on_exit` |
| `reactor_action_duration_seconds` | histogram | `type` |
| `reactor_reaction_latency_seconds` | histogram | `provider` |
| `reactor_webhook_deliveries_total` | counter | `result` |
| `reactor_provider_signal_disagreements_total` | counter | `provider`, `signal` |

Chart: `metrics.enabled`, a Service, the authn/authz RBAC, an unbound `metrics-reader` ClusterRole, a `ServiceMonitor`, a `PrometheusRule` and a grafana-operator `GrafanaDashboard`. **All off by default**, and the last three *fail the render* without `metrics.enabled` rather than shipping something that queries series nothing publishes — which fails as silence, not as an error.

## Cardinality — the reasoning, since you asked for it written down

`isp` (from #56) is the first state key whose values are an **open set**: carrier slugs derived from whatever public address the gateway currently holds. That turns this from theoretical to real, so the decisions are structural rather than conventional.

**`value` is a label only for keys whose provider declares a closed value set.** `unifi.StateVocabulary()` returns `wan`, `ups`, `ups.battery` and their values; `isp` is deliberately absent. An undeclared key *cannot* produce a value-labelled series — it is not a rule someone has to remember, it is the only code path. `TestOnlyDeclaredValuesBecomeSeries` feeds four distinct carrier values through and asserts the series count is still exactly four.

Declaring the vocabulary is also what lets the gauge emit `0` for the values a key does **not** hold. Without that, the series for a value it used to hold goes stale at `1` rather than dropping, and every graph built on it lies. All-values-`0` then unambiguously means "not currently observable" — the metric side of `StateKeyUnavailable`. A key never observed publishes nothing at all, mirroring the provider rule that you omit what you cannot see.

**`from`/`to` are not labels on the transition counter.** Same argument, squared: one open-set key makes `from × to` unbounded. The counter answers "how often does failover happen"; which values it moved between is in `status.lastTransition` and in the `StateEntered` Event.

**`namespace`/`name` on the Automation gauges are labels**, because they are self-limiting — a series appears only when a human writes another policy object — and because `ForgetAutomation` drops them on delete. Without that deletion they would be genuinely unbounded over time, so the label and the cleanup are one decision, not two.

**A target ref, a claimant, and any error string are not labels.** Arbitration is counted by outcome only (`claimed` / `deferred` / `released`, a closed set of three); *which* target was deferred by *whom* is in `status.targets[].deferredBy` and in a `DeferredToOtherAutomation` Event. That is the split: Prometheus keeps what is bounded, Kubernetes keeps what is specific.

**`kind` on `reactor_actions_total` is redundant with `type`, deliberately.** `type` is an open list that grows; `kind` (`desired_state` | `edge`) is the distinction an alert actually means. An alert written as `type!~"kubernetes.*"` breaks silently the day a second desired-state type lands.

**When `device.<name>` (#8) or `client.<name>` (#10) land, `key` itself stops being bounded.** That is the point at which those keys need to be opt-in — noted in the package comment so the decision is made deliberately rather than discovered.

## Rebased onto #57, and what that changed

Not just conflict resolution — edge actions have a genuinely different shape and the observability had to follow:

- **A failed notification is not a failed Automation, and nothing here implies otherwise.** `reactor_actions_total` carries `kind`, and the rules ship **two separate alerts**: `ReactorActionFailing` (`kind="desired_state"` — the cluster is not in the state you asked for) and `ReactorEdgeActionFailing` (`kind="edge"` — nobody was told; the workload was still scaled and the Automation is still `Ready`). The chart test asserts both `kind` values appear.
- `ActionSkipped` is a third result, because an edge action that ran out of budget is neither a success nor a failure and contributes no duration to reason about.
- `reactor_action_duration_seconds` covers every retry an edge action was allowed, since per-type retry lives inside one attempt at the action.
- The edge-action metric sits in `runEdgeActions`, next to the existing status write, not in `Reconcile`.

Also from #56: the five `wan`/`uplink.name`/`last_wan_status`/`isp` disagreement signals are now counted as `reactor_provider_signal_disagreements_total{signal=...}` from a closed set the provider names — so a wrong `wan` derivation announces itself on a graph instead of waiting for someone to read logs mid-outage. The values that disagreed stay in the log line; they come from the outside world. **These are deliberately not Events**: the disagreement is a provider-level fact with no Automation to attach to, and raising it on every Automation would be both spam and a category error.

## Commit 2 — Events, and the RBAC bug that silenced them

```text
Normal   StateEntered               wan moved from "primary" to "backup", so the condition started holding
Normal   TargetScaled               Deployment/media/qbittorrent set to 0 replicas
Normal   EdgeActionSent             notification.ntfy delivered to https://ntfy.example.com:443 after 1 attempt(s)
Normal   DeferredToOtherAutomation  a more restrictive claim is in effect: ... held by power/shed-on-battery
Warning  StateKeyUnavailable        provider "unifi" stopped reporting ups; holding the last known state ...
Normal   StateExited                wan moved from "backup" to "primary", so the condition stopped holding
Normal   TargetReleased             Deployment/media/qbittorrent released; no automation claims it any more
```

Events already existed ad hoc (#54, #55, #57). This is the same mechanism with a consistent reason set, one helper, and one rule for volume.

**`Normal` vs `Warning` is deliberate, not a severity dial.** Being outvoted is `Normal` — it is how two Automations sharing a workload are meant to behave, and reporting it as a fault would train people to ignore Warnings here. `TestBeingOutvotedIsNotAWarning` pins that so it survives the next refactor.

**Events fire on edges, not on states.** #30 (debounce) is not landed and this cannot wait for it. Reconcile runs at least every 15s, so anything raised from a steady condition would be one API write every 15 seconds per Automation, forever. So: a target already at its value produces nothing; a condition still reporting the same reason produces nothing after the first; `ActionFailed` stops at the retry budget and `RetryBudgetExhausted` replaces it exactly once. The **condition itself is the memory** — it already persists the edge, and it survives a restart, unlike anything in-process.

The transition Event is raised *after* the apply-failure branch, matching the ordering rule #57 established for edge actions: a transition whose targets could not be written is not committed and must not be announced until the retry that succeeds.

### The RBAC was wrong, and had been since #54

`mgr.GetEventRecorder` returns the **`events.k8s.io/v1`** recorder, not the deprecated core one. The chart granted only `apiGroups: [""]`. They share storage but are separate API groups for authorization, so **every emission since #54 has been refused** — logged by the broadcaster inside the controller and surfaced nowhere else, so the symptom was an Automation with no Events at all, which reads as nothing having happened.

`TestEventsAreWrittenToTheEventsAPIGroup` builds the broadcaster exactly as controller-runtime does, against an `httptest` server, and asserts the request path starts with `/apis/events.k8s.io/v1/`. It fails if controller-runtime ever moves back, which would make the rule over-broad rather than broken. The chart test asserts exactly two events rules total: the manager's, and leader election's (which still uses the core recorder and has always been correctly granted in its own Role).

## Footprint in `automation_controller.go`

Kept deliberately small given the concurrent work. Net there: two struct fields' worth of context (`observedAt`), a `ForgetAutomation` on not-found, seven `r.Status().Update` → `r.updateStatus` token swaps, and eight one-line call sites. Metric definitions live in `internal/metrics/`, Event helpers in `internal/controller/events.go`, the status/metrics seam in `internal/controller/metrics.go`. Nothing was refactored that did not have to be.

`updateStatus` is the one non-obvious choice: status and metrics answer the same question from opposite ends, and giving them one call site is the cheapest way to keep them from ever disagreeing.

## Scope decision worth flagging

**#28 asks for "both install paths behave identically" and this deliberately does not deliver that.** `install.yaml` enables metrics; the chart defaults `metrics.enabled: false`. Opening a port on a running operator and creating a Service is not something a `helm upgrade` may do on its own, and "anything new in the chart defaults off" is the stronger constraint. The rendered *shape* is identical in both paths — `:8443`, HTTPS, authn/authz filter, same port name — so only the default differs. Converging them the other way (turning metrics off in `install.yaml`) is available if you'd rather have literal parity.

The engine stays provider-agnostic: nothing in `internal/engine` or `internal/metrics` knows what `wan` means. The metrics package receives the vocabulary as opaque `map[string][]string` and never learns what any of it means, only how many series there can be.

`make test` and `make lint` pass; `make manifests generate` is committed and clean.

---

## LIVE VERIFICATION

Everything below is unverified. It needs a real cluster, a real Prometheus, a real Grafana, or hardware, and none of it was touched.

**Needs a real cluster**
- The metrics endpoint actually serving on a chart-installed controller. The chart renders `--metrics-bind-address=:8443` and the port; that the binary then binds and serves is inherited from the kubebuilder scaffold and untested here.
- The authn/authz filter accepting a real bearer token, and the `tokenreviews`/`subjectaccessreviews` grants being sufficient. Verified by reading the filter's requirements, not by scraping.
- **The events RBAC fix.** This is the highest-value thing to confirm and the easiest: `kubectl auth can-i create events.events.k8s.io --namespace media --as system:serviceaccount:reactor-system:reactor` should return `yes` after upgrade and `no` before it. envtest gives the test client admin rights, so RBAC is never exercised in CI.
- `helm upgrade` from the previous chart producing no diff for an install that does not set `metrics.enabled` — asserted at render time only.
- The `ClusterRole`/`ClusterRoleBinding` for `metrics-auth` on a `rbac.clusterWide: false` install. Rendered and inspected; not applied.

**Needs a real Prometheus**
- The `ServiceMonitor` being discovered and the target coming up `UP`, including the `insecureSkipVerify` path against the controller's self-signed certificate.
- **Every alert rule firing.** None has ever evaluated. `ReactorObservationStale` is the one that matters — the honest test is to break connectivity to the console and watch it fire, which is exactly what #28's acceptance criterion asks for. The rest have plausible expressions and correct-looking `for:` durations, and that is all I can claim.
- `ReactorObservationAbsent` not firing spuriously during a controller restart or a leader-election handover.
- That `{{ $labels.provider }}` survives Helm *and* renders in Alertmanager. The chart test proves Helm did not eat it; nothing proves Prometheus is happy with the annotation.
- Rule-group evaluation cost. Trivial by inspection, unmeasured.

**Needs a real Grafana**
- **Importing the dashboard.** The JSON is valid, schema-version-39-shaped and free of pinned datasource UIDs by test — but no panel has ever rendered. Stat panels using `textMode: name` with a `{{value}}` legend to display the *state value as text* is the part most likely to need adjusting, along with the value mappings and the annotation query.
- grafana-operator accepting the `GrafanaDashboard` CR — `instanceSelector`, `resyncPeriod`, `allowCrossNamespaceImport`, `folder` are written from the v1beta1 API docs, not from an accepted object.
- Whether the default `instanceSelector` of `matchLabels: {dashboards: grafana}` matches your instance.

**Needs hardware, or is inherently unverifiable here**
- `reactor_reaction_latency_seconds` agreeing with the v0.3.0 measurement (transition and action in the same second). The metric is computed from `Observation.ObservedAt`, which is correct by construction; the end-to-end number has never been read off a running system.
- `reactor_provider_signal_disagreements_total` incrementing on a **real** failover. Same caveat as #34: the disagreement paths are exercised by `make dev-mock` against five hypotheses, and no real failover has ever been observed.
- `reactor_state_info` on a console with no UPS adopted publishing no `ups` series at all — unit-tested with a synthetic vocabulary, never seen against real hardware.

**Deliberately not done**
- Event volume under a genuinely flapping signal was reasoned about (edge-triggering, retry-budget bound) and bounded by construction, but never measured against a real API server. #30 remains the proper fix if a pathological case appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for observations, automations, actions, transitions, arbitration, reactions, webhooks, and provider health.
  * Added optional secure metrics serving, Prometheus scraping, alert rules, and Grafana dashboard provisioning.
  * Added meaningful Kubernetes Events for state changes, failures, deferrals, and recovery.
* **Documentation**
  * Expanded setup, configuration, development, troubleshooting, and provider guidance for metrics and Events.
* **Bug Fixes**
  * Corrected Kubernetes Events permissions and API-group handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->