### PR TITLE
feat(actions): cronjob.suspend, scale any scalable kind, restart, and cordon (drain declined)

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,43 @@ Scaling cannot express "do not start the nightly backup tonight" — that is `sp
 | | Declares | Arbitrated? | Types |
 | --- | --- | --- | --- |
 | **Desired-state** | a *level* — what a target should be | yes, continuously across every automation sharing the target | `kubernetes.scale`, `kubernetes.cronjob.suspend` |
-| **Edge** | an *occurrence* | no — fires on this automation's own transition and owns nothing | `http.request`, `notification.*` |
+| **Edge** | an *occurrence* | no — fires on this automation's own transition and owns nothing | `kubernetes.restart`, `http.request`, `notification.*` |
 
 `kubernetes.scale` works through the [scale subresource](https://kubernetes.io/docs/reference/using-api/api-concepts/#subresources), so `kind: Deployment` and `kind: StatefulSet` take the same path and Reactor never has to know where a kind keeps its replicas. `target.kind` is still a closed list, on purpose: a kind is only reachable if the chart granted RBAC for it, and RBAC has to name resources explicitly — so an open field would turn a typo into a `Forbidden` discovered *during* the outage, instead of a rejected write at admission.
 
 A level is ordered and nothing else: **lower is more restrictive, and a shared target resolves to the lowest anyone asked for.** For `kubernetes.scale` that is the replica count, so shedding wins. For `kubernetes.cronjob.suspend` it is a switch, ordered so that *suspended* is the restrictive answer — which means suspended wins over running for exactly the same reason 0 replicas wins over 3, and with no new rule to learn. `status.targets[].level` says which in words.
+
+### Restarting a workload
+
+The standard remedy for something wedged — a service that needs to re-resolve DNS or re-establish upstream connections once connectivity returns:
+
+```yaml
+  onExit:
+    - type: kubernetes.restart
+      target: { kind: Deployment, name: sonarr }
+```
+
+It stamps `kubectl.kubernetes.io/restartedAt` on the pod template, exactly as `kubectl rollout restart` does, so the workload controller rolls the pods under whatever update strategy and disruption budget the workload already declares. Reactor never deletes a pod.
+
+Restart is an **edge** action: there is no value a workload can be held at that means "restarted", so it owns nothing, arbitrates with nothing, and fires on this automation's own transition. Put it in `onExit` when you want it on recovery, as above, and in `actions` when you want it on the way in.
+
+> **It is at-most-once, and it has to be.** Every execution rolls the workload, so a retry after an ambiguous failure would be a second outage rather than a correction. Reactor attempts it exactly once per transition, records the outcome in `status.edgeActions`, and never tries again — the failures that actually happen here (a conflict, a `Forbidden`) are not ones a retry fixes. A restart that did not happen is reported as a `Warning` and leaves the automation `Ready`.
+
+#### Restart is why debounce matters
+
+Everything else Reactor does is safe to repeat: scaling to 0 twice is one scale, suspending a suspended CronJob is nothing. **A restart is not.** The engine only acts on transitions, so a steady condition never restarts anything twice — but a *flapping* state key is a stream of transitions, and each one is a real rollout. A `wan` key oscillating every poll would roll the workload every poll.
+
+The engine's answer is [debounce](#settling-a-noisy-signal), and with `kubernetes.restart` it stops being an optimization:
+
+```yaml
+unifi:
+  debounce:
+    default: 1
+    keys:
+      wan: 3      # if wan drives a restart, make it prove itself first
+```
+
+The shipped default is `1` — react on the first observation — because `wan` and `ups` are switch positions that do not flap, and a failover deserves an immediate reaction. That default is chosen for `kubernetes.scale`. **If a key drives a restart, raise its debounce**, and accept the cost: each extra sample is one `pollInterval` of extra reaction time. Before adding a restart to an automation, ask what the key does when the hardware behind it is halfway broken rather than cleanly up or down — that is the state a restart loop is born in.
 
 ## When two automations share a workload
 
@@ -247,7 +279,7 @@ kubectl patch automation <name> -n <namespace> \
 
 Everything above is invisible unless someone is reading controller logs — including the cases where Reactor deliberately did *nothing*, like holding state when the console went quiet. Two action types fix that by leaving the cluster: `notification.*` sends a message, `http.request` calls anything with an HTTP API.
 
-Both are **edge actions**. They fire on this automation's own transitions and own nothing — unlike the desired-state actions, which declare a level that is arbitrated across every automation sharing a target. An edge action in an `onExit` block still fires on this automation's own edge.
+Both are **edge actions**, like [`kubernetes.restart`](#restarting-a-workload). They fire on this automation's own transitions and own nothing — unlike the desired-state actions, which declare a level that is arbitrated across every automation sharing a target. An edge action in an `onExit` block still fires on this automation's own edge.
 
 ```yaml
 apiVersion: reactor.robbeverhelst.com/v1alpha1
@@ -428,6 +460,8 @@ Each extra sample costs one `pollInterval` of reaction time, so the default is `
 `isp` ships at `2` for a different reason: it is not a link state but the result of a geolocation lookup on whatever public address the gateway currently holds, so it can report `unknown` for a poll or two while a new address is being resolved — precisely during the failover you would be reacting to. One extra sample skips that window. Nothing else needs it: `wan` and `ups` are switch positions, and they do not flap.
 
 Debouncing happens in the shared state store, so every automation sees the same settled value. Two automations can never disagree about the current state and fight over a workload they share.
+
+This is the setting to revisit the moment you write a [`kubernetes.restart`](#restart-is-why-debounce-matters): scaling is idempotent and a flap costs nothing, while a restart under a flapping key is a rollout per poll.
 
 ## Knowing it is working
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Your UniFi gear already knows all of this. **UniFi Reactor** is a Kubernetes ope
 
 - **State, not events** — Reactor polls the UniFi Network API and reconciles against what it observes. A dropped webhook, a network blip, or a controller restart can't strand your cluster in the wrong mode, because the next observation corrects it. Webhooks are an optimization, never the mechanism of record.
 - **Reversal is explicit** — an automation says what to do when a condition starts holding, and separately what it wants once it stops. Nothing is inferred, undoing is never guessed, and every execution is recorded in the resource's status.
-- **One workload, many automations** — a target's replica count is arbitrated across every automation pointing at it, not written by whichever one saw a transition last. Two automations can pause the same workload for unrelated reasons, and it stays paused until *neither* wants it down.
+- **One workload, many automations** — a target's level is arbitrated across every automation pointing at it, not written by whichever one saw a transition last. Two automations can pause the same workload for unrelated reasons, and it stays paused until *neither* wants it down.
 - **Safe by default** — a dedicated ServiceAccount with exactly the verbs it needs, no `cluster-admin`, no arbitrary shell execution, and credentials read from Kubernetes Secrets. Scaling is desired-state (`replicas = 0`), so retrying it is harmless; the actions that leave the cluster are refused until you say where they may go.
 - **Boring to operate** — one static binary in a distroless image, no database, no queue, no UI. Small enough to forget about in a homelab.
 
@@ -113,6 +113,31 @@ kubectl -n media get automation
 
 Shedding load during a power cut is the same shape, matching `ups: on-battery` instead.
 
+### Stopping scheduled work
+
+Scaling cannot express "do not start the nightly backup tonight" — that is `spec.suspend` on a CronJob, and it is the single highest-value thing to stop during an outage or on a metered uplink:
+
+```yaml
+  actions:
+    - type: kubernetes.cronjob.suspend
+      target: { kind: CronJob, name: velero-backup, namespace: velero }
+```
+
+`suspended` defaults to `true`, which is what the action is named after; write `suspended: false` in `onExit` to ask for it back explicitly, or omit `onExit` and Reactor restores whatever the CronJob was set to before it claimed it.
+
+**Suspending stops new Jobs being created and does nothing to a Job already running.** That is deliberate, and Reactor is not granted any permission over Jobs at all, so it could not delete one if it wanted to: declining to start more work is a very different act from killing work in flight, and killing work in flight is not a decision an outage should make on your behalf. If a running backup is what you need stopped, stop it yourself.
+
+### The two shapes an action has
+
+| | Declares | Arbitrated? | Types |
+| --- | --- | --- | --- |
+| **Desired-state** | a *level* — what a target should be | yes, continuously across every automation sharing the target | `kubernetes.scale`, `kubernetes.cronjob.suspend` |
+| **Edge** | an *occurrence* | no — fires on this automation's own transition and owns nothing | `http.request`, `notification.*` |
+
+`kubernetes.scale` works through the [scale subresource](https://kubernetes.io/docs/reference/using-api/api-concepts/#subresources), so `kind: Deployment` and `kind: StatefulSet` take the same path and Reactor never has to know where a kind keeps its replicas. `target.kind` is still a closed list, on purpose: a kind is only reachable if the chart granted RBAC for it, and RBAC has to name resources explicitly — so an open field would turn a typo into a `Forbidden` discovered *during* the outage, instead of a rejected write at admission.
+
+A level is ordered and nothing else: **lower is more restrictive, and a shared target resolves to the lowest anyone asked for.** For `kubernetes.scale` that is the replica count, so shedding wins. For `kubernetes.cronjob.suspend` it is a switch, ordered so that *suspended* is the restrictive answer — which means suspended wins over running for exactly the same reason 0 replicas wins over 3, and with no new rule to learn. `status.targets[].level` says which in words.
+
 ## When two automations share a workload
 
 qBittorrent genuinely should pause for *both* a metered uplink and a power cut. Point both automations at it and nothing has to be coordinated by hand:
@@ -124,7 +149,7 @@ kubectl -n media get automation
 # shed-on-battery         unifi      true       false       True    3h
 ```
 
-While *any* automation's condition holds, the workload stays at the **most restrictive** replica count asked for. The WAN recovering above does not bring qBittorrent back, because the UPS automation still wants it down — and the automation that lost says so plainly:
+While *any* automation's condition holds, the workload stays at the **most restrictive** level asked for. The WAN recovering above does not bring qBittorrent back, because the UPS automation still wants it down — and the automation that lost says so plainly:
 
 ```sh
 kubectl -n media get automation pause-on-backup-wan -o jsonpath='{.status.targets[0]}'
@@ -136,7 +161,7 @@ The workload comes back only once **no** automation wants it down.
 
 ### What "coming back" means
 
-`onExit` declares the value an automation wants once nothing is holding the workload down. Omit it and Reactor restores the **baseline** — what the workload was set to before it first claimed it, recorded on the Deployment itself:
+`onExit` declares the level an automation wants once nothing is holding the workload down. Omit it and Reactor restores the **baseline** — what the target was set to before it first claimed it, recorded on the target itself:
 
 ```sh
 kubectl -n media get deploy qbittorrent -o jsonpath='{.metadata.annotations}'
@@ -145,7 +170,7 @@ kubectl -n media get deploy qbittorrent -o jsonpath='{.metadata.annotations}'
 #  "reactor.robbeverhelst.com/claimed-at":"2026-08-13T02:41:07Z"}
 ```
 
-Those annotations are how a workload explains itself at 3am, and they are removed the moment nothing claims it — after which Reactor asserts nothing and you can scale it by hand freely.
+The baseline annotation is named for what it records, so a CronJob carries `baseline-suspend: "false"` rather than a replica count that would mean nothing there — `baseline-replicas` keeps meaning exactly one replica count, forever. Those annotations are how a workload explains itself at 3am, and they are removed the moment nothing claims it — after which Reactor asserts nothing and you can scale it by hand freely.
 
 | `spec.reversal` | What the automation wants once nothing claims the target | Default when |
 | --- | --- | --- |
@@ -222,7 +247,7 @@ kubectl patch automation <name> -n <namespace> \
 
 Everything above is invisible unless someone is reading controller logs — including the cases where Reactor deliberately did *nothing*, like holding state when the console went quiet. Two action types fix that by leaving the cluster: `notification.*` sends a message, `http.request` calls anything with an HTTP API.
 
-Both are **edge actions**. They fire on this automation's own transitions and own nothing — unlike `kubernetes.scale`, which declares a level that is arbitrated across every automation sharing a target. An edge action in an `onExit` block still fires on this automation's own edge.
+Both are **edge actions**. They fire on this automation's own transitions and own nothing — unlike the desired-state actions, which declare a level that is arbitrated across every automation sharing a target. An edge action in an `onExit` block still fires on this automation's own edge.
 
 ```yaml
 apiVersion: reactor.robbeverhelst.com/v1alpha1
@@ -467,7 +492,7 @@ kubectl -n media describe automation pause-downloads-on-backup-wan
 Type     Reason                     Age    From        Message
 ----     ------                     ----   ----        -------
 Normal   StateEntered               3m12s  automation  wan moved from "primary" to "backup", so the condition started holding
-Normal   TargetScaled               3m12s  automation  Deployment/media/qbittorrent set to 0 replicas
+Normal   TargetHeld                 3m12s  automation  Deployment/media/qbittorrent held at 0 replicas
 Normal   EdgeActionSent             3m11s  automation  notification.ntfy delivered to https://ntfy.example.com:443 after 1 attempt(s)
 Normal   DeferredToOtherAutomation  2m40s  automation  a more restrictive claim is in effect: Deployment/media/qbittorrent held by power/shed-on-battery
 Warning  StateKeyUnavailable        1m02s  automation  provider "unifi" stopped reporting ups; holding the last known state rather than treating lost sight of it as the condition ending
@@ -484,7 +509,7 @@ Volume is bounded by the same rule everywhere: **Events fire on edges, not on st
 | Reason | Type | Raised when |
 | --- | --- | --- |
 | `StateEntered` / `StateExited` | Normal | the condition started or stopped holding, naming the key that moved |
-| `TargetScaled` / `TargetReleased` | Normal | a write to a target actually happened |
+| `TargetHeld` / `TargetReleased` | Normal | a write to a target actually happened; the message names the level in words |
 | `DeferredToOtherAutomation` | Normal | a peer's more restrictive claim is the one in effect |
 | `EdgeActionSent` | Normal | a notification or HTTP request was delivered |
 | `StateKeyUnavailable` | Warning | a provider stopped reporting a key, so state is being held |

--- a/README.md
+++ b/README.md
@@ -127,16 +127,41 @@ Scaling cannot express "do not start the nightly backup tonight" — that is `sp
 
 **Suspending stops new Jobs being created and does nothing to a Job already running.** That is deliberate, and Reactor is not granted any permission over Jobs at all, so it could not delete one if it wanted to: declining to start more work is a very different act from killing work in flight, and killing work in flight is not a decision an outage should make on your behalf. If a running backup is what you need stopped, stop it yourself.
 
+### Closing a node to new work
+
+The endgame of a power cut is a graceful shutdown, not a hard cut. Cordoning a worker running on a dying battery stops new pods landing there, so replacements come up on the node still on mains:
+
+```yaml
+  actions:
+    - type: kubernetes.cordon
+      target: { kind: Node, name: worker-03 }
+```
+
+Cordoning is desired-state, like scaling: `spec.unschedulable` is a level, `cordoned` wins over `schedulable` in a fold, and applying it twice is applying it once. `cordoned` defaults to `true`; write `cordoned: false` in `onExit` to reopen explicitly, or omit `onExit` and Reactor restores what it found — **including leaving a node cordoned that you had already cordoned by hand.**
+
+> **It is opt-in, and it is the only permission Reactor asks for that reaches outside the workloads you installed it to manage.** Nodes are cluster-scoped, so `--set rbac.allowNodeActions=true` creates a `ClusterRole` *even in a namespace-scoped install*. It grants `get` and `patch` on nodes; Kubernetes cannot narrow `patch` to one field, so that also permits writing node labels and annotations. Decide whether that is worth it before turning it on. Without it, an automation using `kubernetes.cordon` reports the node as unreachable and names the value to set. The manifest bundle (`install.yaml`) does not offer it at all.
+
+#### Why there is no `kubernetes.drain`
+
+Draining was proposed alongside cordoning and is **deliberately not implemented** — not deferred, not behind a flag. Four reasons, and the first is the one that decides it:
+
+1. **An eviction cannot be un-evicted.** Every other action here declares a *level* that is a pure function of which conditions currently hold, which is what makes the outcome independent of ordering and a controller restart harmless. A drain has no such value: there is no state a node can be held at that means "drained", `onExit` cannot express undoing it, and a flapping key would empty the node again on every flap with nothing to correct it.
+2. **In a small cluster it makes things worse.** Draining assumes somewhere else to go. In a three-node homelab on one UPS, the evicted pods do not reschedule — they go `Pending`, so you lose the workload *before* the battery runs out instead of when it does. Cordoning gets the actual benefit here without that cost.
+3. **It can evict the operator.** If Reactor's own pod is on the node being drained, the action kills the thing performing and reporting it, mid-action. Nothing else Reactor does can do that.
+4. **It hangs, by design.** Eviction respects PodDisruptionBudgets, and a single-replica workload with `minAvailable: 1` blocks forever. That is a bounded-timeout problem on paper and an unbounded blast-radius problem in practice.
+
+So the RBAC that would make it possible is not granted under any setting: `rbac.allowNodeActions` gives access to `nodes` and nothing to `pods` or `pods/eviction`. If your outage plan genuinely needs a drain, `kubernetes.cordon` plus a `notification.*` telling you to run `kubectl drain` yourself is the honest shape — a human is the right thing to make an irreversible cluster-wide decision at 3am.
+
 ### The two shapes an action has
 
 | | Declares | Arbitrated? | Types |
 | --- | --- | --- | --- |
-| **Desired-state** | a *level* — what a target should be | yes, continuously across every automation sharing the target | `kubernetes.scale`, `kubernetes.cronjob.suspend` |
+| **Desired-state** | a *level* — what a target should be | yes, continuously across every automation sharing the target | `kubernetes.scale`, `kubernetes.cronjob.suspend`, `kubernetes.cordon` |
 | **Edge** | an *occurrence* | no — fires on this automation's own transition and owns nothing | `kubernetes.restart`, `http.request`, `notification.*` |
 
 `kubernetes.scale` works through the [scale subresource](https://kubernetes.io/docs/reference/using-api/api-concepts/#subresources), so `kind: Deployment` and `kind: StatefulSet` take the same path and Reactor never has to know where a kind keeps its replicas. `target.kind` is still a closed list, on purpose: a kind is only reachable if the chart granted RBAC for it, and RBAC has to name resources explicitly — so an open field would turn a typo into a `Forbidden` discovered *during* the outage, instead of a rejected write at admission.
 
-A level is ordered and nothing else: **lower is more restrictive, and a shared target resolves to the lowest anyone asked for.** For `kubernetes.scale` that is the replica count, so shedding wins. For `kubernetes.cronjob.suspend` it is a switch, ordered so that *suspended* is the restrictive answer — which means suspended wins over running for exactly the same reason 0 replicas wins over 3, and with no new rule to learn. `status.targets[].level` says which in words.
+A level is ordered and nothing else: **lower is more restrictive, and a shared target resolves to the lowest anyone asked for.** For `kubernetes.scale` that is the replica count, so shedding wins. For `kubernetes.cronjob.suspend` and `kubernetes.cordon` it is a switch, ordered so that *suspended* and *cordoned* are the restrictive answers — which means suspended wins over running for exactly the same reason 0 replicas wins over 3, and with no new rule to learn. `status.targets[].level` says which in words.
 
 ### Restarting a workload
 

--- a/api/v1alpha1/automation_types.go
+++ b/api/v1alpha1/automation_types.go
@@ -185,9 +185,9 @@ type Notification struct {
 //
 // Types divide into two kinds. A desired-state action (kubernetes.scale,
 // kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
-// across every Automation sharing its target. An edge action (http.request,
-// notification.*) expresses an occurrence: it fires on this Automation's own
-// transitions, owns no target and arbitrates with nothing.
+// across every Automation sharing its target. An edge action (kubernetes.restart,
+// http.request, notification.*) expresses an occurrence: it fires on this
+// Automation's own transitions, owns no target and arbitrates with nothing.
 //
 // A desired-state action's level is an integer the arbiter orders and nothing
 // more, so a boolean level is carried as its own field — replicas for a count,
@@ -200,9 +200,10 @@ type Notification struct {
 // +kubebuilder:validation:XValidation:rule="self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)",message="spec.actions: suspended belongs to kubernetes.cronjob.suspend"
 // +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.scale' || self.target.kind in ['Deployment', 'StatefulSet']",message="spec.actions: kubernetes.scale targets a kind with a scale subresource: Deployment or StatefulSet"
 // +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.cronjob.suspend' || self.target.kind == 'CronJob'",message="spec.actions: kubernetes.cronjob.suspend targets a CronJob"
+// +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.restart' || self.target.kind in ['Deployment', 'StatefulSet']",message="spec.actions: kubernetes.restart targets a kind with a pod template: Deployment or StatefulSet"
 type Action struct {
 	// Type of the action, e.g. "kubernetes.scale".
-	// +kubebuilder:validation:Enum=kubernetes.scale;kubernetes.cronjob.suspend;http.request;notification.ntfy;notification.discord;notification.slack
+	// +kubebuilder:validation:Enum=kubernetes.scale;kubernetes.cronjob.suspend;kubernetes.restart;http.request;notification.ntfy;notification.discord;notification.slack
 	Type string `json:"type"`
 
 	// Target of a kubernetes.* action.

--- a/api/v1alpha1/automation_types.go
+++ b/api/v1alpha1/automation_types.go
@@ -37,8 +37,22 @@ type StateTrigger struct {
 
 // TargetRef identifies the Kubernetes object an action operates on.
 type TargetRef struct {
-	// Kind of the target resource. Only "Deployment" is supported in v1alpha1.
-	// +kubebuilder:validation:Enum=Deployment
+	// Kind of the target resource.
+	//
+	// kubernetes.scale works through the scale subresource, so its executor is
+	// kind-agnostic: any object exposing /scale can be held at a replica count
+	// without Reactor knowing where that kind keeps its replicas. This list is
+	// nevertheless closed, and that is the deliberate half of the trade-off
+	// #17 asks about.
+	//
+	// An open field would buy nothing an operator can use. A kind is only
+	// reachable if the chart granted RBAC for it, and RBAC has to name
+	// resources explicitly — so an open enum would accept a kind Reactor cannot
+	// touch and turn a typo into a Forbidden discovered during the outage the
+	// Automation was written for, instead of a rejected write at admission.
+	// Adding a kind is an entry here and a rule in the chart, and no executor
+	// code either way.
+	// +kubebuilder:validation:Enum=Deployment;StatefulSet;CronJob
 	Kind string `json:"kind"`
 
 	// Name of the target resource.
@@ -169,18 +183,26 @@ type Notification struct {
 // Action is a single normalized action. Type selects the action provider;
 // the provider-specific fields are flat and validated per type.
 //
-// Types divide into two kinds. A desired-state action (kubernetes.scale)
-// declares a level and is arbitrated continuously across every Automation
-// sharing its target. An edge action (http.request, notification.*) expresses
-// an occurrence: it fires on this Automation's own transitions, owns no target
-// and arbitrates with nothing.
+// Types divide into two kinds. A desired-state action (kubernetes.scale,
+// kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
+// across every Automation sharing its target. An edge action (http.request,
+// notification.*) expresses an occurrence: it fires on this Automation's own
+// transitions, owns no target and arbitrates with nothing.
+//
+// A desired-state action's level is an integer the arbiter orders and nothing
+// more, so a boolean level is carried as its own field — replicas for a count,
+// suspended for a switch — rather than by overloading one of them. The units
+// differ; the ordering does not.
 // +kubebuilder:validation:XValidation:rule="(self.type == 'http.request') == has(self.request)",message="spec.actions: request is required by http.request and rejected on every other type"
 // +kubebuilder:validation:XValidation:rule="self.type.startsWith('notification.') == has(self.notification)",message="spec.actions: notification is required by the notification.* types and rejected on every other type"
-// +kubebuilder:validation:XValidation:rule="self.type == 'kubernetes.scale' || !has(self.target)",message="spec.actions: target belongs to kubernetes.* actions; the outbound actions have no target"
+// +kubebuilder:validation:XValidation:rule="self.type.startsWith('kubernetes.') == has(self.target)",message="spec.actions: target is required by the kubernetes.* actions and rejected on every other type"
 // +kubebuilder:validation:XValidation:rule="self.type == 'kubernetes.scale' || !has(self.replicas)",message="spec.actions: replicas belongs to kubernetes.scale"
+// +kubebuilder:validation:XValidation:rule="self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)",message="spec.actions: suspended belongs to kubernetes.cronjob.suspend"
+// +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.scale' || self.target.kind in ['Deployment', 'StatefulSet']",message="spec.actions: kubernetes.scale targets a kind with a scale subresource: Deployment or StatefulSet"
+// +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.cronjob.suspend' || self.target.kind == 'CronJob'",message="spec.actions: kubernetes.cronjob.suspend targets a CronJob"
 type Action struct {
 	// Type of the action, e.g. "kubernetes.scale".
-	// +kubebuilder:validation:Enum=kubernetes.scale;http.request;notification.ntfy;notification.discord;notification.slack
+	// +kubebuilder:validation:Enum=kubernetes.scale;kubernetes.cronjob.suspend;http.request;notification.ntfy;notification.discord;notification.slack
 	Type string `json:"type"`
 
 	// Target of a kubernetes.* action.
@@ -192,6 +214,17 @@ type Action struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty"`
 
+	// Suspended is whether kubernetes.cronjob.suspend wants the target CronJob
+	// suspended. Omitting it means true, which is what the action is named
+	// after; write suspended: false in spec.onExit to ask for it back.
+	//
+	// Suspending stops new Jobs being created. It deliberately does nothing to
+	// a Job already running: killing work in flight is a different and much
+	// more dangerous action than declining to start more of it, and mid-flight
+	// deletion is not something an outage should decide on your behalf.
+	// +optional
+	Suspended *bool `json:"suspended,omitempty"`
+
 	// Request describes the outbound call an http.request action makes.
 	// +optional
 	Request *HTTPRequest `json:"request,omitempty"`
@@ -202,7 +235,7 @@ type Action struct {
 
 	// TimeoutSeconds bounds a single attempt at this action, so an
 	// unreachable target or endpoint cannot occupy a reconcile indefinitely.
-	// Defaults to 30 for kubernetes.scale and to 10 for the outbound actions,
+	// Defaults to 30 for the kubernetes.* actions and to 10 for the outbound ones,
 	// which may retry within the same reconcile. Exceeding it is recorded as a
 	// failed execution, not held open.
 	// +kubebuilder:validation:Minimum=1
@@ -375,19 +408,32 @@ type EdgeExecutionStatus struct {
 // arbitration across every Automation sharing that target actually resolved
 // to. When the two differ, DeferredBy names who is holding it there.
 type TargetStatus struct {
-	// Ref is the target this entry describes, as "Kind/namespace/name".
+	// Ref is the target this entry describes, as "Kind/namespace/name", or
+	// "Kind/name" for a cluster-scoped target.
 	Ref string `json:"ref"`
 
-	// Desired is the value this Automation alone wants right now, whether it
+	// Desired is the level this Automation alone wants right now, whether it
 	// is currently matching or reversing. Absent when it wants nothing —
 	// reversal None, or a reversal value it has no way to know.
+	//
+	// A level is ordered and nothing more: lower is more restrictive, and the
+	// arbiter resolves a shared target by taking the lowest. What the number
+	// counts depends on the action that produced it — replicas for
+	// kubernetes.scale, and 0 suspended / 1 running for
+	// kubernetes.cronjob.suspend. Level spells the same value out in words.
 	// +optional
 	Desired *int32 `json:"desired,omitempty"`
 
-	// Effective is the value arbitration resolved to across every Automation
+	// Effective is the level arbitration resolved to across every Automation
 	// claiming this target. Absent while nothing claims it.
 	// +optional
 	Effective *int32 `json:"effective,omitempty"`
+
+	// Level renders Effective in the units of the action that set it — "3
+	// replicas", "suspended" — because a bare number stops explaining itself
+	// once a target's level is a switch rather than a count.
+	// +optional
+	Level string `json:"level,omitempty"`
 
 	// DeferredBy names the Automations whose more restrictive claim is holding
 	// the target away from Desired, as "namespace/name". Empty when this

--- a/api/v1alpha1/automation_types.go
+++ b/api/v1alpha1/automation_types.go
@@ -36,6 +36,17 @@ type StateTrigger struct {
 }
 
 // TargetRef identifies the Kubernetes object an action operates on.
+//
+// The cluster-scope rule below reads __namespace__ rather than namespace, and
+// has to: namespace is a CEL reserved word, so Kubernetes exposes the property
+// under its escaped name. Written the obvious way the rule does not fail at
+// admission — it fails to compile, which makes the whole CRD unapplyable and
+// takes every other field down with it. No unit test catches that, because a
+// CRD is only compiled by a real API server; the e2e suites are what found it.
+//
+// It lives on TargetRef rather than on Action because the constraint is a
+// property of a target reference, not of any particular action that holds one.
+// +kubebuilder:validation:XValidation:rule="self.kind != 'Node' || !has(self.__namespace__)",message="target.namespace: a Node is cluster-scoped and takes no namespace"
 type TargetRef struct {
 	// Kind of the target resource.
 	//
@@ -52,7 +63,7 @@ type TargetRef struct {
 	// Automation was written for, instead of a rejected write at admission.
 	// Adding a kind is an entry here and a rule in the chart, and no executor
 	// code either way.
-	// +kubebuilder:validation:Enum=Deployment;StatefulSet;CronJob
+	// +kubebuilder:validation:Enum=Deployment;StatefulSet;CronJob;Node
 	Kind string `json:"kind"`
 
 	// Name of the target resource.
@@ -62,6 +73,9 @@ type TargetRef struct {
 	// Namespace of the target resource. Defaults to the Automation's own
 	// namespace. Cross-namespace targets require the controller to run with
 	// cluster-wide RBAC; otherwise the Automation reports Ready=False.
+	//
+	// Rejected on a cluster-scoped kind. A Node addressed inside a namespace is
+	// not a different Node, it is a lookup that cannot succeed.
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
 }
@@ -191,19 +205,21 @@ type Notification struct {
 //
 // A desired-state action's level is an integer the arbiter orders and nothing
 // more, so a boolean level is carried as its own field — replicas for a count,
-// suspended for a switch — rather than by overloading one of them. The units
-// differ; the ordering does not.
+// suspended and cordoned for a switch — rather than by overloading one of them.
+// The units differ; the ordering does not.
 // +kubebuilder:validation:XValidation:rule="(self.type == 'http.request') == has(self.request)",message="spec.actions: request is required by http.request and rejected on every other type"
 // +kubebuilder:validation:XValidation:rule="self.type.startsWith('notification.') == has(self.notification)",message="spec.actions: notification is required by the notification.* types and rejected on every other type"
 // +kubebuilder:validation:XValidation:rule="self.type.startsWith('kubernetes.') == has(self.target)",message="spec.actions: target is required by the kubernetes.* actions and rejected on every other type"
 // +kubebuilder:validation:XValidation:rule="self.type == 'kubernetes.scale' || !has(self.replicas)",message="spec.actions: replicas belongs to kubernetes.scale"
 // +kubebuilder:validation:XValidation:rule="self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)",message="spec.actions: suspended belongs to kubernetes.cronjob.suspend"
+// +kubebuilder:validation:XValidation:rule="self.type == 'kubernetes.cordon' || !has(self.cordoned)",message="spec.actions: cordoned belongs to kubernetes.cordon"
+// +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.cordon' || self.target.kind == 'Node'",message="spec.actions: kubernetes.cordon targets a Node"
 // +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.scale' || self.target.kind in ['Deployment', 'StatefulSet']",message="spec.actions: kubernetes.scale targets a kind with a scale subresource: Deployment or StatefulSet"
 // +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.cronjob.suspend' || self.target.kind == 'CronJob'",message="spec.actions: kubernetes.cronjob.suspend targets a CronJob"
 // +kubebuilder:validation:XValidation:rule="!has(self.target) || self.type != 'kubernetes.restart' || self.target.kind in ['Deployment', 'StatefulSet']",message="spec.actions: kubernetes.restart targets a kind with a pod template: Deployment or StatefulSet"
 type Action struct {
 	// Type of the action, e.g. "kubernetes.scale".
-	// +kubebuilder:validation:Enum=kubernetes.scale;kubernetes.cronjob.suspend;kubernetes.restart;http.request;notification.ntfy;notification.discord;notification.slack
+	// +kubebuilder:validation:Enum=kubernetes.scale;kubernetes.cronjob.suspend;kubernetes.cordon;kubernetes.restart;http.request;notification.ntfy;notification.discord;notification.slack
 	Type string `json:"type"`
 
 	// Target of a kubernetes.* action.
@@ -225,6 +241,22 @@ type Action struct {
 	// deletion is not something an outage should decide on your behalf.
 	// +optional
 	Suspended *bool `json:"suspended,omitempty"`
+
+	// Cordoned is whether kubernetes.cordon wants the target Node closed to new
+	// scheduling. Omitting it means true, which is what the action is named
+	// after; write cordoned: false in spec.onExit to reopen it explicitly.
+	//
+	// Cordoning stops new Pods being scheduled onto the Node and moves nothing
+	// that is already running. Evicting those — draining — is not offered, and
+	// not because it was not built: an eviction cannot be reversed, so it has no
+	// level to arbitrate and no reversal to declare, which is the one property
+	// every other action here has. See docs/spec.md.
+	//
+	// Node actions need cluster-scoped RBAC that the chart grants only when
+	// rbac.allowNodeActions is set. Without it the Automation reports the target
+	// as unreachable and names the value to set.
+	// +optional
+	Cordoned *bool `json:"cordoned,omitempty"`
 
 	// Request describes the outbound call an http.request action makes.
 	// +optional

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -38,6 +38,11 @@ func (in *Action) DeepCopyInto(out *Action) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Suspended != nil {
+		in, out := &in.Suspended, &out.Suspended
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Request != nil {
 		in, out := &in.Request, &out.Request
 		*out = new(HTTPRequest)

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -43,6 +43,11 @@ func (in *Action) DeepCopyInto(out *Action) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.Cordoned != nil {
+		in, out := &in.Cordoned, &out.Cordoned
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Request != nil {
 		in, out := &in.Request, &out.Request
 		*out = new(HTTPRequest)

--- a/charts/reactor/templates/crds.yaml
+++ b/charts/reactor/templates/crds.yaml
@@ -81,11 +81,16 @@ spec:
                     Action is a single normalized action. Type selects the action provider;
                     the provider-specific fields are flat and validated per type.
 
-                    Types divide into two kinds. A desired-state action (kubernetes.scale)
-                    declares a level and is arbitrated continuously across every Automation
-                    sharing its target. An edge action (http.request, notification.*) expresses
-                    an occurrence: it fires on this Automation's own transitions, owns no target
-                    and arbitrates with nothing.
+                    Types divide into two kinds. A desired-state action (kubernetes.scale,
+                    kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
+                    across every Automation sharing its target. An edge action (http.request,
+                    notification.*) expresses an occurrence: it fires on this Automation's own
+                    transitions, owns no target and arbitrates with nothing.
+
+                    A desired-state action's level is an integer the arbiter orders and nothing
+                    more, so a boolean level is carried as its own field — replicas for a count,
+                    suspended for a switch — rather than by overloading one of them. The units
+                    differ; the ordering does not.
                   properties:
                     notification:
                       description: Notification is the message a notification.* action
@@ -217,14 +222,41 @@ spec:
                           maxLength: 2048
                           type: string
                       type: object
+                    suspended:
+                      description: |-
+                        Suspended is whether kubernetes.cronjob.suspend wants the target CronJob
+                        suspended. Omitting it means true, which is what the action is named
+                        after; write suspended: false in spec.onExit to ask for it back.
+
+                        Suspending stops new Jobs being created. It deliberately does nothing to
+                        a Job already running: killing work in flight is a different and much
+                        more dangerous action than declining to start more of it, and mid-flight
+                        deletion is not something an outage should decide on your behalf.
+                      type: boolean
                     target:
                       description: Target of a kubernetes.* action.
                       properties:
                         kind:
-                          description: Kind of the target resource. Only "Deployment"
-                            is supported in v1alpha1.
+                          description: |-
+                            Kind of the target resource.
+
+                            kubernetes.scale works through the scale subresource, so its executor is
+                            kind-agnostic: any object exposing /scale can be held at a replica count
+                            without Reactor knowing where that kind keeps its replicas. This list is
+                            nevertheless closed, and that is the deliberate half of the trade-off
+                            #17 asks about.
+
+                            An open field would buy nothing an operator can use. A kind is only
+                            reachable if the chart granted RBAC for it, and RBAC has to name
+                            resources explicitly — so an open enum would accept a kind Reactor cannot
+                            touch and turn a typo into a Forbidden discovered during the outage the
+                            Automation was written for, instead of a rejected write at admission.
+                            Adding a kind is an entry here and a rule in the chart, and no executor
+                            code either way.
                           enum:
                           - Deployment
+                          - StatefulSet
+                          - CronJob
                           type: string
                         name:
                           description: Name of the target resource.
@@ -244,7 +276,7 @@ spec:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
                         unreachable target or endpoint cannot occupy a reconcile indefinitely.
-                        Defaults to 30 for kubernetes.scale and to 10 for the outbound actions,
+                        Defaults to 30 for the kubernetes.* actions and to 10 for the outbound ones,
                         which may retry within the same reconcile. Exceeding it is recorded as a
                         failed execution, not held open.
                       format: int32
@@ -255,6 +287,7 @@ spec:
                       description: Type of the action, e.g. "kubernetes.scale".
                       enum:
                       - kubernetes.scale
+                      - kubernetes.cronjob.suspend
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -270,11 +303,20 @@ spec:
                   - message: 'spec.actions: notification is required by the notification.*
                       types and rejected on every other type'
                     rule: self.type.startsWith('notification.') == has(self.notification)
-                  - message: 'spec.actions: target belongs to kubernetes.* actions;
-                      the outbound actions have no target'
-                    rule: self.type == 'kubernetes.scale' || !has(self.target)
+                  - message: 'spec.actions: target is required by the kubernetes.*
+                      actions and rejected on every other type'
+                    rule: self.type.startsWith('kubernetes.') == has(self.target)
                   - message: 'spec.actions: replicas belongs to kubernetes.scale'
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
+                  - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
+                    rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: kubernetes.scale targets a kind with a
+                      scale subresource: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.scale''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
+                  - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
+                      || self.target.kind == ''CronJob'''
                 minItems: 1
                 type: array
               onExit:
@@ -289,11 +331,16 @@ spec:
                     Action is a single normalized action. Type selects the action provider;
                     the provider-specific fields are flat and validated per type.
 
-                    Types divide into two kinds. A desired-state action (kubernetes.scale)
-                    declares a level and is arbitrated continuously across every Automation
-                    sharing its target. An edge action (http.request, notification.*) expresses
-                    an occurrence: it fires on this Automation's own transitions, owns no target
-                    and arbitrates with nothing.
+                    Types divide into two kinds. A desired-state action (kubernetes.scale,
+                    kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
+                    across every Automation sharing its target. An edge action (http.request,
+                    notification.*) expresses an occurrence: it fires on this Automation's own
+                    transitions, owns no target and arbitrates with nothing.
+
+                    A desired-state action's level is an integer the arbiter orders and nothing
+                    more, so a boolean level is carried as its own field — replicas for a count,
+                    suspended for a switch — rather than by overloading one of them. The units
+                    differ; the ordering does not.
                   properties:
                     notification:
                       description: Notification is the message a notification.* action
@@ -425,14 +472,41 @@ spec:
                           maxLength: 2048
                           type: string
                       type: object
+                    suspended:
+                      description: |-
+                        Suspended is whether kubernetes.cronjob.suspend wants the target CronJob
+                        suspended. Omitting it means true, which is what the action is named
+                        after; write suspended: false in spec.onExit to ask for it back.
+
+                        Suspending stops new Jobs being created. It deliberately does nothing to
+                        a Job already running: killing work in flight is a different and much
+                        more dangerous action than declining to start more of it, and mid-flight
+                        deletion is not something an outage should decide on your behalf.
+                      type: boolean
                     target:
                       description: Target of a kubernetes.* action.
                       properties:
                         kind:
-                          description: Kind of the target resource. Only "Deployment"
-                            is supported in v1alpha1.
+                          description: |-
+                            Kind of the target resource.
+
+                            kubernetes.scale works through the scale subresource, so its executor is
+                            kind-agnostic: any object exposing /scale can be held at a replica count
+                            without Reactor knowing where that kind keeps its replicas. This list is
+                            nevertheless closed, and that is the deliberate half of the trade-off
+                            #17 asks about.
+
+                            An open field would buy nothing an operator can use. A kind is only
+                            reachable if the chart granted RBAC for it, and RBAC has to name
+                            resources explicitly — so an open enum would accept a kind Reactor cannot
+                            touch and turn a typo into a Forbidden discovered during the outage the
+                            Automation was written for, instead of a rejected write at admission.
+                            Adding a kind is an entry here and a rule in the chart, and no executor
+                            code either way.
                           enum:
                           - Deployment
+                          - StatefulSet
+                          - CronJob
                           type: string
                         name:
                           description: Name of the target resource.
@@ -452,7 +526,7 @@ spec:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
                         unreachable target or endpoint cannot occupy a reconcile indefinitely.
-                        Defaults to 30 for kubernetes.scale and to 10 for the outbound actions,
+                        Defaults to 30 for the kubernetes.* actions and to 10 for the outbound ones,
                         which may retry within the same reconcile. Exceeding it is recorded as a
                         failed execution, not held open.
                       format: int32
@@ -463,6 +537,7 @@ spec:
                       description: Type of the action, e.g. "kubernetes.scale".
                       enum:
                       - kubernetes.scale
+                      - kubernetes.cronjob.suspend
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -478,11 +553,20 @@ spec:
                   - message: 'spec.actions: notification is required by the notification.*
                       types and rejected on every other type'
                     rule: self.type.startsWith('notification.') == has(self.notification)
-                  - message: 'spec.actions: target belongs to kubernetes.* actions;
-                      the outbound actions have no target'
-                    rule: self.type == 'kubernetes.scale' || !has(self.target)
+                  - message: 'spec.actions: target is required by the kubernetes.*
+                      actions and rejected on every other type'
+                    rule: self.type.startsWith('kubernetes.') == has(self.target)
                   - message: 'spec.actions: replicas belongs to kubernetes.scale'
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
+                  - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
+                    rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: kubernetes.scale targets a kind with a
+                      scale subresource: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.scale''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
+                  - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
+                      || self.target.kind == ''CronJob'''
                 type: array
               reversal:
                 description: |-
@@ -742,19 +826,33 @@ spec:
                       type: array
                     desired:
                       description: |-
-                        Desired is the value this Automation alone wants right now, whether it
+                        Desired is the level this Automation alone wants right now, whether it
                         is currently matching or reversing. Absent when it wants nothing —
                         reversal None, or a reversal value it has no way to know.
+
+                        A level is ordered and nothing more: lower is more restrictive, and the
+                        arbiter resolves a shared target by taking the lowest. What the number
+                        counts depends on the action that produced it — replicas for
+                        kubernetes.scale, and 0 suspended / 1 running for
+                        kubernetes.cronjob.suspend. Level spells the same value out in words.
                       format: int32
                       type: integer
                     effective:
                       description: |-
-                        Effective is the value arbitration resolved to across every Automation
+                        Effective is the level arbitration resolved to across every Automation
                         claiming this target. Absent while nothing claims it.
                       format: int32
                       type: integer
+                    level:
+                      description: |-
+                        Level renders Effective in the units of the action that set it — "3
+                        replicas", "suspended" — because a bare number stops explaining itself
+                        once a target's level is a switch rather than a count.
+                      type: string
                     ref:
-                      description: Ref is the target this entry describes, as "Kind/namespace/name".
+                      description: |-
+                        Ref is the target this entry describes, as "Kind/namespace/name", or
+                        "Kind/name" for a cluster-scoped target.
                       type: string
                   required:
                   - ref

--- a/charts/reactor/templates/crds.yaml
+++ b/charts/reactor/templates/crds.yaml
@@ -83,9 +83,9 @@ spec:
 
                     Types divide into two kinds. A desired-state action (kubernetes.scale,
                     kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
-                    across every Automation sharing its target. An edge action (http.request,
-                    notification.*) expresses an occurrence: it fires on this Automation's own
-                    transitions, owns no target and arbitrates with nothing.
+                    across every Automation sharing its target. An edge action (kubernetes.restart,
+                    http.request, notification.*) expresses an occurrence: it fires on this
+                    Automation's own transitions, owns no target and arbitrates with nothing.
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
@@ -288,6 +288,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.restart
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -317,6 +318,10 @@ spec:
                   - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
                     rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
                       || self.target.kind == ''CronJob'''
+                  - message: 'spec.actions: kubernetes.restart targets a kind with
+                      a pod template: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.restart''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
                 minItems: 1
                 type: array
               onExit:
@@ -333,9 +338,9 @@ spec:
 
                     Types divide into two kinds. A desired-state action (kubernetes.scale,
                     kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
-                    across every Automation sharing its target. An edge action (http.request,
-                    notification.*) expresses an occurrence: it fires on this Automation's own
-                    transitions, owns no target and arbitrates with nothing.
+                    across every Automation sharing its target. An edge action (kubernetes.restart,
+                    http.request, notification.*) expresses an occurrence: it fires on this
+                    Automation's own transitions, owns no target and arbitrates with nothing.
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
@@ -538,6 +543,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.restart
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -567,6 +573,10 @@ spec:
                   - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
                     rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
                       || self.target.kind == ''CronJob'''
+                  - message: 'spec.actions: kubernetes.restart targets a kind with
+                      a pod template: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.restart''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
                 type: array
               reversal:
                 description: |-

--- a/charts/reactor/templates/crds.yaml
+++ b/charts/reactor/templates/crds.yaml
@@ -89,9 +89,25 @@ spec:
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
-                    suspended for a switch — rather than by overloading one of them. The units
-                    differ; the ordering does not.
+                    suspended and cordoned for a switch — rather than by overloading one of them.
+                    The units differ; the ordering does not.
                   properties:
+                    cordoned:
+                      description: |-
+                        Cordoned is whether kubernetes.cordon wants the target Node closed to new
+                        scheduling. Omitting it means true, which is what the action is named
+                        after; write cordoned: false in spec.onExit to reopen it explicitly.
+
+                        Cordoning stops new Pods being scheduled onto the Node and moves nothing
+                        that is already running. Evicting those — draining — is not offered, and
+                        not because it was not built: an eviction cannot be reversed, so it has no
+                        level to arbitrate and no reversal to declare, which is the one property
+                        every other action here has. See docs/spec.md.
+
+                        Node actions need cluster-scoped RBAC that the chart grants only when
+                        rbac.allowNodeActions is set. Without it the Automation reports the target
+                        as unreachable and names the value to set.
+                      type: boolean
                     notification:
                       description: Notification is the message a notification.* action
                         sends.
@@ -257,6 +273,7 @@ spec:
                           - Deployment
                           - StatefulSet
                           - CronJob
+                          - Node
                           type: string
                         name:
                           description: Name of the target resource.
@@ -267,11 +284,18 @@ spec:
                             Namespace of the target resource. Defaults to the Automation's own
                             namespace. Cross-namespace targets require the controller to run with
                             cluster-wide RBAC; otherwise the Automation reports Ready=False.
+
+                            Rejected on a cluster-scoped kind. A Node addressed inside a namespace is
+                            not a different Node, it is a lookup that cannot succeed.
                           type: string
                       required:
                       - kind
                       - name
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'target.namespace: a Node is cluster-scoped and takes
+                          no namespace'
+                        rule: self.kind != 'Node' || !has(self.__namespace__)
                     timeoutSeconds:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
@@ -288,6 +312,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.cordon
                       - kubernetes.restart
                       - http.request
                       - notification.ntfy
@@ -311,6 +336,11 @@ spec:
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
                   - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
                     rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: cordoned belongs to kubernetes.cordon'
+                    rule: self.type == 'kubernetes.cordon' || !has(self.cordoned)
+                  - message: 'spec.actions: kubernetes.cordon targets a Node'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cordon''
+                      || self.target.kind == ''Node'''
                   - message: 'spec.actions: kubernetes.scale targets a kind with a
                       scale subresource: Deployment or StatefulSet'
                     rule: '!has(self.target) || self.type != ''kubernetes.scale''
@@ -344,9 +374,25 @@ spec:
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
-                    suspended for a switch — rather than by overloading one of them. The units
-                    differ; the ordering does not.
+                    suspended and cordoned for a switch — rather than by overloading one of them.
+                    The units differ; the ordering does not.
                   properties:
+                    cordoned:
+                      description: |-
+                        Cordoned is whether kubernetes.cordon wants the target Node closed to new
+                        scheduling. Omitting it means true, which is what the action is named
+                        after; write cordoned: false in spec.onExit to reopen it explicitly.
+
+                        Cordoning stops new Pods being scheduled onto the Node and moves nothing
+                        that is already running. Evicting those — draining — is not offered, and
+                        not because it was not built: an eviction cannot be reversed, so it has no
+                        level to arbitrate and no reversal to declare, which is the one property
+                        every other action here has. See docs/spec.md.
+
+                        Node actions need cluster-scoped RBAC that the chart grants only when
+                        rbac.allowNodeActions is set. Without it the Automation reports the target
+                        as unreachable and names the value to set.
+                      type: boolean
                     notification:
                       description: Notification is the message a notification.* action
                         sends.
@@ -512,6 +558,7 @@ spec:
                           - Deployment
                           - StatefulSet
                           - CronJob
+                          - Node
                           type: string
                         name:
                           description: Name of the target resource.
@@ -522,11 +569,18 @@ spec:
                             Namespace of the target resource. Defaults to the Automation's own
                             namespace. Cross-namespace targets require the controller to run with
                             cluster-wide RBAC; otherwise the Automation reports Ready=False.
+
+                            Rejected on a cluster-scoped kind. A Node addressed inside a namespace is
+                            not a different Node, it is a lookup that cannot succeed.
                           type: string
                       required:
                       - kind
                       - name
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'target.namespace: a Node is cluster-scoped and takes
+                          no namespace'
+                        rule: self.kind != 'Node' || !has(self.__namespace__)
                     timeoutSeconds:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
@@ -543,6 +597,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.cordon
                       - kubernetes.restart
                       - http.request
                       - notification.ntfy
@@ -566,6 +621,11 @@ spec:
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
                   - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
                     rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: cordoned belongs to kubernetes.cordon'
+                    rule: self.type == 'kubernetes.cordon' || !has(self.cordoned)
+                  - message: 'spec.actions: kubernetes.cordon targets a Node'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cordon''
+                      || self.target.kind == ''Node'''
                   - message: 'spec.actions: kubernetes.scale targets a kind with a
                       scale subresource: Deployment or StatefulSet'
                     rule: '!has(self.target) || self.type != ''kubernetes.scale''

--- a/charts/reactor/templates/rbac.yaml
+++ b/charts/reactor/templates/rbac.yaml
@@ -111,6 +111,52 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "reactor.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- if .Values.rbac.allowNodeActions }}
+---
+# kubernetes.cordon, and nothing else. Off unless rbac.allowNodeActions is set,
+# because this is the one grant here that reaches outside the workloads Reactor
+# was installed to manage.
+#
+# It is a ClusterRole in BOTH RBAC modes, and it has to be: Nodes are
+# cluster-scoped, and a namespaced Role cannot grant access to them at all. So
+# turning this on in a namespace-scoped install is a real widening of the
+# operator's reach, not a formality — it is the reason this is a separate
+# object with its own value rather than three more lines in the rule list above.
+#
+# What it does and does not permit:
+#   - patch on nodes lets Reactor set spec.unschedulable and write its own
+#     baseline and claim annotations. It also lets it write any other node
+#     label or annotation, which is not a permission Kubernetes lets us split
+#     more finely, and is the honest cost of this feature.
+#   - It grants nothing over pods and nothing over pods/eviction, so Reactor
+#     cannot drain a node however it is configured. That action is not
+#     implemented, and this is the second lock on it.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "reactor.fullname" . }}-node-actions
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "reactor.fullname" . }}-node-actions
+  labels:
+    {{- include "reactor.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "reactor.fullname" . }}-node-actions
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "reactor.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
 ---
 # Leader election needs lease access in the release namespace in both modes.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/reactor/templates/rbac.yaml
+++ b/charts/reactor/templates/rbac.yaml
@@ -28,9 +28,33 @@ rules:
   - apiGroups: ["reactor.robbeverhelst.com"]
     resources: ["automations/finalizers"]
     verbs: ["update"]
+  # The target kinds an Automation may name, and nothing else. Reactor reads a
+  # target as an unstructured object through its uncached client, so a kind
+  # costs "get" to read and "patch" to write it — no list, no watch, and no
+  # informer holding every Deployment in the cluster in the operator's memory.
+  #
+  # This list and the target.kind enum in the CRD are the same decision written
+  # twice: the enum is what turns an unsupported kind into a rejected write at
+  # admission instead of a Forbidden at 3am. Adding a kind means adding it to
+  # both.
+  #
+  # kubernetes.scale reads and writes a replica count through the scale
+  # subresource, so a scalable kind is two rules: its own object, for the
+  # annotations that record the baseline and the claim, and its /scale, for the
+  # level. That split is what lets one executor serve every scalable kind
+  # without knowing where any of them keeps its replicas.
   - apiGroups: ["apps"]
-    resources: ["deployments"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "patch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments/scale", "statefulsets/scale"]
+    verbs: ["get", "update"]
+  # kubernetes.cronjob.suspend. Suspending sets spec.suspend and nothing else:
+  # this grants no permission over Jobs, so a Job already running is untouched
+  # and untouchable, which is deliberate.
+  - apiGroups: ["batch"]
+    resources: ["cronjobs"]
+    verbs: ["get", "patch"]
   # Events on the Automations themselves: every transition, every write to a
   # target, every action that failed. Automations live in the namespaces they
   # act on, so this follows the same scope as the rest of the manager's rules

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -239,6 +239,28 @@ rbac:
   #   can only target resources in that same namespace.
   clusterWide: true
 
+  # Let Automations use kubernetes.cordon, which closes a node to new
+  # scheduling while a condition holds — a worker running on a UPS whose
+  # battery is draining, say, so that replacement pods land on the node still
+  # on mains.
+  #
+  # Off by default, and it is the one permission here that reaches outside the
+  # workloads you installed Reactor to manage. Nodes are cluster-scoped, so
+  # enabling this creates a ClusterRole even when rbac.clusterWide is false —
+  # a namespaced Role cannot grant node access at all. Read that as a real
+  # widening of the operator's reach, not a formality.
+  #
+  # What it grants: get and patch on nodes. Kubernetes has no way to narrow
+  # patch to one field, so this also permits writing node labels and
+  # annotations. What it does NOT grant, at all and under any setting: pods or
+  # pods/eviction. Reactor cannot drain a node — that action is not implemented
+  # on purpose, because an eviction cannot be reversed and so has no level to
+  # arbitrate and no reversal to declare. See the README.
+  #
+  # Leaving this false does not break an Automation that uses kubernetes.cordon;
+  # it reports the node as unreachable and names this value.
+  allowNodeActions: false
+
 serviceAccount:
   create: true
   name: ""

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -318,8 +318,16 @@ func main() {
 	}
 
 	mgr, err := ctrl.NewManager(restConfig, ctrl.Options{
-		Scheme:                 scheme,
-		Cache:                  cacheOptions,
+		Scheme: scheme,
+		Cache:  cacheOptions,
+		// Targets are read as unstructured objects so that no code path has to
+		// enumerate target kinds. Saying explicitly that unstructured reads are
+		// not cached is what lets the chart grant get and patch on those kinds
+		// and nothing else: a cached read would start an informer, which needs
+		// list and watch, and would hold every Deployment in the cluster in
+		// this process's memory to answer a question asked once every fifteen
+		// seconds about one of them.
+		Client:                 client.Options{Cache: &client.CacheOptions{Unstructured: false}},
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
 		HealthProbeBindAddress: probeAddr,

--- a/config/crd/bases/reactor.robbeverhelst.com_automations.yaml
+++ b/config/crd/bases/reactor.robbeverhelst.com_automations.yaml
@@ -74,9 +74,9 @@ spec:
 
                     Types divide into two kinds. A desired-state action (kubernetes.scale,
                     kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
-                    across every Automation sharing its target. An edge action (http.request,
-                    notification.*) expresses an occurrence: it fires on this Automation's own
-                    transitions, owns no target and arbitrates with nothing.
+                    across every Automation sharing its target. An edge action (kubernetes.restart,
+                    http.request, notification.*) expresses an occurrence: it fires on this
+                    Automation's own transitions, owns no target and arbitrates with nothing.
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
@@ -279,6 +279,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.restart
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -308,6 +309,10 @@ spec:
                   - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
                     rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
                       || self.target.kind == ''CronJob'''
+                  - message: 'spec.actions: kubernetes.restart targets a kind with
+                      a pod template: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.restart''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
                 minItems: 1
                 type: array
               onExit:
@@ -324,9 +329,9 @@ spec:
 
                     Types divide into two kinds. A desired-state action (kubernetes.scale,
                     kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
-                    across every Automation sharing its target. An edge action (http.request,
-                    notification.*) expresses an occurrence: it fires on this Automation's own
-                    transitions, owns no target and arbitrates with nothing.
+                    across every Automation sharing its target. An edge action (kubernetes.restart,
+                    http.request, notification.*) expresses an occurrence: it fires on this
+                    Automation's own transitions, owns no target and arbitrates with nothing.
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
@@ -529,6 +534,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.restart
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -558,6 +564,10 @@ spec:
                   - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
                     rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
                       || self.target.kind == ''CronJob'''
+                  - message: 'spec.actions: kubernetes.restart targets a kind with
+                      a pod template: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.restart''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
                 type: array
               reversal:
                 description: |-

--- a/config/crd/bases/reactor.robbeverhelst.com_automations.yaml
+++ b/config/crd/bases/reactor.robbeverhelst.com_automations.yaml
@@ -72,11 +72,16 @@ spec:
                     Action is a single normalized action. Type selects the action provider;
                     the provider-specific fields are flat and validated per type.
 
-                    Types divide into two kinds. A desired-state action (kubernetes.scale)
-                    declares a level and is arbitrated continuously across every Automation
-                    sharing its target. An edge action (http.request, notification.*) expresses
-                    an occurrence: it fires on this Automation's own transitions, owns no target
-                    and arbitrates with nothing.
+                    Types divide into two kinds. A desired-state action (kubernetes.scale,
+                    kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
+                    across every Automation sharing its target. An edge action (http.request,
+                    notification.*) expresses an occurrence: it fires on this Automation's own
+                    transitions, owns no target and arbitrates with nothing.
+
+                    A desired-state action's level is an integer the arbiter orders and nothing
+                    more, so a boolean level is carried as its own field — replicas for a count,
+                    suspended for a switch — rather than by overloading one of them. The units
+                    differ; the ordering does not.
                   properties:
                     notification:
                       description: Notification is the message a notification.* action
@@ -208,14 +213,41 @@ spec:
                           maxLength: 2048
                           type: string
                       type: object
+                    suspended:
+                      description: |-
+                        Suspended is whether kubernetes.cronjob.suspend wants the target CronJob
+                        suspended. Omitting it means true, which is what the action is named
+                        after; write suspended: false in spec.onExit to ask for it back.
+
+                        Suspending stops new Jobs being created. It deliberately does nothing to
+                        a Job already running: killing work in flight is a different and much
+                        more dangerous action than declining to start more of it, and mid-flight
+                        deletion is not something an outage should decide on your behalf.
+                      type: boolean
                     target:
                       description: Target of a kubernetes.* action.
                       properties:
                         kind:
-                          description: Kind of the target resource. Only "Deployment"
-                            is supported in v1alpha1.
+                          description: |-
+                            Kind of the target resource.
+
+                            kubernetes.scale works through the scale subresource, so its executor is
+                            kind-agnostic: any object exposing /scale can be held at a replica count
+                            without Reactor knowing where that kind keeps its replicas. This list is
+                            nevertheless closed, and that is the deliberate half of the trade-off
+                            #17 asks about.
+
+                            An open field would buy nothing an operator can use. A kind is only
+                            reachable if the chart granted RBAC for it, and RBAC has to name
+                            resources explicitly — so an open enum would accept a kind Reactor cannot
+                            touch and turn a typo into a Forbidden discovered during the outage the
+                            Automation was written for, instead of a rejected write at admission.
+                            Adding a kind is an entry here and a rule in the chart, and no executor
+                            code either way.
                           enum:
                           - Deployment
+                          - StatefulSet
+                          - CronJob
                           type: string
                         name:
                           description: Name of the target resource.
@@ -235,7 +267,7 @@ spec:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
                         unreachable target or endpoint cannot occupy a reconcile indefinitely.
-                        Defaults to 30 for kubernetes.scale and to 10 for the outbound actions,
+                        Defaults to 30 for the kubernetes.* actions and to 10 for the outbound ones,
                         which may retry within the same reconcile. Exceeding it is recorded as a
                         failed execution, not held open.
                       format: int32
@@ -246,6 +278,7 @@ spec:
                       description: Type of the action, e.g. "kubernetes.scale".
                       enum:
                       - kubernetes.scale
+                      - kubernetes.cronjob.suspend
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -261,11 +294,20 @@ spec:
                   - message: 'spec.actions: notification is required by the notification.*
                       types and rejected on every other type'
                     rule: self.type.startsWith('notification.') == has(self.notification)
-                  - message: 'spec.actions: target belongs to kubernetes.* actions;
-                      the outbound actions have no target'
-                    rule: self.type == 'kubernetes.scale' || !has(self.target)
+                  - message: 'spec.actions: target is required by the kubernetes.*
+                      actions and rejected on every other type'
+                    rule: self.type.startsWith('kubernetes.') == has(self.target)
                   - message: 'spec.actions: replicas belongs to kubernetes.scale'
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
+                  - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
+                    rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: kubernetes.scale targets a kind with a
+                      scale subresource: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.scale''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
+                  - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
+                      || self.target.kind == ''CronJob'''
                 minItems: 1
                 type: array
               onExit:
@@ -280,11 +322,16 @@ spec:
                     Action is a single normalized action. Type selects the action provider;
                     the provider-specific fields are flat and validated per type.
 
-                    Types divide into two kinds. A desired-state action (kubernetes.scale)
-                    declares a level and is arbitrated continuously across every Automation
-                    sharing its target. An edge action (http.request, notification.*) expresses
-                    an occurrence: it fires on this Automation's own transitions, owns no target
-                    and arbitrates with nothing.
+                    Types divide into two kinds. A desired-state action (kubernetes.scale,
+                    kubernetes.cronjob.suspend) declares a level and is arbitrated continuously
+                    across every Automation sharing its target. An edge action (http.request,
+                    notification.*) expresses an occurrence: it fires on this Automation's own
+                    transitions, owns no target and arbitrates with nothing.
+
+                    A desired-state action's level is an integer the arbiter orders and nothing
+                    more, so a boolean level is carried as its own field — replicas for a count,
+                    suspended for a switch — rather than by overloading one of them. The units
+                    differ; the ordering does not.
                   properties:
                     notification:
                       description: Notification is the message a notification.* action
@@ -416,14 +463,41 @@ spec:
                           maxLength: 2048
                           type: string
                       type: object
+                    suspended:
+                      description: |-
+                        Suspended is whether kubernetes.cronjob.suspend wants the target CronJob
+                        suspended. Omitting it means true, which is what the action is named
+                        after; write suspended: false in spec.onExit to ask for it back.
+
+                        Suspending stops new Jobs being created. It deliberately does nothing to
+                        a Job already running: killing work in flight is a different and much
+                        more dangerous action than declining to start more of it, and mid-flight
+                        deletion is not something an outage should decide on your behalf.
+                      type: boolean
                     target:
                       description: Target of a kubernetes.* action.
                       properties:
                         kind:
-                          description: Kind of the target resource. Only "Deployment"
-                            is supported in v1alpha1.
+                          description: |-
+                            Kind of the target resource.
+
+                            kubernetes.scale works through the scale subresource, so its executor is
+                            kind-agnostic: any object exposing /scale can be held at a replica count
+                            without Reactor knowing where that kind keeps its replicas. This list is
+                            nevertheless closed, and that is the deliberate half of the trade-off
+                            #17 asks about.
+
+                            An open field would buy nothing an operator can use. A kind is only
+                            reachable if the chart granted RBAC for it, and RBAC has to name
+                            resources explicitly — so an open enum would accept a kind Reactor cannot
+                            touch and turn a typo into a Forbidden discovered during the outage the
+                            Automation was written for, instead of a rejected write at admission.
+                            Adding a kind is an entry here and a rule in the chart, and no executor
+                            code either way.
                           enum:
                           - Deployment
+                          - StatefulSet
+                          - CronJob
                           type: string
                         name:
                           description: Name of the target resource.
@@ -443,7 +517,7 @@ spec:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
                         unreachable target or endpoint cannot occupy a reconcile indefinitely.
-                        Defaults to 30 for kubernetes.scale and to 10 for the outbound actions,
+                        Defaults to 30 for the kubernetes.* actions and to 10 for the outbound ones,
                         which may retry within the same reconcile. Exceeding it is recorded as a
                         failed execution, not held open.
                       format: int32
@@ -454,6 +528,7 @@ spec:
                       description: Type of the action, e.g. "kubernetes.scale".
                       enum:
                       - kubernetes.scale
+                      - kubernetes.cronjob.suspend
                       - http.request
                       - notification.ntfy
                       - notification.discord
@@ -469,11 +544,20 @@ spec:
                   - message: 'spec.actions: notification is required by the notification.*
                       types and rejected on every other type'
                     rule: self.type.startsWith('notification.') == has(self.notification)
-                  - message: 'spec.actions: target belongs to kubernetes.* actions;
-                      the outbound actions have no target'
-                    rule: self.type == 'kubernetes.scale' || !has(self.target)
+                  - message: 'spec.actions: target is required by the kubernetes.*
+                      actions and rejected on every other type'
+                    rule: self.type.startsWith('kubernetes.') == has(self.target)
                   - message: 'spec.actions: replicas belongs to kubernetes.scale'
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
+                  - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
+                    rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: kubernetes.scale targets a kind with a
+                      scale subresource: Deployment or StatefulSet'
+                    rule: '!has(self.target) || self.type != ''kubernetes.scale''
+                      || self.target.kind in [''Deployment'', ''StatefulSet'']'
+                  - message: 'spec.actions: kubernetes.cronjob.suspend targets a CronJob'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cronjob.suspend''
+                      || self.target.kind == ''CronJob'''
                 type: array
               reversal:
                 description: |-
@@ -733,19 +817,33 @@ spec:
                       type: array
                     desired:
                       description: |-
-                        Desired is the value this Automation alone wants right now, whether it
+                        Desired is the level this Automation alone wants right now, whether it
                         is currently matching or reversing. Absent when it wants nothing —
                         reversal None, or a reversal value it has no way to know.
+
+                        A level is ordered and nothing more: lower is more restrictive, and the
+                        arbiter resolves a shared target by taking the lowest. What the number
+                        counts depends on the action that produced it — replicas for
+                        kubernetes.scale, and 0 suspended / 1 running for
+                        kubernetes.cronjob.suspend. Level spells the same value out in words.
                       format: int32
                       type: integer
                     effective:
                       description: |-
-                        Effective is the value arbitration resolved to across every Automation
+                        Effective is the level arbitration resolved to across every Automation
                         claiming this target. Absent while nothing claims it.
                       format: int32
                       type: integer
+                    level:
+                      description: |-
+                        Level renders Effective in the units of the action that set it — "3
+                        replicas", "suspended" — because a bare number stops explaining itself
+                        once a target's level is a switch rather than a count.
+                      type: string
                     ref:
-                      description: Ref is the target this entry describes, as "Kind/namespace/name".
+                      description: |-
+                        Ref is the target this entry describes, as "Kind/namespace/name", or
+                        "Kind/name" for a cluster-scoped target.
                       type: string
                   required:
                   - ref

--- a/config/crd/bases/reactor.robbeverhelst.com_automations.yaml
+++ b/config/crd/bases/reactor.robbeverhelst.com_automations.yaml
@@ -80,9 +80,25 @@ spec:
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
-                    suspended for a switch — rather than by overloading one of them. The units
-                    differ; the ordering does not.
+                    suspended and cordoned for a switch — rather than by overloading one of them.
+                    The units differ; the ordering does not.
                   properties:
+                    cordoned:
+                      description: |-
+                        Cordoned is whether kubernetes.cordon wants the target Node closed to new
+                        scheduling. Omitting it means true, which is what the action is named
+                        after; write cordoned: false in spec.onExit to reopen it explicitly.
+
+                        Cordoning stops new Pods being scheduled onto the Node and moves nothing
+                        that is already running. Evicting those — draining — is not offered, and
+                        not because it was not built: an eviction cannot be reversed, so it has no
+                        level to arbitrate and no reversal to declare, which is the one property
+                        every other action here has. See docs/spec.md.
+
+                        Node actions need cluster-scoped RBAC that the chart grants only when
+                        rbac.allowNodeActions is set. Without it the Automation reports the target
+                        as unreachable and names the value to set.
+                      type: boolean
                     notification:
                       description: Notification is the message a notification.* action
                         sends.
@@ -248,6 +264,7 @@ spec:
                           - Deployment
                           - StatefulSet
                           - CronJob
+                          - Node
                           type: string
                         name:
                           description: Name of the target resource.
@@ -258,11 +275,18 @@ spec:
                             Namespace of the target resource. Defaults to the Automation's own
                             namespace. Cross-namespace targets require the controller to run with
                             cluster-wide RBAC; otherwise the Automation reports Ready=False.
+
+                            Rejected on a cluster-scoped kind. A Node addressed inside a namespace is
+                            not a different Node, it is a lookup that cannot succeed.
                           type: string
                       required:
                       - kind
                       - name
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'target.namespace: a Node is cluster-scoped and takes
+                          no namespace'
+                        rule: self.kind != 'Node' || !has(self.__namespace__)
                     timeoutSeconds:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
@@ -279,6 +303,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.cordon
                       - kubernetes.restart
                       - http.request
                       - notification.ntfy
@@ -302,6 +327,11 @@ spec:
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
                   - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
                     rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: cordoned belongs to kubernetes.cordon'
+                    rule: self.type == 'kubernetes.cordon' || !has(self.cordoned)
+                  - message: 'spec.actions: kubernetes.cordon targets a Node'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cordon''
+                      || self.target.kind == ''Node'''
                   - message: 'spec.actions: kubernetes.scale targets a kind with a
                       scale subresource: Deployment or StatefulSet'
                     rule: '!has(self.target) || self.type != ''kubernetes.scale''
@@ -335,9 +365,25 @@ spec:
 
                     A desired-state action's level is an integer the arbiter orders and nothing
                     more, so a boolean level is carried as its own field — replicas for a count,
-                    suspended for a switch — rather than by overloading one of them. The units
-                    differ; the ordering does not.
+                    suspended and cordoned for a switch — rather than by overloading one of them.
+                    The units differ; the ordering does not.
                   properties:
+                    cordoned:
+                      description: |-
+                        Cordoned is whether kubernetes.cordon wants the target Node closed to new
+                        scheduling. Omitting it means true, which is what the action is named
+                        after; write cordoned: false in spec.onExit to reopen it explicitly.
+
+                        Cordoning stops new Pods being scheduled onto the Node and moves nothing
+                        that is already running. Evicting those — draining — is not offered, and
+                        not because it was not built: an eviction cannot be reversed, so it has no
+                        level to arbitrate and no reversal to declare, which is the one property
+                        every other action here has. See docs/spec.md.
+
+                        Node actions need cluster-scoped RBAC that the chart grants only when
+                        rbac.allowNodeActions is set. Without it the Automation reports the target
+                        as unreachable and names the value to set.
+                      type: boolean
                     notification:
                       description: Notification is the message a notification.* action
                         sends.
@@ -503,6 +549,7 @@ spec:
                           - Deployment
                           - StatefulSet
                           - CronJob
+                          - Node
                           type: string
                         name:
                           description: Name of the target resource.
@@ -513,11 +560,18 @@ spec:
                             Namespace of the target resource. Defaults to the Automation's own
                             namespace. Cross-namespace targets require the controller to run with
                             cluster-wide RBAC; otherwise the Automation reports Ready=False.
+
+                            Rejected on a cluster-scoped kind. A Node addressed inside a namespace is
+                            not a different Node, it is a lookup that cannot succeed.
                           type: string
                       required:
                       - kind
                       - name
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'target.namespace: a Node is cluster-scoped and takes
+                          no namespace'
+                        rule: self.kind != 'Node' || !has(self.__namespace__)
                     timeoutSeconds:
                       description: |-
                         TimeoutSeconds bounds a single attempt at this action, so an
@@ -534,6 +588,7 @@ spec:
                       enum:
                       - kubernetes.scale
                       - kubernetes.cronjob.suspend
+                      - kubernetes.cordon
                       - kubernetes.restart
                       - http.request
                       - notification.ntfy
@@ -557,6 +612,11 @@ spec:
                     rule: self.type == 'kubernetes.scale' || !has(self.replicas)
                   - message: 'spec.actions: suspended belongs to kubernetes.cronjob.suspend'
                     rule: self.type == 'kubernetes.cronjob.suspend' || !has(self.suspended)
+                  - message: 'spec.actions: cordoned belongs to kubernetes.cordon'
+                    rule: self.type == 'kubernetes.cordon' || !has(self.cordoned)
+                  - message: 'spec.actions: kubernetes.cordon targets a Node'
+                    rule: '!has(self.target) || self.type != ''kubernetes.cordon''
+                      || self.target.kind == ''Node'''
                   - message: 'spec.actions: kubernetes.scale targets a kind with a
                       scale subresource: Deployment or StatefulSet'
                     rule: '!has(self.target) || self.type != ''kubernetes.scale''

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,12 +14,25 @@ rules:
   - apps
   resources:
   - deployments
+  - statefulsets
   verbs:
   - get
-  - list
   - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments/scale
+  - statefulsets/scale
+  verbs:
+  - get
   - update
-  - watch
+- apiGroups:
+  - batch
+  resources:
+  - cronjobs
+  verbs:
+  - get
+  - patch
 - apiGroups:
   - events.k8s.io
   resources:

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -571,6 +571,55 @@ permission over Jobs at all: declining to start more work is a categorically
 safer act than killing work in flight, and deleting in-flight Jobs is not
 something an outage should decide on the operator's behalf.
 
+#### Cordon — and why there is no drain
+
+`kubernetes.cordon` is shipped, as a desired-state action behind an explicit
+chart opt-in:
+
+```yaml
+- type: kubernetes.cordon
+  target:
+    kind: Node
+    name: worker-03
+  cordoned: true         # optional; true is the default
+```
+
+`spec.unschedulable` is a level, ordered so that cordoned is the restrictive
+answer, so it folds like every other level and needs no new rule. It is the
+first cluster-scoped target, which is why `target.namespace` is rejected on a
+`Node` rather than defaulted.
+
+`kubernetes.drain` — proposed in #18 alongside it — is **deliberately not
+implemented**. Not deferred behind a flag, not implemented with a timeout: not
+built. The reasoning, because a well-evidenced "no" is worth more here than a
+dangerous feature:
+
+1. **An eviction cannot be reversed, so it cannot be a level.** Every action in
+   this design declares a value that is a pure function of which conditions
+   currently hold — that is what makes the outcome independent of reconcile
+   order, a controller restart harmless, and `onExit` expressible. A drain has
+   no such value. There is no state a node can be held at that means "drained",
+   nothing for `spec.reversal` to declare, and nothing for a later reconcile to
+   correct. A flapping key would empty the node once per flap.
+2. **It inverts its own goal on a small cluster.** Draining assumes spare
+   capacity elsewhere. On three nodes behind one UPS the evicted pods do not
+   move, they go Pending — so the workload is lost at the moment of the drain
+   rather than at the moment the battery dies. Cordoning delivers the actual
+   benefit (new pods land on the node still on mains) without that cost.
+3. **It can evict the operator performing it**, if Reactor's own pod is on the
+   node. Nothing else here can kill the thing doing and reporting the work,
+   mid-action.
+4. **It hangs by design.** Eviction respects PodDisruptionBudgets, and a
+   single-replica workload with `minAvailable: 1` blocks indefinitely. A
+   timeout bounds the call; it does not bound a half-drained node.
+
+The RBAC follows the decision rather than merely reflecting it:
+`rbac.allowNodeActions` grants `nodes` and nothing over `pods` or
+`pods/eviction`, under any setting. An operator whose plan genuinely needs a
+drain should pair `kubernetes.cordon` with a notification and run `kubectl
+drain` by hand — an irreversible cluster-wide decision at 3am is the right
+place for a human.
+
 #### Patch resource
 
 Potential future action:
@@ -781,6 +830,15 @@ cluster-admin
 
 unless there is a compelling reason.
 
+Anything reaching outside the workloads Reactor was installed to manage is
+opt-in rather than default, and is a separate object so that turning it on is a
+visible decision. `kubernetes.cordon` is the only such permission today: nodes
+are cluster-scoped, so `rbac.allowNodeActions` creates a ClusterRole even in a
+namespace-scoped install, and the chart says so where the value is set. The
+generated `config/rbac/role.yaml` deliberately does not carry it, so the
+manifest bundle grants no node access at all.
+
+Document how users can restrict Reactor's permissions.
 
 ## Observability
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -506,14 +506,38 @@ written where the API server can enforce it.
 
 #### Restart
 
-Potential future action:
+Shipped, as an **edge** action. There is no value a workload can be held at
+that means "restarted", so it declares no level, participates in no
+arbitration, and fires on its own Automation's transition:
 
 ```yaml
 - type: kubernetes.restart
   target:
-    kind: Deployment
+    kind: Deployment      # or StatefulSet
     name: qbittorrent
 ```
+
+It stamps `kubectl.kubernetes.io/restartedAt` on the pod template — the same
+annotation `kubectl rollout restart` writes, so a workload Reactor restarted
+and one restarted by hand are indistinguishable afterwards, and the workload
+controller rolls the pods under the update strategy and disruption budget the
+workload already declares. Reactor never deletes a pod.
+
+**At-most-once, unconditionally.** This is the first non-idempotent action, and
+it is the reason #33's retry policy is per-type rather than global. Every
+execution rolls the workload, so retrying after an ambiguous failure is a
+second outage rather than a correction, and the failures that actually occur —
+a conflict, a Forbidden — are not ones a retry fixes. It is attempted once per
+transition, recorded in `status.edgeActions`, and never retried: not within the
+reconcile, and not across reconciles, because the transition is committed to
+status before the action runs and a later reconcile therefore sees no edge.
+
+**It is also what makes #30's debounce load-bearing.** The engine acts on
+transitions, so a steady condition never restarts twice — but a flapping key is
+a stream of transitions and each one is a real rollout. Scaling made flapping
+harmless; this does not. The default debounce of 1 was chosen for
+`kubernetes.scale`, and a key that drives a restart should be raised above it,
+at a cost of one poll interval of reaction time per extra sample.
 
 #### Suspend CronJob
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -485,10 +485,24 @@ Initial Kubernetes actions:
 ```yaml
 - type: kubernetes.scale
   target:
-    kind: Deployment
+    kind: Deployment      # or StatefulSet
     name: qbittorrent
   replicas: 0
 ```
+
+Reads and writes go through the `scale` subresource rather than the kind's own
+`spec.replicas`. `/scale` is the interface that says "this object has a replica
+count" without saying where it is kept, so one executor serves every scalable
+kind: adding one is an entry in the handler registry, an entry in the CRD enum
+and an RBAC rule, and no new executor code.
+
+`target.kind` stays a **closed enum** anyway, which is the deliberate half of
+the trade-off. The gain from opening it would be imaginary: a kind is only
+reachable if the chart granted RBAC for it, and RBAC has to name resources
+explicitly, so an open field would accept a kind the operator cannot touch and
+report a typo as a `Forbidden` during the incident rather than as a rejected
+write at admission. The enum is the same decision as the chart's rule list,
+written where the API server can enforce it.
 
 #### Restart
 
@@ -503,14 +517,35 @@ Potential future action:
 
 #### Suspend CronJob
 
-Potential future action:
+Shipped. Desired-state, and the first action whose level is a switch rather
+than a count:
 
 ```yaml
 - type: kubernetes.cronjob.suspend
   target:
+    kind: CronJob
     name: large-backup
-  suspended: true
+  suspended: true          # optional; true is the default
 ```
+
+`engine.Resolve` was deliberately *not* generalised over an ordered type
+parameter to accommodate it. A switch is a two-element lattice, and embedding
+it in the integers as "suspended is 0, running is 1" is order-preserving, so
+the meet stays `min` and "most restrictive wins" stays "suspended wins" without
+the engine learning a second kind of value. A target has exactly one kind, so
+two levels in different units never meet in the first place — the generality
+would have had no case to serve.
+
+The baseline is recorded under `reactor.robbeverhelst.com/baseline-suspend`,
+not under `baseline-replicas`. That annotation is a compatibility promise about
+replica counts as of v1.0, and a reader — a person, or a script over `kubectl
+get -o custom-columns` — is entitled to keep reading `"1"` there as one
+replica. A kind whose level is not a count records it under its own name.
+
+Suspending does not stop a Job already running, and deliberately grants no
+permission over Jobs at all: declining to start more work is a categorically
+safer act than killing work in flight, and deleting in-flight Jobs is not
+something an outage should decide on the operator's behalf.
 
 #### Patch resource
 
@@ -701,11 +736,18 @@ The operator should follow least privilege.
 If the controller needs:
 
 ```text
-get/list/watch deployments
+get deployments
 patch deployments
 ```
 
 give it exactly those permissions.
+
+As shipped, a target kind costs `get` and `patch` and nothing else. Targets are
+read as unstructured objects through the manager's uncached client, so no
+target kind starts an informer — which is what would have made `list` and
+`watch` necessary, and would have held every object of that kind in the
+operator's memory to answer a question asked about one of them every fifteen
+seconds.
 
 Do not ship:
 

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -757,7 +757,6 @@ cluster-admin
 
 unless there is a compelling reason.
 
-Document how users can restrict Reactor's permissions.
 
 ## Observability
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -90,7 +90,7 @@ kubectl -n media describe automation pause-downloads-on-backup-wan | tail -20
 | Reason | Type | Means |
 | --- | --- | --- |
 | `StateEntered` / `StateExited` | Normal | the condition started or stopped holding; the message names the key that moved |
-| `TargetScaled` / `TargetReleased` | Normal | a write to a target actually happened |
+| `TargetHeld` / `TargetReleased` | Normal | a write to a target actually happened; the message names the level in words ("0 replicas", "suspended") |
 | `DeferredToOtherAutomation` | Normal | a peer's more restrictive claim won — [§7](#7-two-automations-fighting-over-one-target) |
 | `EdgeActionSent` | Normal | a notification or HTTP request was delivered |
 | `StateKeyUnavailable` | Warning | a key vanished and state is being held — [§2](#2-statekeyunavailable-and-held-state) |
@@ -328,6 +328,14 @@ kubectl auth can-i patch deployments \
   --as system:serviceaccount:reactor-system:reactor
 ```
 
+Scaling needs **two** permissions, because a replica count is read and written through the `scale` subresource while the baseline annotation goes on the object itself. If a target's annotations appear but its replicas never move, this is why:
+
+```sh
+kubectl auth can-i update statefulsets/scale \
+  --namespace other-ns \
+  --as system:serviceaccount:reactor-system:reactor
+```
+
 Two ways out, and the second is usually better in a homelab you did not want cluster-wide RBAC in:
 
 - `helm upgrade ... --set rbac.clusterWide=true`
@@ -413,7 +421,7 @@ status:
 
 ```sh
 kubectl -n media get deploy qbittorrent -o jsonpath='{.metadata.annotations}'
-# reactor.robbeverhelst.com/baseline-replicas: "1"
+# reactor.robbeverhelst.com/baseline-replicas: "1"   # or baseline-suspend on a CronJob
 # reactor.robbeverhelst.com/claimed-by: "power/shed-on-battery,net/pause-on-backup-wan"
 # reactor.robbeverhelst.com/claimed-at: "..."
 ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -92,11 +92,11 @@ kubectl -n media describe automation pause-downloads-on-backup-wan | tail -20
 | `StateEntered` / `StateExited` | Normal | the condition started or stopped holding; the message names the key that moved |
 | `TargetHeld` / `TargetReleased` | Normal | a write to a target actually happened; the message names the level in words ("0 replicas", "suspended") |
 | `DeferredToOtherAutomation` | Normal | a peer's more restrictive claim won — [§7](#7-two-automations-fighting-over-one-target) |
-| `EdgeActionSent` | Normal | a notification or HTTP request was delivered |
+| `EdgeActionSent` | Normal | an edge action ran: a notification or HTTP request delivered, or a restart applied |
 | `StateKeyUnavailable` | Warning | a key vanished and state is being held — [§2](#2-statekeyunavailable-and-held-state) |
 | `ActionFailed` | Warning | a desired-state action could not be applied — [§5](#5-rbac-refuses-a-cross-namespace-target) |
 | `RetryBudgetExhausted` | Warning | Reactor stopped retrying and is waiting for the next state change |
-| `EdgeActionFailed` / `EdgeActionSkipped` | Warning | a notification or HTTP request did not go out — [§12](#12-a-notification-or-http-request-did-not-arrive) |
+| `EdgeActionFailed` / `EdgeActionSkipped` | Warning | an edge action did not happen — [§12](#12-a-notification-or-http-request-did-not-arrive) |
 | `ReleaseFailed` | Warning | deletion could not hand a target back and let the object go anyway — [§8](#8-a-workload-is-stuck-down-after-an-automation-was-deleted) |
 | `EventTriggerRemoved` | Warning | a leftover `spec.trigger` automation that does nothing; delete it |
 
@@ -577,9 +577,9 @@ The [compatibility matrix](../README.md#compatibility) is what these lines are c
 
 ---
 
-## 12. A notification or HTTP request did not arrive
+## 12. An edge action did not happen — or happened too often
 
-Outbound actions never fail the Automation — the scale is the thing that had to happen, the notification is the report of it — so `Ready` stays `True` and the answer is in `status.edgeActions` and in the resource's Events:
+Edge actions never fail the Automation — the desired-state action is the thing that had to happen, and a notification or a restart is not — so `Ready` stays `True` and the answer is in `status.edgeActions` and in the resource's Events:
 
 ```sh
 kubectl -n media get automation notify-on-failover -o jsonpath='{.status.edgeActions}' | jq
@@ -604,8 +604,31 @@ An empty `status.edgeActions` when you expected one means the action never fired
 - **The automation is suspended.** `spec.suspend: true` sends nothing, the same way a deleted one does not.
 - **It was a deletion.** Deleting an Automation is not a state transition and fires no edge action.
 
-A destination is only ever reported as `scheme://host:port`. That is not a truncation bug: for every notification transport the path is the credential, so it is kept out of status, logs and Events on purpose.
+A destination is only ever reported as `scheme://host:port`. That is not a truncation bug: for every notification transport the path is the credential, so it is kept out of status, logs and Events on purpose. A `kubernetes.restart` reports its target as `Kind/namespace/name` in the same field.
 
+### A workload keeps restarting
+
+`kubernetes.restart` is the only action where a repeat is harmful, so this has exactly one cause worth looking for: **the state key driving it is flapping.**
+
+```sh
+# how many times has this key actually changed value?
+#   increase(reactor_state_transitions_total{key="wan"}[1h])
+kubectl -n media describe automation restart-on-recovery | grep -E 'StateEntered|StateExited'
+```
+
+A pair of `StateEntered` / `StateExited` Events every poll is a flapping signal, not a restart bug. The engine only acts on transitions, so a *steady* condition never restarts anything twice — but each flap is a genuine transition and therefore a genuine rollout.
+
+The fix is [debounce](../README.md#settling-a-noisy-signal), and it belongs on the key rather than on the automation, so that every automation still sees one settled value:
+
+```sh
+helm upgrade reactor oci://ghcr.io/robbeverhelst/charts/reactor \
+  --namespace reactor-system --reuse-values \
+  --set unifi.debounce.keys.wan=3
+```
+
+Each extra sample costs one `pollInterval` of reaction time. The shipped default of `1` is chosen for `kubernetes.scale`, where a flap is harmless; a key that drives a restart should be raised above it. `spec.suspend: true` stops the restarts immediately while you decide.
+
+Two things that are *not* the cause: a reconcile without a transition (edge actions do not fire), and a retry (a restart is attempted exactly once per transition and never retried).
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -336,7 +336,17 @@ kubectl auth can-i update statefulsets/scale \
   --as system:serviceaccount:reactor-system:reactor
 ```
 
-Two ways out, and the second is usually better in a homelab you did not want cluster-wide RBAC in:
+A `Node` target is a different problem with a different fix. Node access is opt-in, so the message says so directly:
+
+```text
+Ready  False  ActionFailed
+target Node/worker-03 not reachable with current RBAC
+(node actions are opt-in: install with rbac.allowNodeActions=true): ...
+```
+
+Nodes are cluster-scoped, so enabling that creates a ClusterRole even in a namespace-scoped install — see the README before you do. The manifest bundle does not offer node RBAC at all; use the chart, or grant the ClusterRole yourself.
+
+Two ways out for a namespaced target, and the second is usually better in a homelab you did not want cluster-wide RBAC in:
 
 - `helm upgrade ... --set rbac.clusterWide=true`
 - Move the Automation into the target's namespace and drop `target.namespace`. Automations are namespaced precisely so they can live next to what they act on.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -606,6 +606,7 @@ An empty `status.edgeActions` when you expected one means the action never fired
 
 A destination is only ever reported as `scheme://host:port`. That is not a truncation bug: for every notification transport the path is the credential, so it is kept out of status, logs and Events on purpose.
 
+
 ---
 
 ## 13. Reactor is running but nothing is reacting

--- a/internal/controller/arbitration.go
+++ b/internal/controller/arbitration.go
@@ -19,14 +19,14 @@ package controller
 import (
 	"context"
 	"fmt"
+	"maps"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
-	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -34,21 +34,6 @@ import (
 	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
 	"github.com/robbeverhelst/unifi-reactor/internal/engine"
 	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
-)
-
-const (
-	// annotationBaselineReplicas records what a target was set to before
-	// Reactor first claimed it. It lives on the target rather than in an
-	// Automation's status because it has to outlive both the Automation and
-	// Reactor itself: it is the only thing that can answer "what was this
-	// before?" after the operator is uninstalled.
-	annotationBaselineReplicas = "reactor.robbeverhelst.com/baseline-replicas"
-	// annotationClaimedBy names the Automations currently holding the target.
-	// Advisory: refreshed on every claim, never read back as truth. It exists
-	// so that describing a Deployment explains why it is scaled to zero.
-	annotationClaimedBy = "reactor.robbeverhelst.com/claimed-by"
-	// annotationClaimedAt records when the current claim began.
-	annotationClaimedAt = "reactor.robbeverhelst.com/claimed-at"
 )
 
 // targetKey identifies a target workload across every Automation referencing
@@ -60,6 +45,9 @@ type targetKey struct {
 }
 
 func (k targetKey) String() string {
+	if k.Namespace == "" {
+		return k.Kind + "/" + k.Name
+	}
 	return k.Kind + "/" + k.Namespace + "/" + k.Name
 }
 
@@ -110,13 +98,15 @@ func references(automation *reactorv1alpha1.Automation, key targetKey) bool {
 // levelFor returns the level a set of actions asks for on one target.
 func levelFor(automation *reactorv1alpha1.Automation, actions []reactorv1alpha1.Action, key targetKey) (int64, bool) {
 	for _, action := range actions {
-		if !isDesiredState(action.Type) || action.Replicas == nil {
+		if !isDesiredState(action.Type) {
 			continue
 		}
 		if k, ok := targetKeyFor(automation, action); !ok || k != key {
 			continue
 		}
-		return int64(*action.Replicas), true
+		if level, ok := levelOfAction(action); ok {
+			return level, true
+		}
 	}
 	return 0, false
 }
@@ -163,17 +153,20 @@ func reversalFor(
 	}
 }
 
-// baselineOf reads the recorded pre-claim value off a target. recorded reports
+// baselineOf reads the recorded pre-claim level off a target. recorded reports
 // whether Reactor has ever claimed this target, which is what distinguishes
 // "release it back to where it was" from "never touched it, leave it alone".
 // A value that cannot be parsed still counts as recorded: the target is
 // released, it simply cannot contribute a baseline reversal.
-func baselineOf(deployment *appsv1.Deployment) (level *int64, recorded bool) {
-	raw, ok := deployment.Annotations[annotationBaselineReplicas]
+//
+// Which annotation holds it is the handler's business, because the level is
+// only a replica count for the kinds whose level is a count.
+func baselineOf(handler targetHandler, obj *unstructured.Unstructured) (level *int64, recorded bool) {
+	raw, ok := obj.GetAnnotations()[handler.baseline]
 	if !ok {
 		return nil, false
 	}
-	parsed, err := strconv.ParseInt(raw, 10, 32)
+	parsed, err := handler.parse(raw)
 	if err != nil {
 		return nil, true
 	}
@@ -202,6 +195,9 @@ type targetOutcome struct {
 	// effective is what arbitration resolved across every claimant, or nil
 	// while nothing claims the target.
 	effective *int32
+	// level says effective in the units of the action that set it, because a
+	// bare number stops explaining itself once a level is a switch.
+	level string
 	// deferredBy names the claimants holding the target away from desired.
 	deferredBy []string
 	// changed reports whether this reconcile actually wrote to the target.
@@ -227,14 +223,19 @@ func (r *AutomationReconciler) reconcileTarget(
 	ctx, cancel := context.WithTimeout(ctx, timeoutFor(self, key, selfMatching))
 	defer cancel()
 
+	handler, err := handlerFor(key.Kind)
+	if err != nil {
+		return outcome, err
+	}
+
 	peers, err := r.referencingAutomations(ctx, key, self)
 	if err != nil {
 		return outcome, err
 	}
 
-	var deployment appsv1.Deployment
+	target := newTarget(handler)
 	name := types.NamespacedName{Namespace: key.Namespace, Name: key.Name}
-	if err := r.Get(ctx, name, &deployment); err != nil {
+	if err := r.Get(ctx, name, target); err != nil {
 		if outOfScope(err) {
 			return outcome, fmt.Errorf(
 				"target %s not reachable with current RBAC (cross-namespace targets need cluster-wide permissions): %w",
@@ -242,7 +243,7 @@ func (r *AutomationReconciler) reconcileTarget(
 		}
 		return outcome, fmt.Errorf("getting target %s: %w", key, err)
 	}
-	baseline, recorded := baselineOf(&deployment)
+	baseline, recorded := baselineOf(handler, target)
 
 	var claims, reversals []engine.Intent
 	for _, peer := range peers {
@@ -277,35 +278,44 @@ func (r *AutomationReconciler) reconcileTarget(
 	case claimed:
 		value := int32(resolution.Level)
 		outcome.effective = &value
+		outcome.level = handler.describe(resolution.Level)
 		if outcome.desired != nil && *outcome.desired != value {
 			outcome.deferredBy = withoutClaimant(resolution.Winners, claimantOf(self))
 		}
 		metrics.ArbitrationResolved(outcomeOf(outcome))
-		changed, err := claimTarget(ctx, r.Client, &deployment, resolution, claims)
+		changed, err := claimTarget(ctx, r.Client, handler, target, resolution, claims)
 		outcome.changed = changed
 		return outcome, err
 
 	case recorded:
 		// Claimed before, claimed by nobody now: apply the agreed reversal and
 		// stop asserting a value for this target at all.
-		var level *int32
+		var level *int64
 		if release, ok := engine.Resolve(reversals); ok {
-			value := int32(release.Level)
-			level = &value
+			level = &release.Level
 		}
 		metrics.ArbitrationResolved(metrics.OutcomeReleased)
-		changed, err := releaseTarget(ctx, r.Client, &deployment, level)
+		changed, err := releaseTarget(ctx, r.Client, handler, target, level)
 		outcome.changed = changed
 		if changed {
-			log.Info("released target", "target", key.String(), "replicas", level)
+			log.Info("released target", "target", key.String(), "level", describeLevel(handler, level))
 		}
 		return outcome, err
 
 	default:
-		// Never claimed. Reactor asserts nothing, so the user is free to scale
+		// Never claimed. Reactor asserts nothing, so the user is free to change
 		// this workload by hand.
 		return outcome, nil
 	}
+}
+
+// describeLevel renders a level that may be absent, which is what a release
+// with every claimant on reversal None looks like.
+func describeLevel(handler targetHandler, level *int64) string {
+	if level == nil {
+		return "left as found"
+	}
+	return handler.describe(*level)
 }
 
 // timeoutFor bounds one attempt at a target, taken from the action this
@@ -335,7 +345,12 @@ func actionTypeFor(self *reactorv1alpha1.Automation, key targetKey, matching boo
 		}
 	}
 	// Reached only through a target this Automation names on the other side of
-	// the transition, e.g. a reversal to baseline with no onExit entry.
+	// the transition, e.g. a reversal to baseline with no onExit entry. The
+	// kind decides it, because a kind has exactly one desired-state action that
+	// reaches it.
+	if handler, err := handlerFor(key.Kind); err == nil {
+		return handler.actionType
+	}
 	return actionKubernetesScale
 }
 
@@ -425,97 +440,147 @@ func (r *AutomationReconciler) matchingOf(automation *reactorv1alpha1.Automation
 	return assessment.matching
 }
 
-// claimTarget writes the resolved value and marks the target as claimed.
+// claimTarget marks the target as claimed and writes the resolved level.
+//
+// The annotations go first and in their own write. The baseline is the record
+// of what the target was before Reactor touched it, so capturing it has to be
+// durable before the value it describes is overwritten: a crash between the two
+// leaves a target still at its own value with the baseline already recorded,
+// which the next reconcile corrects. The other order loses the baseline
+// permanently.
 func claimTarget(
 	ctx context.Context,
 	c client.Client,
-	deployment *appsv1.Deployment,
+	handler targetHandler,
+	target *unstructured.Unstructured,
 	resolution engine.Resolution,
 	claims []engine.Intent,
 ) (bool, error) {
-	patch := client.MergeFrom(deployment.DeepCopy())
-	dirty := false
-
-	if _, recorded := deployment.Annotations[annotationBaselineReplicas]; !recorded {
-		// Recorded once, on the transition from unclaimed to claimed. Writing
-		// it again later would capture the value Reactor itself set — after a
-		// controller restart mid-outage that means recording 0 as the
-		// baseline, and the workload never comes back.
-		baseline := int32(0)
-		if deployment.Spec.Replicas != nil {
-			baseline = *deployment.Spec.Replicas
-		}
-		dirty = setAnnotation(deployment, annotationBaselineReplicas, strconv.Itoa(int(baseline))) || dirty
-		dirty = setAnnotation(deployment, annotationClaimedAt, metav1.Now().UTC().Format(time.RFC3339)) || dirty
-	}
-
 	claimants := make([]string, 0, len(claims))
 	for _, claim := range claims {
 		claimants = append(claimants, claim.Claimant)
 	}
 	slices.Sort(claimants)
-	dirty = setAnnotation(deployment, annotationClaimedBy, strings.Join(claimants, ",")) || dirty
 
-	replicas := int32(resolution.Level)
-	if deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != replicas {
-		deployment.Spec.Replicas = &replicas
-		dirty = true
+	annotations := map[string]string{annotationClaimedBy: strings.Join(claimants, ",")}
+	if _, recorded := target.GetAnnotations()[handler.baseline]; !recorded {
+		// Recorded once, on the transition from unclaimed to claimed. Writing
+		// it again later would capture the value Reactor itself set — after a
+		// controller restart mid-outage that means recording 0 as the
+		// baseline, and the workload never comes back.
+		found, err := handler.read(ctx, c, target)
+		if err != nil {
+			return false, err
+		}
+		annotations[handler.baseline] = handler.format(found)
+		annotations[annotationClaimedAt] = metav1.Now().UTC().Format(time.RFC3339)
 	}
-	if !dirty {
-		return false, nil
+	changed, err := setAnnotations(ctx, c, target, annotations)
+	if err != nil {
+		return changed, fmt.Errorf("recording the claim on %s: %w", describeObject(target), err)
 	}
 
-	if err := c.Patch(ctx, deployment, patch); err != nil {
-		return false, fmt.Errorf("claiming %s/%s at %d replicas: %w",
-			deployment.Namespace, deployment.Name, replicas, err)
+	written, err := handler.apply(ctx, c, target, resolution.Level)
+	if err != nil {
+		return changed, err
+	}
+	if !written {
+		return changed, nil
 	}
 	logf.FromContext(ctx).Info("claimed target",
-		"target", fmt.Sprintf("deployment/%s/%s", deployment.Namespace, deployment.Name),
-		"replicas", replicas, "claimedBy", claimants)
+		"target", describeObject(target),
+		"level", handler.describe(resolution.Level), "claimedBy", claimants)
 	return true, nil
 }
 
 // releaseTarget applies the agreed reversal, if any, and removes Reactor's
 // annotations so that nothing asserts a value for this target any more.
+//
+// The reverse order to claiming, for the same reason: the annotations are what
+// says the target is still held, so they come off only once the value they
+// describe has been restored.
 func releaseTarget(
 	ctx context.Context,
 	c client.Client,
-	deployment *appsv1.Deployment,
-	level *int32,
+	handler targetHandler,
+	target *unstructured.Unstructured,
+	level *int64,
 ) (bool, error) {
-	patch := client.MergeFrom(deployment.DeepCopy())
-	dirty := false
-
-	if level != nil && (deployment.Spec.Replicas == nil || *deployment.Spec.Replicas != *level) {
-		value := *level
-		deployment.Spec.Replicas = &value
-		dirty = true
+	changed := false
+	if level != nil {
+		written, err := handler.apply(ctx, c, target, *level)
+		if err != nil {
+			return false, err
+		}
+		changed = written
 	}
-	for _, annotation := range []string{annotationBaselineReplicas, annotationClaimedBy, annotationClaimedAt} {
-		if _, present := deployment.Annotations[annotation]; present {
-			delete(deployment.Annotations, annotation)
+
+	cleared, err := clearAnnotations(ctx, c, target)
+	if err != nil {
+		return changed, fmt.Errorf("releasing %s: %w", describeObject(target), err)
+	}
+	return changed || cleared, nil
+}
+
+// setAnnotations adds or updates the annotations given and touches no other,
+// reporting whether that changed anything so callers can skip a write that
+// would produce an empty patch.
+//
+// Adding only. A claim refreshes claimed-by on every reconcile but passes the
+// baseline exactly once, on the reconcile that first took the target — so
+// anything that treated "not in this map" as "remove it" would erase the
+// baseline fifteen seconds after recording it, and the release would then find
+// nothing to restore.
+func setAnnotations(
+	ctx context.Context,
+	c client.Client,
+	target *unstructured.Unstructured,
+	want map[string]string,
+) (bool, error) {
+	current := target.GetAnnotations()
+	next := maps.Clone(current)
+	if next == nil {
+		next = map[string]string{}
+	}
+	dirty := false
+	for annotation, value := range want {
+		if current[annotation] != value {
+			next[annotation] = value
 			dirty = true
 		}
 	}
+	return patchAnnotations(ctx, c, target, next, dirty)
+}
+
+// clearAnnotations removes every annotation a claim writes, which is what stops
+// Reactor asserting anything about a target at all.
+func clearAnnotations(ctx context.Context, c client.Client, target *unstructured.Unstructured) (bool, error) {
+	current := target.GetAnnotations()
+	next := maps.Clone(current)
+	dirty := false
+	for _, annotation := range claimAnnotations {
+		if _, present := next[annotation]; present {
+			delete(next, annotation)
+			dirty = true
+		}
+	}
+	return patchAnnotations(ctx, c, target, next, dirty)
+}
+
+func patchAnnotations(
+	ctx context.Context,
+	c client.Client,
+	target *unstructured.Unstructured,
+	next map[string]string,
+	dirty bool,
+) (bool, error) {
 	if !dirty {
 		return false, nil
 	}
-
-	if err := c.Patch(ctx, deployment, patch); err != nil {
-		return false, fmt.Errorf("releasing %s/%s: %w", deployment.Namespace, deployment.Name, err)
+	patch := client.MergeFrom(target.DeepCopy())
+	target.SetAnnotations(next)
+	if err := c.Patch(ctx, target, patch); err != nil {
+		return false, err
 	}
 	return true, nil
-}
-
-// setAnnotation sets one annotation and reports whether that changed anything,
-// so callers can skip writes that would produce an empty patch.
-func setAnnotation(deployment *appsv1.Deployment, key, value string) bool {
-	if deployment.Annotations == nil {
-		deployment.Annotations = map[string]string{}
-	}
-	if deployment.Annotations[key] == value {
-		return false
-	}
-	deployment.Annotations[key] = value
-	return true
 }

--- a/internal/controller/arbitration.go
+++ b/internal/controller/arbitration.go
@@ -53,12 +53,21 @@ func (k targetKey) String() string {
 
 // targetKeyFor resolves an action's target, defaulting the namespace to the
 // Automation's own — the same defaulting the API documents.
+//
+// A cluster-scoped kind gets no namespace at all, not even a defaulted one. The
+// CRD rejects a namespace on one, and this is the second half of that rule: a
+// Node addressed inside a namespace is not a different Node, it is a read that
+// fails, and the failure would be reported as an unreachable target rather than
+// as the mistake it is.
 func targetKeyFor(automation *reactorv1alpha1.Automation, action reactorv1alpha1.Action) (targetKey, bool) {
 	if action.Target == nil {
 		return targetKey{}, false
 	}
 	namespace := action.Target.Namespace
-	if namespace == "" {
+	switch {
+	case clusterScopedKind(action.Target.Kind):
+		namespace = ""
+	case namespace == "":
 		namespace = automation.Namespace
 	}
 	return targetKey{Kind: action.Target.Kind, Namespace: namespace, Name: action.Target.Name}, true
@@ -173,6 +182,18 @@ func baselineOf(handler targetHandler, obj *unstructured.Unstructured) (level *i
 	return &parsed, true
 }
 
+// permissionHint names what an unreachable target would have needed. The two
+// ways it happens have different fixes, and the person reading this cannot see
+// the operator's RBAC: a namespaced target is a scope problem, while a node is
+// a feature the install has to opt into and would otherwise look like a bug in
+// the automation rather than a value that was never set.
+func permissionHint(kind string) string {
+	if clusterScopedKind(kind) {
+		return "node actions are opt-in: install with rbac.allowNodeActions=true"
+	}
+	return "cross-namespace targets need cluster-wide permissions"
+}
+
 // outOfScope reports whether a target could not be read because Reactor is not
 // allowed to see it, in either of the two ways that happens.
 //
@@ -237,9 +258,8 @@ func (r *AutomationReconciler) reconcileTarget(
 	name := types.NamespacedName{Namespace: key.Namespace, Name: key.Name}
 	if err := r.Get(ctx, name, target); err != nil {
 		if outOfScope(err) {
-			return outcome, fmt.Errorf(
-				"target %s not reachable with current RBAC (cross-namespace targets need cluster-wide permissions): %w",
-				key, err)
+			return outcome, fmt.Errorf("target %s not reachable with current RBAC (%s): %w",
+				key, permissionHint(key.Kind), err)
 		}
 		return outcome, fmt.Errorf("getting target %s: %w", key, err)
 	}

--- a/internal/controller/automation_controller.go
+++ b/internal/controller/automation_controller.go
@@ -69,6 +69,15 @@ const (
 	// running alone: declining to start more work is a different and far safer
 	// act than killing work in flight.
 	actionCronJobSuspend = "kubernetes.cronjob.suspend"
+	// actionKubernetesRestart rolls a workload's pods, the way `kubectl rollout
+	// restart` does. It is an edge action: a restart is an occurrence, not a
+	// level — there is no value a target can be held at that means "restarted",
+	// and nothing to arbitrate with a peer over.
+	actionKubernetesRestart = "kubernetes.restart"
+	// actionPrefixKubernetes marks the actions that act on the cluster rather
+	// than leave it, which is what decides whether an edge action goes through
+	// the outbound client and its destination allowlist.
+	actionPrefixKubernetes = "kubernetes."
 	// reevaluateInterval bounds how stale a matching decision can get relative
 	// to the poller's StateStore when nothing else triggers a reconcile.
 	reevaluateInterval = 15 * time.Second
@@ -90,9 +99,18 @@ const (
 	// action fires on an occurrence that has already passed, so it is never
 	// retried across reconciles — a later reconcile has no new transition, and
 	// re-sending there would be a duplicate rather than a retry. Whether it may
-	// be repeated at all within its one reconcile is decided per type in
-	// retryable(): notifications are publishes and retry, an arbitrary POST or
-	// PATCH might not be and is attempted exactly once.
+	// be repeated at all within its one reconcile is decided per type:
+	//
+	//   - notification.*    retried. Every transport shipped is a publish, so a
+	//                       duplicate is noise on a phone and a miss is the
+	//                       failure the feature exists to prevent.
+	//   - http.request      retried only when the method is idempotent by RFC
+	//                       9110, or the author declares it so. See retryable().
+	//   - kubernetes.restart AT-MOST-ONCE, unconditionally. Every execution rolls
+	//                       the workload, so a retry after an ambiguous failure
+	//                       is a second outage rather than a correction — and
+	//                       the failures that matter here (a conflict, a
+	//                       Forbidden) are not the kind a retry fixes.
 	maxActionAttempts = 5
 	// retryBackoffBase and retryBackoffCap bound the exponential delay between
 	// those attempts.

--- a/internal/controller/automation_controller.go
+++ b/internal/controller/automation_controller.go
@@ -62,8 +62,13 @@ const (
 	// reasonActionFailed is reported when a desired-state action could not be
 	// applied to its target.
 	reasonActionFailed = "ActionFailed"
-	// actionKubernetesScale is the only action type implemented in v0.1.
+	// actionKubernetesScale holds a workload at a replica count.
 	actionKubernetesScale = "kubernetes.scale"
+	// actionCronJobSuspend holds a CronJob at suspended or running. Suspending
+	// stops new Jobs being created and deliberately leaves a Job already
+	// running alone: declining to start more work is a different and far safer
+	// act than killing work in flight.
+	actionCronJobSuspend = "kubernetes.cronjob.suspend"
 	// reevaluateInterval bounds how stale a matching decision can get relative
 	// to the poller's StateStore when nothing else triggers a reconcile.
 	reevaluateInterval = 15 * time.Second
@@ -134,6 +139,7 @@ func retryBackoff(attempts int32) time.Duration {
 // element for it, it is an edge action and belongs out of this map.
 var desiredStateActions = map[string]bool{
 	actionKubernetesScale: true,
+	actionCronJobSuspend:  true,
 }
 
 func isDesiredState(actionType string) bool {
@@ -172,7 +178,15 @@ type AutomationReconciler struct {
 // +kubebuilder:rbac:groups=reactor.robbeverhelst.com,resources=automations,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=reactor.robbeverhelst.com,resources=automations/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=reactor.robbeverhelst.com,resources=automations/finalizers,verbs=update
-// +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;update;patch
+// Targets are read as unstructured objects through the uncached client, so a
+// target kind needs get to read it and patch to write it — no list, no watch,
+// and no informer holding every object of that kind in memory.
+// A replica count is read and written through the scale subresource, so a
+// scalable kind needs its parent for the annotations and its /scale for the
+// level. That split is what keeps one executor serving every scalable kind.
+// +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments/scale;statefulsets/scale,verbs=get;update
+// +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;patch
 // mgr.GetEventRecorder returns the events.k8s.io/v1 recorder, not the deprecated
 // core/v1 one. They share storage but are separate API groups for authorization,
 // and a rule naming only "" fails every emission with a Forbidden the broadcaster
@@ -535,6 +549,7 @@ func targetStatuses(outcomes []targetOutcome) []reactorv1alpha1.TargetStatus {
 			Ref:        outcome.ref,
 			Desired:    outcome.desired,
 			Effective:  outcome.effective,
+			Level:      outcome.level,
 			DeferredBy: outcome.deferredBy,
 		})
 	}

--- a/internal/controller/automation_controller.go
+++ b/internal/controller/automation_controller.go
@@ -69,6 +69,16 @@ const (
 	// running alone: declining to start more work is a different and far safer
 	// act than killing work in flight.
 	actionCronJobSuspend = "kubernetes.cronjob.suspend"
+	// actionKubernetesCordon holds a Node at schedulable or unschedulable. It is
+	// desired-state for the same reason suspend is: schedulable is a level, it
+	// is reversible, and applying it twice is applying it once.
+	//
+	// Its sibling in #18, kubernetes.drain, is deliberately not here and is not
+	// implemented anywhere. See docs/spec.md for the reasoning; the short form
+	// is that an eviction cannot be un-evicted, so a drain has no level to
+	// arbitrate, no reversal to declare, and no way to be a pure function of
+	// which conditions currently hold.
+	actionKubernetesCordon = "kubernetes.cordon"
 	// actionKubernetesRestart rolls a workload's pods, the way `kubectl rollout
 	// restart` does. It is an edge action: a restart is an occurrence, not a
 	// level — there is no value a target can be held at that means "restarted",
@@ -156,8 +166,9 @@ func retryBackoff(attempts int32) time.Duration {
 // The rule for a new action type: if you cannot define a meet with an identity
 // element for it, it is an edge action and belongs out of this map.
 var desiredStateActions = map[string]bool{
-	actionKubernetesScale: true,
-	actionCronJobSuspend:  true,
+	actionKubernetesScale:  true,
+	actionCronJobSuspend:   true,
+	actionKubernetesCordon: true,
 }
 
 func isDesiredState(actionType string) bool {
@@ -205,6 +216,15 @@ type AutomationReconciler struct {
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=get;patch
 // +kubebuilder:rbac:groups=apps,resources=deployments/scale;statefulsets/scale,verbs=get;update
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;patch
+//
+// Nodes are deliberately NOT marked here, even though kubernetes.cordon targets
+// them. These markers generate config/rbac/role.yaml, which is granted
+// unconditionally by `make deploy` and by the manifest bundle — and node access
+// is the one grant in this operator that reaches outside the workloads it was
+// installed to manage, so it must be something an install opts into rather than
+// something every install carries. The chart renders it under
+// rbac.allowNodeActions; the bundle does not offer it at all, and an Automation
+// that needs it says so in its status.
 // mgr.GetEventRecorder returns the events.k8s.io/v1 recorder, not the deprecated
 // core/v1 one. They share storage but are separate API groups for authorization,
 // and a rule naming only "" fails every emission with a Forbidden the broadcaster

--- a/internal/controller/automation_controller_test.go
+++ b/internal/controller/automation_controller_test.go
@@ -932,6 +932,116 @@ var _ = Describe("Automation Controller", func() {
 		})
 	})
 
+	// A Node is the first cluster-scoped target, and cordoning is the first
+	// action whose blast radius is the cluster rather than one workload.
+	Context("with a Node", func() {
+		cordon := func(target string, cordoned *bool) reactorv1alpha1.Action {
+			return reactorv1alpha1.Action{
+				Type:     actionKubernetesCordon,
+				Target:   &reactorv1alpha1.TargetRef{Kind: kindNode, Name: target},
+				Cordoned: cordoned,
+			}
+		}
+
+		createNode := func(name string, unschedulable bool) {
+			node := &corev1.Node{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+				Spec:       corev1.NodeSpec{Unschedulable: unschedulable},
+			}
+			Expect(k8sClient.Create(ctx, node)).To(Succeed())
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, node) })
+		}
+
+		nodeOf := func(name string) corev1.Node {
+			var node corev1.Node
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: name}, &node)).To(Succeed())
+			return node
+		}
+
+		It("cordons on entering the state and reopens on leaving it", func() {
+			const (
+				target     = "worker-on-battery"
+				automation = "cordon-on-battery"
+			)
+			createNode(target, false)
+			createAutomation(automation, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{cordon(target, nil)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery})
+			reconcileOnce(automation)
+			Expect(nodeOf(target).Spec.Unschedulable).To(BeTrue())
+			Expect(nodeOf(target).Annotations).To(HaveKeyWithValue(annotationBaselineUnschedulable, "false"))
+
+			By("addressing a cluster-scoped target without a namespace")
+			status := statusOf(automation)
+			Expect(status.Targets).To(HaveLen(1))
+			Expect(status.Targets[0].Ref).To(Equal("Node/"+target),
+				"a Node has no namespace, so the ref must not invent one")
+			Expect(status.Targets[0].Level).To(Equal("cordoned"))
+
+			By("reopening it once the power returns")
+			observe(map[string]string{keyUPS: upsOnline})
+			reconcileOnce(automation)
+			Expect(nodeOf(target).Spec.Unschedulable).To(BeFalse())
+			Expect(nodeOf(target).Annotations).NotTo(HaveKey(annotationBaselineUnschedulable))
+		})
+
+		It("leaves a node cordoned by hand cordoned", func() {
+			const (
+				target     = "worker-in-maintenance"
+				automation = "cordon-maintenance"
+			)
+			createNode(target, true)
+			createAutomation(automation, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{cordon(target, nil)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery})
+			reconcileOnce(automation)
+			Expect(nodeOf(target).Annotations).To(HaveKeyWithValue(annotationBaselineUnschedulable, "true"))
+
+			By("releasing to what a human chose, not to schedulable")
+			observe(map[string]string{keyUPS: upsOnline})
+			reconcileOnce(automation)
+			Expect(nodeOf(target).Spec.Unschedulable).To(BeTrue(),
+				"restoring the baseline must not quietly undo somebody's maintenance")
+		})
+
+		It("resolves cordoned against schedulable in favour of cordoned", func() {
+			const (
+				target = "worker-contested"
+				sheds  = "cordon-sheds"
+				opens  = "cordon-opens"
+			)
+			createNode(target, false)
+			createAutomation(sheds, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{cordon(target, nil)},
+			})
+			open := false
+			createAutomation(opens, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyWAN: wanBackup},
+				},
+				Actions: []reactorv1alpha1.Action{cordon(target, &open)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery, keyWAN: wanBackup})
+			reconcileOnce(opens)
+			Expect(nodeOf(target).Spec.Unschedulable).To(BeTrue())
+			Expect(statusOf(opens).Targets[0].DeferredBy).To(Equal([]string{testNamespace + "/" + sheds}))
+		})
+	})
+
 	// kubernetes.restart is the first edge action that acts on the cluster
 	// rather than leaving it, and the first non-idempotent action of any kind.
 	Context("with a restart", func() {

--- a/internal/controller/automation_controller_test.go
+++ b/internal/controller/automation_controller_test.go
@@ -932,6 +932,98 @@ var _ = Describe("Automation Controller", func() {
 		})
 	})
 
+	// kubernetes.restart is the first edge action that acts on the cluster
+	// rather than leaving it, and the first non-idempotent action of any kind.
+	Context("with a restart", func() {
+		restart := func(kind, target string) reactorv1alpha1.Action {
+			return reactorv1alpha1.Action{
+				Type:   actionKubernetesRestart,
+				Target: &reactorv1alpha1.TargetRef{Kind: kind, Name: target},
+			}
+		}
+
+		restartedAt := func(name string) string {
+			var deployment appsv1.Deployment
+			key := types.NamespacedName{Name: name, Namespace: testNamespace}
+			Expect(k8sClient.Get(ctx, key, &deployment)).To(Succeed())
+			return deployment.Spec.Template.Annotations[annotationRestartedAt]
+		}
+
+		It("stamps the pod template on the transition and only on the transition", func() {
+			const target = "resolver"
+			createDeployment(target, 1)
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyWAN: wanPrimary},
+				},
+				Actions: []reactorv1alpha1.Action{restart(kindDeployment, target)},
+			})
+
+			By("not restarting anything before the condition holds")
+			observe(map[string]string{keyWAN: wanBackup})
+			reconcileOnce(target)
+			Expect(restartedAt(target)).To(BeEmpty())
+
+			By("restarting on the edge, with no outbound destination configured at all")
+			observe(map[string]string{keyWAN: wanPrimary})
+			reconcileOnce(target)
+			stamp := restartedAt(target)
+			Expect(stamp).NotTo(BeEmpty(), "the annotation kubectl rollout restart writes")
+			Expect(statusOf(target).EdgeActions).To(HaveLen(1))
+			Expect(statusOf(target).EdgeActions[0].Status).To(Equal(executionSuccess))
+			Expect(statusOf(target).EdgeActions[0].Destination).To(
+				Equal("Deployment/" + testNamespace + "/" + target))
+			Expect(statusOf(target).EdgeActions[0].Attempts).To(Equal(int32(1)),
+				"at-most-once: a restart is never repeated")
+
+			By("not restarting again while the same condition keeps holding")
+			for range 3 {
+				observe(map[string]string{keyWAN: wanPrimary})
+				reconcileOnce(target)
+			}
+			Expect(restartedAt(target)).To(Equal(stamp))
+		})
+
+		It("holds no target, so it is Applied without claiming anything", func() {
+			const target = "restart-only"
+			createDeployment(target, 2)
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyWAN: wanBackup},
+				},
+				Actions: []reactorv1alpha1.Action{restart(kindDeployment, target)},
+			})
+
+			observe(map[string]string{keyWAN: wanBackup})
+			reconcileOnce(target)
+
+			Expect(replicasOf(target)).To(Equal(int32(2)), "an edge action owns no level")
+			Expect(annotationsOf(target)).NotTo(HaveKey(annotationBaselineReplicas),
+				"nothing claims a target it only restarts, so there is no baseline to record")
+			Expect(statusOf(target).Targets).To(BeEmpty())
+			Expect(conditionOf(statusOf(target), conditionApplied).Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("records a failure without making the automation unhealthy", func() {
+			const target = "restart-missing"
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyWAN: wanBackup},
+				},
+				Actions: []reactorv1alpha1.Action{restart(kindDeployment, "no-such-workload")},
+			})
+
+			observe(map[string]string{keyWAN: wanBackup})
+			reconcileOnce(target)
+
+			status := statusOf(target)
+			Expect(status.EdgeActions).To(HaveLen(1))
+			Expect(status.EdgeActions[0].Status).To(Equal(executionFailed))
+			Expect(conditionOf(status, conditionReady).Status).To(Equal(metav1.ConditionTrue),
+				"a restart that did not happen did not stop this automation doing its job")
+		})
+	})
+
 	// A CronJob's level is a switch, not a count, and the point of these is that
 	// nothing about arbitration, the baseline or the release had to learn a
 	// second kind of value to hold one.

--- a/internal/controller/automation_controller_test.go
+++ b/internal/controller/automation_controller_test.go
@@ -23,8 +23,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -35,21 +37,21 @@ import (
 )
 
 const (
-	testNamespace  = "default"
-	wanPrimary     = "primary"
-	wanBackup      = "backup"
-	keyWAN         = "wan"
-	keyUPS         = "ups"
-	upsOnline      = "online"
-	upsOnBattery   = "on-battery"
-	kindDeployment = "Deployment"
-	targetQbit     = "qbittorrent"
-	labelApp       = "app"
+	testNamespace = "default"
+	wanPrimary    = "primary"
+	wanBackup     = "backup"
+	keyWAN        = "wan"
+	keyUPS        = "ups"
+	upsOnline     = "online"
+	upsOnBattery  = "on-battery"
+	targetQbit    = "qbittorrent"
+	labelApp      = "app"
 )
 
 // stallingClient stands in for a target that has stopped answering: reads of
 // the Automation itself still work, so the reconcile gets far enough to block
-// on the target the way a wedged API call would.
+// on the target the way a wedged API call would. Targets are read as
+// unstructured objects, which is what distinguishes them here.
 type stallingClient struct {
 	client.Client
 }
@@ -60,7 +62,7 @@ func (s stallingClient) Get(
 	obj client.Object,
 	opts ...client.GetOption,
 ) error {
-	if _, isTarget := obj.(*appsv1.Deployment); !isTarget {
+	if _, isTarget := obj.(*unstructured.Unstructured); !isTarget {
 		return s.Client.Get(ctx, key, obj, opts...)
 	}
 	<-ctx.Done()
@@ -168,6 +170,78 @@ var _ = Describe("Automation Controller", func() {
 		Expect(k8sClient.Get(ctx, key, &deployment)).To(Succeed())
 		deployment.Spec.Replicas = &replicas
 		Expect(k8sClient.Update(ctx, &deployment)).To(Succeed())
+	}
+
+	scaleKindTo := func(kind, target string, replicas int32) reactorv1alpha1.Action {
+		return reactorv1alpha1.Action{
+			Type:     actionKubernetesScale,
+			Target:   &reactorv1alpha1.TargetRef{Kind: kind, Name: target},
+			Replicas: &replicas,
+		}
+	}
+
+	createStatefulSet := func(name string, replicas int32) {
+		selector := &metav1.LabelSelector{MatchLabels: map[string]string{labelApp: name}}
+		set := &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+			Spec: appsv1.StatefulSetSpec{
+				Replicas:    &replicas,
+				ServiceName: name,
+				Selector:    selector,
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelApp: name}},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{
+						{Name: name, Image: "example/" + name},
+					}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, set)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, set) })
+	}
+
+	statefulSetOf := func(name string) appsv1.StatefulSet {
+		var set appsv1.StatefulSet
+		key := types.NamespacedName{Name: name, Namespace: testNamespace}
+		Expect(k8sClient.Get(ctx, key, &set)).To(Succeed())
+		return set
+	}
+
+	suspendCronJob := func(target string, suspended *bool) reactorv1alpha1.Action {
+		return reactorv1alpha1.Action{
+			Type:      actionCronJobSuspend,
+			Target:    &reactorv1alpha1.TargetRef{Kind: kindCronJob, Name: target},
+			Suspended: suspended,
+		}
+	}
+
+	createCronJob := func(name string, suspended bool) {
+		cronJob := &batchv1.CronJob{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+			Spec: batchv1.CronJobSpec{
+				Schedule: "0 3 * * *",
+				Suspend:  &suspended,
+				JobTemplate: batchv1.JobTemplateSpec{Spec: batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyOnFailure,
+						Containers:    []corev1.Container{{Name: name, Image: "example/" + name}},
+					}},
+				}},
+			},
+		}
+		Expect(k8sClient.Create(ctx, cronJob)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, cronJob) })
+	}
+
+	cronJobOf := func(name string) batchv1.CronJob {
+		var cronJob batchv1.CronJob
+		key := types.NamespacedName{Name: name, Namespace: testNamespace}
+		Expect(k8sClient.Get(ctx, key, &cronJob)).To(Succeed())
+		return cronJob
+	}
+
+	suspendedOf := func(name string) bool {
+		return *cronJobOf(name).Spec.Suspend
 	}
 
 	statusOf := func(name string) reactorv1alpha1.AutomationStatus {
@@ -788,6 +862,167 @@ var _ = Describe("Automation Controller", func() {
 			Expect(replicasOf(target)).To(Equal(int32(0)),
 				"the WAN automation's claim counts even when the UPS one is doing the reconciling")
 			Expect(annotationsOf(target)).To(HaveKeyWithValue(annotationClaimedBy, testNamespace+"/"+wanned))
+		})
+	})
+
+	// Scaling goes through the scale subresource, so nothing here is Deployment
+	// code with a second kind bolted on: the same executor holds a StatefulSet
+	// at a replica count without knowing where a StatefulSet keeps one.
+	Context("with a StatefulSet", func() {
+		It("scales it and restores its baseline through the scale subresource", func() {
+			const target = "postgres"
+			createStatefulSet(target, 2)
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{scaleKindTo(kindStatefulSet, target, 0)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery})
+			reconcileOnce(target)
+			Expect(*statefulSetOf(target).Spec.Replicas).To(Equal(int32(0)))
+
+			By("recording the baseline on the StatefulSet itself, under the same annotation a count always uses")
+			Expect(statefulSetOf(target).Annotations).To(HaveKeyWithValue(annotationBaselineReplicas, "2"))
+
+			status := statusOf(target)
+			Expect(status.Targets[0].Ref).To(Equal("StatefulSet/" + testNamespace + "/" + target))
+			Expect(status.Targets[0].Level).To(Equal("0 replicas"))
+
+			By("restoring it when the condition ends")
+			observe(map[string]string{keyUPS: upsOnline})
+			reconcileOnce(target)
+			Expect(*statefulSetOf(target).Spec.Replicas).To(Equal(int32(2)))
+			Expect(statefulSetOf(target).Annotations).NotTo(HaveKey(annotationBaselineReplicas))
+		})
+
+		It("arbitrates a StatefulSet against a Deployment claim independently", func() {
+			const (
+				set        = "shared-set"
+				deployment = "shared-deploy"
+				automation = "mixed-kinds"
+			)
+			createStatefulSet(set, 3)
+			createDeployment(deployment, 1)
+			createAutomation(automation, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyWAN: wanBackup},
+				},
+				Actions: []reactorv1alpha1.Action{
+					scaleKindTo(kindStatefulSet, set, 1),
+					scaleKindTo(kindDeployment, deployment, 0),
+				},
+			})
+
+			observe(map[string]string{keyWAN: wanBackup})
+			reconcileOnce(automation)
+			Expect(*statefulSetOf(set).Spec.Replicas).To(Equal(int32(1)))
+			Expect(replicasOf(deployment)).To(Equal(int32(0)))
+
+			targets := statusOf(automation).Targets
+			refs := make([]string, 0, len(targets))
+			for _, target := range targets {
+				refs = append(refs, target.Ref)
+			}
+			Expect(refs).To(ConsistOf(
+				"Deployment/"+testNamespace+"/"+deployment,
+				"StatefulSet/"+testNamespace+"/"+set,
+			), "each kind is its own target, arbitrated on its own")
+		})
+	})
+
+	// A CronJob's level is a switch, not a count, and the point of these is that
+	// nothing about arbitration, the baseline or the release had to learn a
+	// second kind of value to hold one.
+	Context("with a CronJob whose level is a switch", func() {
+		It("suspends on entering the state and unsuspends on leaving it", func() {
+			const target = "backup-nightly"
+			createCronJob(target, false)
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{suspendCronJob(target, nil)},
+			})
+
+			By("suspending it, and recording the baseline under its own annotation")
+			observe(map[string]string{keyUPS: upsOnBattery})
+			reconcileOnce(target)
+			Expect(suspendedOf(target)).To(BeTrue())
+			annotations := cronJobOf(target).Annotations
+			Expect(annotations).To(HaveKeyWithValue(annotationBaselineSuspend, "false"))
+			Expect(annotations).NotTo(HaveKey(annotationBaselineReplicas),
+				"baseline-replicas is a promise about replica counts and must not be overloaded")
+
+			By("keeping the baseline across a steady-state reconcile")
+			reconcileOnce(target)
+			Expect(cronJobOf(target).Annotations).To(HaveKeyWithValue(annotationBaselineSuspend, "false"))
+
+			By("reporting the level in words as well as in the number the arbiter ordered")
+			status := statusOf(target)
+			Expect(status.Targets).To(HaveLen(1))
+			Expect(status.Targets[0].Ref).To(Equal("CronJob/" + testNamespace + "/" + target))
+			Expect(*status.Targets[0].Effective).To(Equal(int32(0)))
+			Expect(status.Targets[0].Level).To(Equal("suspended"))
+
+			By("unsuspending it on leaving the state, with no onExit written")
+			observe(map[string]string{keyUPS: upsOnline})
+			reconcileOnce(target)
+			Expect(suspendedOf(target)).To(BeFalse())
+			Expect(cronJobOf(target).Annotations).NotTo(HaveKey(annotationBaselineSuspend))
+		})
+
+		It("leaves a CronJob suspended when it was already suspended before the claim", func() {
+			const target = "already-off"
+			createCronJob(target, true)
+			createAutomation(target, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{suspendCronJob(target, nil)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery})
+			reconcileOnce(target)
+			Expect(cronJobOf(target).Annotations).To(HaveKeyWithValue(annotationBaselineSuspend, "true"))
+
+			By("restoring the operator's own choice rather than turning it back on")
+			observe(map[string]string{keyUPS: upsOnline})
+			reconcileOnce(target)
+			Expect(suspendedOf(target)).To(BeTrue())
+		})
+
+		It("resolves suspended against running in favour of suspended", func() {
+			const (
+				target  = "contested-cron"
+				sheds   = "cron-sheds"
+				resumes = "cron-resumes"
+			)
+			createCronJob(target, false)
+			createAutomation(sheds, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyUPS: upsOnBattery},
+				},
+				Actions: []reactorv1alpha1.Action{suspendCronJob(target, nil)},
+			})
+			running := false
+			createAutomation(resumes, reactorv1alpha1.AutomationSpec{
+				When: &reactorv1alpha1.StateTrigger{
+					Provider: providerUniFi, State: map[string]string{keyWAN: wanBackup},
+				},
+				Actions: []reactorv1alpha1.Action{suspendCronJob(target, &running)},
+			})
+
+			observe(map[string]string{keyUPS: upsOnBattery, keyWAN: wanBackup})
+			reconcileOnce(resumes)
+			Expect(suspendedOf(target)).To(BeTrue(),
+				"the meet of a switch is the restrictive answer, exactly as it is for replicas")
+
+			status := statusOf(resumes)
+			Expect(*status.Targets[0].Desired).To(Equal(int32(1)))
+			Expect(*status.Targets[0].Effective).To(Equal(int32(0)))
+			Expect(status.Targets[0].DeferredBy).To(Equal([]string{testNamespace + "/" + sheds}))
 		})
 	})
 })

--- a/internal/controller/edge_actions.go
+++ b/internal/controller/edge_actions.go
@@ -148,30 +148,51 @@ func (r *AutomationReconciler) reportEdgeAction(
 	automation *reactorv1alpha1.Automation,
 	entry reactorv1alpha1.EdgeExecutionStatus,
 ) {
+	done, failed := edgeVerbs(entry.Type)
 	switch entry.Status {
 	case executionSuccess:
 		log.Info("edge action sent", "automation", claimantOf(automation),
 			"action", entry.Type, "destination", entry.Destination, "attempts", entry.Attempts)
 		r.event(automation, corev1.EventTypeNormal, reasonEdgeActionSent, actionEdge,
-			"%s delivered to %s after %d attempt(s)", entry.Type, entry.Destination, entry.Attempts)
+			"%s %s %s after %d attempt(s)", entry.Type, done, entry.Destination, entry.Attempts)
 	case executionFailed:
 		log.Info("edge action failed", "automation", claimantOf(automation),
 			"action", entry.Type, "destination", entry.Destination, "reason", entry.Reason)
 		r.event(automation, corev1.EventTypeWarning, reasonEdgeActionFailed, actionEdge,
-			"%s was not delivered: %s", entry.Type, entry.Reason)
+			"%s %s: %s", entry.Type, failed, entry.Reason)
 	default:
 		r.event(automation, corev1.EventTypeWarning, reasonEdgeActionSkipped, actionEdge,
 			"%s did not run: %s", entry.Type, entry.Reason)
 	}
 }
 
-// runEdgeAction resolves one action into a request and sends it.
+// edgeVerbs says what an edge action did in words that fit what it acted on. A
+// request is delivered to a destination; a restart is applied to an object, and
+// reading "delivered to Deployment/media/sonarr" at 3am would make an operator
+// wonder what was delivered.
+func edgeVerbs(actionType string) (done, failed string) {
+	if isKubernetesAction(actionType) {
+		return "applied to", "was not applied"
+	}
+	return "delivered to", "was not delivered"
+}
+
+// runEdgeAction performs one edge action.
+//
+// The two families are separated here rather than inside the outbound client,
+// because a kubernetes.* edge action goes to the API server this operator is
+// already authenticated to — there is no destination to allow, no credential to
+// resolve, and no allowlist that could sensibly apply. An install that has
+// deliberately allowed no outbound destination can still restart a workload.
 func (r *AutomationReconciler) runEdgeAction(
 	ctx context.Context,
 	automation *reactorv1alpha1.Automation,
 	action reactorv1alpha1.Action,
 	data actions.Context,
 ) (actions.Result, error) {
+	if isKubernetesAction(action.Type) {
+		return r.runClusterAction(ctx, automation, action)
+	}
 	if r.Outbound == nil || !r.Outbound.Enabled() {
 		return actions.Result{}, errors.New(
 			"outbound actions are disabled on this install: no destination is allowed")

--- a/internal/controller/events.go
+++ b/internal/controller/events.go
@@ -36,10 +36,16 @@ const (
 	// and the moment it stopped.
 	reasonStateEntered = "StateEntered"
 	reasonStateExited  = "StateExited"
-	// reasonTargetScaled and reasonTargetReleased record a write that actually
+	// reasonTargetHeld and reasonTargetReleased record a write that actually
 	// happened. Reconciling a target that is already where it should be is the
 	// common case and produces nothing.
-	reasonTargetScaled   = "TargetScaled"
+	//
+	// One reason covers every desired-state action rather than one per kind:
+	// what happened is that arbitration moved a target to its resolved level,
+	// and the note says in words which level that was. A per-kind reason would
+	// make `kubectl get events --field-selector reason=...` an incomplete
+	// question that silently stops matching each time a kind is added.
+	reasonTargetHeld     = "TargetHeld"
 	reasonTargetReleased = "TargetReleased"
 	// reasonDeferred is Normal on purpose. Being outvoted by a more restrictive
 	// claim is how two Automations sharing a workload are meant to behave, and
@@ -155,7 +161,7 @@ func (r *AutomationReconciler) eventsForTargets(automation *reactorv1alpha1.Auto
 				"%s released; no automation claims it any more", outcome.ref)
 			continue
 		}
-		r.event(automation, corev1.EventTypeNormal, reasonTargetScaled, actionExecute,
-			"%s set to %d replicas", outcome.ref, *outcome.effective)
+		r.event(automation, corev1.EventTypeNormal, reasonTargetHeld, actionExecute,
+			"%s held at %s", outcome.ref, outcome.level)
 	}
 }

--- a/internal/controller/events_test.go
+++ b/internal/controller/events_test.go
@@ -186,8 +186,8 @@ func TestOnlyChangedTargetsRaiseAnEvent(t *testing.T) {
 
 	zero, one := int32(0), int32(1)
 	r.eventsForTargets(automation, []targetOutcome{
-		{ref: "Deployment/media/unchanged", effective: &one, changed: false},
-		{ref: "Deployment/media/qbittorrent", effective: &zero, changed: true},
+		{ref: "Deployment/media/unchanged", effective: &one, level: "1 replicas", changed: false},
+		{ref: "Deployment/media/qbittorrent", effective: &zero, level: "0 replicas", changed: true},
 		{ref: "Deployment/media/sonarr", effective: nil, changed: true},
 	})
 
@@ -195,9 +195,9 @@ func TestOnlyChangedTargetsRaiseAnEvent(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("expected one Event per write that happened, got %d: %v", len(got), got)
 	}
-	scaled, ok := recorder.find(reasonTargetScaled)
-	if !ok || !strings.Contains(scaled.Note, "qbittorrent") || !strings.Contains(scaled.Note, "0 replicas") {
-		t.Errorf("the scale Event does not say what was written: %+v", scaled)
+	held, ok := recorder.find(reasonTargetHeld)
+	if !ok || !strings.Contains(held.Note, "qbittorrent") || !strings.Contains(held.Note, "0 replicas") {
+		t.Errorf("the write Event does not say what was written: %+v", held)
 	}
 	released, ok := recorder.find(reasonTargetReleased)
 	if !ok || !strings.Contains(released.Note, "sonarr") {

--- a/internal/controller/release.go
+++ b/internal/controller/release.go
@@ -202,16 +202,21 @@ func releaseClaimedTarget(
 	key targetKey,
 	automations []*reactorv1alpha1.Automation,
 ) error {
-	var deployment appsv1.Deployment
+	handler, err := handlerFor(key.Kind)
+	if err != nil {
+		return err
+	}
+
+	target := newTarget(handler)
 	name := types.NamespacedName{Namespace: key.Namespace, Name: key.Name}
-	if err := c.Get(ctx, name, &deployment); err != nil {
+	if err := c.Get(ctx, name, target); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
 		return fmt.Errorf("getting target %s: %w", key, err)
 	}
 
-	baseline, recorded := baselineOf(&deployment)
+	baseline, recorded := baselineOf(handler, target)
 	if !recorded {
 		return nil // never claimed, so there is nothing to hand back
 	}
@@ -222,18 +227,18 @@ func releaseClaimedTarget(
 			reversals = append(reversals, reversal)
 		}
 	}
-	var level *int32
+	var level *int64
 	if release, ok := engine.Resolve(reversals); ok {
-		value := int32(release.Level)
-		level = &value
+		level = &release.Level
 	}
 
-	changed, err := releaseTarget(ctx, c, &deployment, level)
+	changed, err := releaseTarget(ctx, c, handler, target, level)
 	if err != nil {
 		return err
 	}
 	if changed {
-		logf.FromContext(ctx).Info("released target", "target", key.String(), "replicas", level)
+		logf.FromContext(ctx).Info("released target",
+			"target", key.String(), "level", describeLevel(handler, level))
 	}
 	return nil
 }

--- a/internal/controller/restart.go
+++ b/internal/controller/restart.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+	"github.com/robbeverhelst/unifi-reactor/internal/actions"
+)
+
+// annotationRestartedAt is the pod-template annotation `kubectl rollout
+// restart` writes. Reactor uses the same one deliberately: a workload restarted
+// by Reactor and one restarted by hand should be indistinguishable afterwards,
+// and anything already reading this annotation — a dashboard, an audit, the
+// next person running `kubectl rollout history` — keeps working.
+const annotationRestartedAt = "kubectl.kubernetes.io/restartedAt"
+
+// templateAnnotations is where a rollout-triggering annotation lives. Changing
+// the pod template is what makes the workload controller roll its pods; nothing
+// about the annotation's value matters beyond being different from last time.
+var templateAnnotations = []string{fieldSpec, "template", "metadata", "annotations"}
+
+// isKubernetesAction reports whether an action acts on this cluster rather than
+// leaving it.
+func isKubernetesAction(actionType string) bool {
+	return strings.HasPrefix(actionType, actionPrefixKubernetes)
+}
+
+// runClusterAction performs one edge action against the cluster.
+//
+// It is at-most-once, and unconditionally so — there is no per-type retry
+// decision here the way there is for an HTTP method, because there is no
+// kubernetes edge action for which repeating is harmless. Every execution of
+// kubernetes.restart rolls the workload, so retrying after an ambiguous failure
+// is a second outage rather than a correction. The failures that actually occur
+// here are a conflict or a Forbidden, and neither is fixed by trying again
+// inside the same reconcile.
+//
+// The transition it fires on has already been committed to status by the time
+// this runs, so a later reconcile sees no edge and does not fire it again
+// either. A crash in the window between the two loses the restart, which is the
+// right way round: a workload that did not get restarted is visible and fixable,
+// a workload restarted twice during an incident is neither.
+func (r *AutomationReconciler) runClusterAction(
+	ctx context.Context,
+	automation *reactorv1alpha1.Automation,
+	action reactorv1alpha1.Action,
+) (actions.Result, error) {
+	key, ok := targetKeyFor(automation, action)
+	if !ok {
+		return actions.Result{}, fmt.Errorf("%s needs a target", action.Type)
+	}
+	result := actions.Result{Origin: key.String(), Attempts: 1}
+
+	handler, err := handlerFor(key.Kind)
+	if err != nil {
+		return result, err
+	}
+
+	timeout := defaultActionTimeout
+	if action.TimeoutSeconds != nil {
+		timeout = time.Duration(*action.TimeoutSeconds) * time.Second
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	target := newTarget(handler)
+	name := types.NamespacedName{Namespace: key.Namespace, Name: key.Name}
+	if err := r.Get(ctx, name, target); err != nil {
+		if outOfScope(err) {
+			return result, fmt.Errorf(
+				"target %s not reachable with current RBAC (cross-namespace targets need cluster-wide permissions): %w",
+				key, err)
+		}
+		return result, fmt.Errorf("getting target %s: %w", key, err)
+	}
+
+	if action.Type != actionKubernetesRestart {
+		return result, fmt.Errorf("no executor for action %q", action.Type)
+	}
+	return result, restartTarget(ctx, r.Client, target)
+}
+
+// restartTarget rolls a workload's pods by stamping its pod template, which is
+// exactly what `kubectl rollout restart` does.
+//
+// It patches the template rather than deleting pods: the workload controller
+// then rolls them under whatever update strategy and disruption budget the
+// workload already declares, so a restart during an incident respects the same
+// availability rules a deploy does. Deleting pods would bypass both.
+//
+// The stamp has second granularity, which means two restarts inside the same
+// second produce no change and therefore no second rollout. That is a
+// coincidence rather than a design, and it is not the flapping protection —
+// debounce is. See the notes on kubernetes.restart in the README.
+func restartTarget(ctx context.Context, c client.Client, target *unstructured.Unstructured) error {
+	patch := client.MergeFrom(target.DeepCopy())
+
+	annotations, _, err := unstructured.NestedStringMap(target.Object, templateAnnotations...)
+	if err != nil {
+		return fmt.Errorf("reading the pod template of %s: %w", describeObject(target), err)
+	}
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	annotations[annotationRestartedAt] = metav1.Now().UTC().Format(time.RFC3339)
+	if err := unstructured.SetNestedStringMap(target.Object, annotations, templateAnnotations...); err != nil {
+		return fmt.Errorf("stamping the pod template of %s: %w", describeObject(target), err)
+	}
+
+	if err := c.Patch(ctx, target, patch); err != nil {
+		return fmt.Errorf("restarting %s: %w", describeObject(target), err)
+	}
+	return nil
+}

--- a/internal/controller/restart.go
+++ b/internal/controller/restart.go
@@ -91,9 +91,8 @@ func (r *AutomationReconciler) runClusterAction(
 	name := types.NamespacedName{Namespace: key.Namespace, Name: key.Name}
 	if err := r.Get(ctx, name, target); err != nil {
 		if outOfScope(err) {
-			return result, fmt.Errorf(
-				"target %s not reachable with current RBAC (cross-namespace targets need cluster-wide permissions): %w",
-				key, err)
+			return result, fmt.Errorf("target %s not reachable with current RBAC (%s): %w",
+				key, permissionHint(key.Kind), err)
 		}
 		return result, fmt.Errorf("getting target %s: %w", key, err)
 	}

--- a/internal/controller/targets.go
+++ b/internal/controller/targets.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -39,6 +40,7 @@ const (
 	kindDeployment  = "Deployment"
 	kindStatefulSet = "StatefulSet"
 	kindCronJob     = "CronJob"
+	kindNode        = "Node"
 )
 
 // fieldSpec is the top of every path below. Spelled once because a typo in it
@@ -79,6 +81,11 @@ const (
 	// annotationBaselineSuspend records whether a CronJob was suspended before
 	// Reactor first claimed it, as "true" or "false".
 	annotationBaselineSuspend = "reactor.robbeverhelst.com/baseline-suspend"
+	// annotationBaselineUnschedulable records whether a Node was cordoned before
+	// Reactor first claimed it, as "true" or "false". It matters more here than
+	// anywhere else: a node cordoned by hand for maintenance must come back
+	// cordoned, or Reactor's release would quietly undo a human's decision.
+	annotationBaselineUnschedulable = "reactor.robbeverhelst.com/baseline-unschedulable"
 	// annotationClaimedBy names the Automations currently holding the target.
 	// Advisory: refreshed on every claim, never read back as truth. It exists
 	// so that describing a target explains why it is scaled to zero.
@@ -92,6 +99,7 @@ const (
 var claimAnnotations = []string{
 	annotationBaselineReplicas,
 	annotationBaselineSuspend,
+	annotationBaselineUnschedulable,
 	annotationClaimedBy,
 	annotationClaimedAt,
 }
@@ -108,6 +116,10 @@ type targetHandler struct {
 	// than a typed one so that no path here has to enumerate kinds, and
 	// uncached, so a target kind costs no informer and needs no list or watch.
 	gvk schema.GroupVersionKind
+
+	// clusterScoped marks a kind that has no namespace, so a target ref naming
+	// one is never silently defaulted into the Automation's own.
+	clusterScoped bool
 
 	// baseline is the annotation this kind's pre-claim level is recorded in.
 	baseline string
@@ -146,6 +158,27 @@ var handlers = map[string]targetHandler{
 		actionCronJobSuspend,
 		"suspended", "running",
 	),
+	kindNode: clusterScopedHandler(switchHandler(
+		corev1.SchemeGroupVersion.WithKind(kindNode),
+		[]string{fieldSpec, "unschedulable"},
+		annotationBaselineUnschedulable,
+		actionKubernetesCordon,
+		"cordoned", "schedulable",
+	)),
+}
+
+// clusterScopedHandler marks a handler's kind as having no namespace.
+func clusterScopedHandler(handler targetHandler) targetHandler {
+	handler.clusterScoped = true
+	return handler
+}
+
+// clusterScopedKind reports whether a target kind has no namespace. An
+// unrecognised kind is treated as namespaced, which is the safe answer: it will
+// fail at handlerFor with a clear message rather than being looked up at the
+// wrong scope.
+func clusterScopedKind(kind string) bool {
+	return handlers[kind].clusterScoped
 }
 
 // handlerFor resolves a target kind. It fails rather than defaulting: a kind
@@ -330,6 +363,8 @@ func levelOfAction(action reactorv1alpha1.Action) (int64, bool) {
 		return int64(*action.Replicas), true
 	case actionCronJobSuspend:
 		return levelOfFlag(action.Suspended == nil || *action.Suspended), true
+	case actionKubernetesCordon:
+		return levelOfFlag(action.Cordoned == nil || *action.Cordoned), true
 	default:
 		return 0, false
 	}

--- a/internal/controller/targets.go
+++ b/internal/controller/targets.go
@@ -1,0 +1,340 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+)
+
+// The kinds an action may target. The set is closed in the CRD as well, and
+// deliberately: it is also the set the chart grants RBAC for, so an open field
+// would accept a kind the operator cannot touch and report that as a Forbidden
+// at 3am rather than as a rejected write at admission.
+const (
+	kindDeployment  = "Deployment"
+	kindStatefulSet = "StatefulSet"
+	kindCronJob     = "CronJob"
+)
+
+// A level is an int64 the arbiter orders and never interprets: lower is more
+// restrictive, and a shared target resolves to the lowest anybody asked for.
+//
+// That is the whole reason a boolean action fits the existing arbiter without
+// generalising it. A switch is a two-element lattice, and embedding it in the
+// integers as "set is 0, clear is 1" is order-preserving, so meet stays min and
+// "most restrictive wins" stays "suspended wins" without the engine learning a
+// second kind of value. Generalising engine.Resolve over an ordered type
+// parameter would buy nothing here either: a target has exactly one kind, so
+// two levels of different units never meet in the first place.
+const (
+	// levelSet is a boolean target's restrictive level: suspended.
+	levelSet int64 = 0
+	// levelClear is its permissive one: running.
+	levelClear int64 = 1
+)
+
+const (
+	// annotationBaselineReplicas records the replica count a scalable target
+	// had before Reactor first claimed it. It lives on the target rather than
+	// in an Automation's status because it has to outlive both the Automation
+	// and Reactor itself: it is the only thing that can answer "what was this
+	// before?" after the operator is uninstalled.
+	//
+	// It is a compatibility promise, so it keeps meaning exactly a replica
+	// count. A target whose level is not a replica count records its baseline
+	// under its own annotation instead of borrowing this one, because a
+	// v1.0-era reader — a person, a script over `kubectl get -o custom-columns`
+	// — is entitled to keep reading "1" here as one replica.
+	annotationBaselineReplicas = "reactor.robbeverhelst.com/baseline-replicas"
+	// annotationBaselineSuspend records whether a CronJob was suspended before
+	// Reactor first claimed it, as "true" or "false".
+	annotationBaselineSuspend = "reactor.robbeverhelst.com/baseline-suspend"
+	// annotationClaimedBy names the Automations currently holding the target.
+	// Advisory: refreshed on every claim, never read back as truth. It exists
+	// so that describing a target explains why it is scaled to zero.
+	annotationClaimedBy = "reactor.robbeverhelst.com/claimed-by"
+	// annotationClaimedAt records when the current claim began.
+	annotationClaimedAt = "reactor.robbeverhelst.com/claimed-at"
+)
+
+// claimAnnotations are every annotation a claim writes, and so every one a
+// release has to take back off again.
+var claimAnnotations = []string{
+	annotationBaselineReplicas,
+	annotationBaselineSuspend,
+	annotationClaimedBy,
+	annotationClaimedAt,
+}
+
+// targetHandler is everything Reactor needs to know about one target kind: how
+// to address it, what its level means, and where the pre-claim value is kept.
+//
+// It exists so that arbitration, the baseline, the release finalizer and the
+// pre-delete sweep are written once against "a target with a level" rather than
+// once per kind. Adding a kind is an entry in handlers, an entry in the CRD
+// enum and a rule in the chart — no new code on any of those four paths.
+type targetHandler struct {
+	// gvk addresses the target. Reads go through an unstructured object rather
+	// than a typed one so that no path here has to enumerate kinds, and
+	// uncached, so a target kind costs no informer and needs no list or watch.
+	gvk schema.GroupVersionKind
+
+	// baseline is the annotation this kind's pre-claim level is recorded in.
+	baseline string
+
+	// actionType is the desired-state action that reaches this kind. It is
+	// reported in metrics for a target this Automation only names on the other
+	// side of its transition, where there is no action to read it from.
+	actionType string
+
+	// read returns the level the target currently holds. It takes a client
+	// because a level does not have to live in the object: a replica count is
+	// read through the scale subresource, which is what makes one handler serve
+	// every scalable kind rather than one per replicas field path.
+	read func(ctx context.Context, c client.Client, obj *unstructured.Unstructured) (int64, error)
+
+	// apply writes level and reports whether that changed anything.
+	apply func(ctx context.Context, c client.Client, obj *unstructured.Unstructured, level int64) (bool, error)
+
+	// format and parse move a level in and out of the baseline annotation.
+	format func(int64) string
+	parse  func(string) (int64, error)
+
+	// describe renders a level for an Event, a log line and status.level.
+	describe func(int64) string
+}
+
+// handlers is the registry. A kind absent from it cannot be targeted, which is
+// also what the CRD enum enforces one layer earlier.
+var handlers = map[string]targetHandler{
+	kindDeployment:  replicaHandler(appsv1.SchemeGroupVersion.WithKind(kindDeployment)),
+	kindStatefulSet: replicaHandler(appsv1.SchemeGroupVersion.WithKind(kindStatefulSet)),
+	kindCronJob: switchHandler(
+		batchv1.SchemeGroupVersion.WithKind(kindCronJob),
+		[]string{"spec", "suspend"},
+		annotationBaselineSuspend,
+		actionCronJobSuspend,
+		"suspended", "running",
+	),
+}
+
+// handlerFor resolves a target kind. It fails rather than defaulting: a kind
+// that reached here unrecognised means the CRD enum and this registry have
+// drifted apart, and guessing which one is right would write to the wrong
+// object.
+func handlerFor(kind string) (targetHandler, error) {
+	handler, ok := handlers[kind]
+	if !ok {
+		return targetHandler{}, fmt.Errorf("no handler for target kind %q", kind)
+	}
+	return handler, nil
+}
+
+// newTarget builds the empty object a target is read into.
+func newTarget(handler targetHandler) *unstructured.Unstructured {
+	object := &unstructured.Unstructured{}
+	object.SetGroupVersionKind(handler.gvk)
+	return object
+}
+
+// replicaHandler is the level-as-a-count kind: a replica count, ordered so that
+// fewer replicas is more restrictive and shedding therefore wins a fold.
+//
+// It reads and writes through the scale subresource rather than the kind's own
+// replicas field, which is the whole reason one handler covers Deployment,
+// StatefulSet and anything else scalable: /scale is the interface that says
+// "this object has a replica count" without saying where it is kept, so a kind
+// costs an entry in handlers, an entry in the CRD enum and an RBAC rule, and no
+// code at all. A kind whose replicas live somewhere unusual works for free; a
+// kind with no scale subresource is refused by the API server rather than
+// half-written.
+func replicaHandler(gvk schema.GroupVersionKind) targetHandler {
+	path := []string{"spec", "replicas"}
+	return targetHandler{
+		gvk:        gvk,
+		baseline:   annotationBaselineReplicas,
+		actionType: actionKubernetesScale,
+		read: func(ctx context.Context, c client.Client, obj *unstructured.Unstructured) (int64, error) {
+			scale, err := scaleOf(ctx, c, obj)
+			if err != nil {
+				return 0, err
+			}
+			value, found, err := unstructured.NestedInt64(scale.Object, path...)
+			if err != nil {
+				return 0, fmt.Errorf("reading the scale of %s: %w", describeObject(obj), err)
+			}
+			if !found {
+				// The API server defaults it, so this is only reachable for a
+				// kind whose scale reports none. One is the value such an object
+				// behaves as, and is what a release should restore.
+				return 1, nil
+			}
+			return value, nil
+		},
+		apply: func(ctx context.Context, c client.Client, obj *unstructured.Unstructured, level int64) (bool, error) {
+			scale, err := scaleOf(ctx, c, obj)
+			if err != nil {
+				return false, err
+			}
+			current, _, err := unstructured.NestedInt64(scale.Object, path...)
+			if err != nil {
+				return false, fmt.Errorf("reading the scale of %s: %w", describeObject(obj), err)
+			}
+			if current == level {
+				return false, nil
+			}
+			if err := unstructured.SetNestedField(scale.Object, level, path...); err != nil {
+				return false, fmt.Errorf("setting the scale of %s: %w", describeObject(obj), err)
+			}
+			if err := c.SubResource(subResourceScale).Update(ctx, obj, client.WithSubResourceBody(scale)); err != nil {
+				return false, fmt.Errorf("scaling %s to %d: %w", describeObject(obj), level, err)
+			}
+			return true, nil
+		},
+		format:   func(level int64) string { return strconv.FormatInt(level, 10) },
+		parse:    func(raw string) (int64, error) { return strconv.ParseInt(raw, 10, 32) },
+		describe: func(level int64) string { return fmt.Sprintf("%d replicas", level) },
+	}
+}
+
+// subResourceScale is the subresource every scalable kind exposes.
+const subResourceScale = "scale"
+
+// scaleOf reads a target's scale subresource.
+//
+// It is fetched as an unstructured autoscaling/v1 Scale rather than the typed
+// one because the parent is unstructured, and controller-runtime's unstructured
+// client requires a subresource body of the same shape.
+func scaleOf(
+	ctx context.Context,
+	c client.Client,
+	obj *unstructured.Unstructured,
+) (*unstructured.Unstructured, error) {
+	scale := &unstructured.Unstructured{}
+	scale.SetGroupVersionKind(autoscalingv1.SchemeGroupVersion.WithKind("Scale"))
+	if err := c.SubResource(subResourceScale).Get(ctx, obj, scale); err != nil {
+		return nil, fmt.Errorf("reading the scale of %s: %w", describeObject(obj), err)
+	}
+	return scale, nil
+}
+
+// switchHandler is the level-as-a-switch kind: one boolean spec field whose
+// true is the restrictive answer, mapped onto levelSet so that the fold reads
+// the same way it does for replicas — most restrictive wins.
+//
+// set and clear are how the two levels are said out loud, because "0" is not
+// what an operator reading an Event at 3am needs to be told.
+func switchHandler(
+	gvk schema.GroupVersionKind,
+	path []string,
+	baseline, actionType, set, clear string,
+) targetHandler {
+	return targetHandler{
+		gvk:        gvk,
+		baseline:   baseline,
+		actionType: actionType,
+		read: func(_ context.Context, _ client.Client, obj *unstructured.Unstructured) (int64, error) {
+			value, _, err := unstructured.NestedBool(obj.Object, path...)
+			if err != nil {
+				return 0, fmt.Errorf("reading %v of %s: %w", path, describeObject(obj), err)
+			}
+			// Absent is false, which is what the API server defaults it to.
+			return levelOfFlag(value), nil
+		},
+		apply: func(ctx context.Context, c client.Client, obj *unstructured.Unstructured, level int64) (bool, error) {
+			current, _, err := unstructured.NestedBool(obj.Object, path...)
+			if err != nil {
+				return false, fmt.Errorf("reading %v of %s: %w", path, describeObject(obj), err)
+			}
+			want := level == levelSet
+			if current == want {
+				return false, nil
+			}
+			patch := client.MergeFrom(obj.DeepCopy())
+			if err := unstructured.SetNestedField(obj.Object, want, path...); err != nil {
+				return false, fmt.Errorf("setting %v of %s: %w", path, describeObject(obj), err)
+			}
+			if err := c.Patch(ctx, obj, patch); err != nil {
+				return false, fmt.Errorf("setting %s to %v on %s: %w",
+					path[len(path)-1], want, describeObject(obj), err)
+			}
+			return true, nil
+		},
+		format: func(level int64) string { return strconv.FormatBool(level == levelSet) },
+		parse: func(raw string) (int64, error) {
+			flag, err := strconv.ParseBool(raw)
+			if err != nil {
+				return 0, err
+			}
+			return levelOfFlag(flag), nil
+		},
+		describe: func(level int64) string {
+			if level == levelSet {
+				return set
+			}
+			return clear
+		},
+	}
+}
+
+// levelOfFlag maps a boolean spec field onto the arbiter's ordering: true is
+// the restrictive answer and therefore the one a fold picks.
+func levelOfFlag(flag bool) int64 {
+	if flag {
+		return levelSet
+	}
+	return levelClear
+}
+
+// levelOfAction is the level one action asks for, in the units of its type.
+//
+// A boolean action with its field omitted means the level it is named after —
+// kubernetes.cronjob.suspend means suspended — so that spec.actions reads as
+// the sentence it is, and spec.onExit says suspended: false to ask for it back.
+func levelOfAction(action reactorv1alpha1.Action) (int64, bool) {
+	switch action.Type {
+	case actionKubernetesScale:
+		if action.Replicas == nil {
+			return 0, false
+		}
+		return int64(*action.Replicas), true
+	case actionCronJobSuspend:
+		return levelOfFlag(action.Suspended == nil || *action.Suspended), true
+	default:
+		return 0, false
+	}
+}
+
+// describeObject names an object for an error message without assuming it has
+// a namespace.
+func describeObject(obj *unstructured.Unstructured) string {
+	if obj.GetNamespace() == "" {
+		return obj.GetKind() + "/" + obj.GetName()
+	}
+	return obj.GetKind() + "/" + obj.GetNamespace() + "/" + obj.GetName()
+}

--- a/internal/controller/targets.go
+++ b/internal/controller/targets.go
@@ -41,6 +41,11 @@ const (
 	kindCronJob     = "CronJob"
 )
 
+// fieldSpec is the top of every path below. Spelled once because a typo in it
+// reads as "the field is absent", which for a boolean level means "not
+// suspended" — a wrong answer rather than an error.
+const fieldSpec = "spec"
+
 // A level is an int64 the arbiter orders and never interprets: lower is more
 // restrictive, and a shared target resolves to the lowest anybody asked for.
 //
@@ -136,7 +141,7 @@ var handlers = map[string]targetHandler{
 	kindStatefulSet: replicaHandler(appsv1.SchemeGroupVersion.WithKind(kindStatefulSet)),
 	kindCronJob: switchHandler(
 		batchv1.SchemeGroupVersion.WithKind(kindCronJob),
-		[]string{"spec", "suspend"},
+		[]string{fieldSpec, "suspend"},
 		annotationBaselineSuspend,
 		actionCronJobSuspend,
 		"suspended", "running",
@@ -174,7 +179,7 @@ func newTarget(handler targetHandler) *unstructured.Unstructured {
 // kind with no scale subresource is refused by the API server rather than
 // half-written.
 func replicaHandler(gvk schema.GroupVersionKind) targetHandler {
-	path := []string{"spec", "replicas"}
+	path := []string{fieldSpec, "replicas"}
 	return targetHandler{
 		gvk:        gvk,
 		baseline:   annotationBaselineReplicas,

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -48,7 +48,15 @@ const (
 	// tokenReviews is how the metrics endpoint's authn/authz filter appears in
 	// the rendered RBAC.
 	tokenReviews = "tokenreviews"
+	// clusterWide and namespaced are the two RBAC modes. Anything the operator
+	// is granted has to be checked in both, because they render as different
+	// object kinds from the same rule list.
+	clusterWide    = "rbac.clusterWide=true"
+	namespacedRBAC = "rbac.clusterWide=false"
 )
+
+// rbacModes is both RBAC modes, for the rules that must travel with either.
+var rbacModes = []string{clusterWide, namespacedRBAC}
 
 func chartDir() string { return filepath.Join("..", "..", "charts", "reactor") }
 
@@ -178,7 +186,7 @@ func TestCredentialsAreMountedForRotation(t *testing.T) {
 // at every list and reconciles nothing — while its health probes, which only
 // ping, keep reporting it ready.
 func TestNamespacedRBACScopesTheWatch(t *testing.T) {
-	scoped := render(t, unifiURL, "rbac.clusterWide=false")
+	scoped := render(t, unifiURL, namespacedRBAC)
 	if !strings.Contains(scoped, "name: WATCH_NAMESPACE") {
 		t.Fatal("namespace-scoped RBAC did not tell the operator which namespace it may watch")
 	}
@@ -198,7 +206,7 @@ func TestNamespacedRBACScopesTheWatch(t *testing.T) {
 func TestSecretAccessFollowsTheGrantedScope(t *testing.T) {
 	const destination = "actions.allowedDestinations={https://ntfy.example.com}"
 
-	namespaced := render(t, unifiURL, "rbac.clusterWide=false", destination)
+	namespaced := render(t, unifiURL, namespacedRBAC, destination)
 	if strings.Contains(namespaced, "kind: ClusterRole") {
 		t.Fatal("allowing a destination widened a namespaced install to cluster-scoped RBAC")
 	}
@@ -211,7 +219,7 @@ func TestSecretAccessFollowsTheGrantedScope(t *testing.T) {
 	}
 
 	// The same switch, off, in the mode the outbound-action tests do not cover.
-	if off := render(t, unifiURL, "rbac.clusterWide=false"); strings.Contains(off, secretsRule) {
+	if off := render(t, unifiURL, namespacedRBAC); strings.Contains(off, secretsRule) {
 		t.Error("a namespaced install that allows no destination was still granted read access to Secrets")
 	}
 
@@ -528,7 +536,7 @@ func TestDashboardCarriesNothingSiteSpecific(t *testing.T) {
 func TestEventsAreGrantedOnTheRightAPIGroup(t *testing.T) {
 	// Both RBAC modes: the manager's rules render as a ClusterRole in one and a
 	// Role in the other, and the events rule travels with them either way.
-	for _, mode := range []string{"rbac.clusterWide=true", "rbac.clusterWide=false"} {
+	for _, mode := range rbacModes {
 		t.Run(mode, func(t *testing.T) {
 			manifests := render(t, unifiURL, mode)
 			if !strings.Contains(manifests, `apiGroups: ["events.k8s.io"]`) {
@@ -543,6 +551,35 @@ func TestEventsAreGrantedOnTheRightAPIGroup(t *testing.T) {
 	}
 }
 
+// TestTargetKindsAreGrantedInBothRBACModes checks the rule that turns a
+// supported action into one that works.
+//
+// Every desired-state action targets a kind, and a kind the operator has not
+// been granted fails at the write rather than at admission — during the outage
+// the automation existed for. The verbs are asserted too, because targets are
+// read uncached: get to read and patch to write is the whole grant, and a
+// widening back to list or watch would put an informer over every object of
+// that kind in the operator's memory.
+func TestTargetKindsAreGrantedInBothRBACModes(t *testing.T) {
+	// The object a target is read from and its annotations written to, then the
+	// scale subresource a replica count is read from and written through.
+	rules := map[string]string{
+		`resources: \["deployments", "statefulsets"\]`:             `verbs: \["get", "patch"\]`,
+		`resources: \["deployments/scale", "statefulsets/scale"\]`: `verbs: \["get", "update"\]`,
+		`resources: \["cronjobs"\]`:                                `verbs: \["get", "patch"\]`,
+	}
+	for _, mode := range rbacModes {
+		t.Run(mode, func(t *testing.T) {
+			manifests := render(t, unifiURL, mode)
+			for resources, verbs := range rules {
+				if !regexp.MustCompile(resources + `\n\s+` + verbs).MatchString(manifests) {
+					t.Errorf("%s is not granted exactly %s", resources, verbs)
+				}
+			}
+		})
+	}
+}
+
 // TestNamespacedInstallsStayNamespacedWithoutSecureMetrics states the one place
 // rbac.clusterWide=false still produces cluster-scoped RBAC, and the escape
 // hatch from it.
@@ -552,7 +589,7 @@ func TestEventsAreGrantedOnTheRightAPIGroup(t *testing.T) {
 // a real consequence of asking for a protected endpoint, and it should be a
 // stated behaviour rather than something an operator discovers in an audit.
 func TestNamespacedInstallsStayNamespacedWithoutSecureMetrics(t *testing.T) {
-	namespaced := []string{unifiURL, "rbac.clusterWide=false"}
+	namespaced := []string{unifiURL, namespacedRBAC}
 
 	if got := strings.Count(render(t, namespaced...), "\nkind: Cluster"); got != 0 {
 		t.Errorf("a namespace-scoped install created %d cluster-scoped RBAC objects", got)

--- a/test/chart/chart_test.go
+++ b/test/chart/chart_test.go
@@ -48,6 +48,8 @@ const (
 	// tokenReviews is how the metrics endpoint's authn/authz filter appears in
 	// the rendered RBAC.
 	tokenReviews = "tokenreviews"
+	// nodesRule is how kubernetes.cordon's opt-in permission appears.
+	nodesRule = `resources: ["nodes"]`
 	// clusterWide and namespaced are the two RBAC modes. Anything the operator
 	// is granted has to be checked in both, because they render as different
 	// object kinds from the same rule list.
@@ -144,6 +146,62 @@ func readSpec(t *testing.T, path string) string {
 	// The chart copy ends with the Helm guard; the generated one does not.
 	spec, _, _ = strings.Cut(spec, "\n{{- end }}")
 	return strings.TrimSpace(spec)
+}
+
+// celReservedWords are the identifiers CEL reserves. Kubernetes exposes a
+// schema property whose name collides with one only under an escaped name
+// (__namespace__ for namespace), and a rule that spells it plainly does not
+// fail validation — it fails to COMPILE, which the API server reports by
+// rejecting the entire CustomResourceDefinition.
+//
+// See https://kubernetes.io/docs/reference/using-api/cel/#escaping.
+var celReservedWords = []string{
+	"as", "break", "const", "continue", "else", "false", "for", "function",
+	"if", "import", "in", "let", "loop", "namespace", "null", "package",
+	"return", "true", "var", "void", "while",
+}
+
+// stringLiteral matches a CEL single-quoted literal, which is stripped before
+// scanning so that a reserved word inside a message or a compared value —
+// 'notification.' has no reserved word, but a future rule's might — cannot be
+// mistaken for a field select.
+var stringLiteral = regexp.MustCompile(`'[^']*'`)
+
+// TestCELRulesEscapeReservedWords guards a failure mode that no other test in
+// this repository can reach.
+//
+// A CEL rule is compiled by the API server and nowhere else. Get one wrong and
+// the CRD is rejected whole — every field, not just the offending rule — so an
+// install or upgrade fails outright and takes the operator down with it. Go
+// vet, the unit suites and `helm template` all pass regardless, because none of
+// them compiles CEL. This test cannot compile it either, but it can check the
+// one mistake that is easy to make and expensive to discover: selecting a
+// property whose name is a CEL reserved word without escaping it.
+//
+// Found the hard way. `has(self.namespace)` on TargetRef was correct-looking,
+// passed everything local, and was rejected by the API server the moment the
+// e2e suite tried to install the chart.
+func TestCELRulesEscapeReservedWords(t *testing.T) {
+	crd, err := os.ReadFile(filepath.Join("..", "..", "config", "crd", "bases",
+		"reactor.robbeverhelst.com_automations.yaml"))
+	if err != nil {
+		t.Fatalf("reading the generated CRD: %v", err)
+	}
+
+	rules := regexp.MustCompile(`(?m)^\s*(?:- )?rule: (.*)$`).FindAllStringSubmatch(string(crd), -1)
+	if len(rules) == 0 {
+		t.Fatal("no x-kubernetes-validations rules found; this test is checking nothing")
+	}
+	for _, match := range rules {
+		rule := stringLiteral.ReplaceAllString(match[1], "''")
+		for _, word := range celReservedWords {
+			unescaped := regexp.MustCompile(`\.` + word + `\b`)
+			if unescaped.MatchString(rule) {
+				t.Errorf("rule selects the CEL reserved word %q unescaped, so the API server "+
+					"will refuse the whole CRD; write __%s__ instead:\n  %s", word, word, match[1])
+			}
+		}
+	}
 }
 
 // TestLogLevelIsSettable covers the knob that makes the V(1) observation lines
@@ -575,6 +633,39 @@ func TestTargetKindsAreGrantedInBothRBACModes(t *testing.T) {
 				if !regexp.MustCompile(resources + `\n\s+` + verbs).MatchString(manifests) {
 					t.Errorf("%s is not granted exactly %s", resources, verbs)
 				}
+			}
+		})
+	}
+}
+
+// TestNodeActionsAreOptIn pins the gate on the one permission Reactor asks for
+// that reaches outside the workloads it was installed to manage.
+//
+// Two properties, and the second is the one that would be easy to lose. Node
+// RBAC must be absent by default in both modes. And when it is turned on it
+// must grant nodes and nothing else — in particular nothing over pods or
+// pods/eviction, because kubernetes.drain is deliberately not implemented and
+// this is the second lock on it.
+func TestNodeActionsAreOptIn(t *testing.T) {
+	for _, mode := range rbacModes {
+		t.Run(mode, func(t *testing.T) {
+			if strings.Contains(render(t, unifiURL, mode), nodesRule) {
+				t.Fatal("node RBAC is granted by default; kubernetes.cordon must be opted into")
+			}
+
+			enabled := render(t, unifiURL, mode, "rbac.allowNodeActions=true")
+			if !strings.Contains(enabled, nodesRule) {
+				t.Fatal("rbac.allowNodeActions=true granted no access to nodes")
+			}
+			// Cluster-scoped in both modes, because a namespaced Role cannot
+			// grant access to a cluster-scoped resource at all.
+			if !strings.Contains(enabled, "kind: ClusterRole\nmetadata:\n  name: reactor-node-actions") {
+				t.Error("node RBAC is not a ClusterRole, so it cannot reach a cluster-scoped resource")
+			}
+			// A rule, not a mention: the template's own comments name
+			// pods/eviction to say it is deliberately absent.
+			if pods := regexp.MustCompile(`resources: \[[^\]]*"pods`); pods.MatchString(enabled) {
+				t.Error("enabling node actions granted access to pods; draining is not an action Reactor has")
 			}
 		})
 	}

--- a/test/e2e/reaction/kinds_test.go
+++ b/test/e2e/reaction/kinds_test.go
@@ -1,0 +1,206 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaction
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+
+	"github.com/robbeverhelst/unifi-reactor/test/e2e/harness"
+)
+
+// Target kinds beyond Deployment, against a real API server and the real chart
+// RBAC.
+//
+// envtest already proves the executor: it reads a replica count through the
+// scale subresource, so a StatefulSet needs no code a Deployment does not. What
+// it cannot prove is the half that fails in production — whether the
+// ServiceAccount the chart actually renders is allowed to do it. A missing
+// statefulsets/scale rule, or a cronjobs rule on the wrong API group, compiles,
+// passes every unit test, and then refuses the one write the automation existed
+// for. That is the shape of both bugs these suites caught before v1.0.
+var _ = Describe("Holding target kinds other than Deployment", Ordered, func() {
+	const (
+		set        = "ledger"
+		cron       = "nightly-backup"
+		setClaim   = "shed-statefulset"
+		cronClaim  = "pause-cronjob"
+		setInitial = 2
+	)
+
+	onBattery := map[string]string{keyUPS: upsOnBattery}
+	manifests := []string{
+		statefulSet(set, setInitial),
+		cronJob(cron),
+		kindAutomation(setClaim, onBattery, `
+    - type: kubernetes.scale
+      target: {kind: StatefulSet, name: `+set+`}
+      replicas: 0`),
+		kindAutomation(cronClaim, onBattery, `
+    - type: kubernetes.cronjob.suspend
+      target: {kind: CronJob, name: `+cron+`}`),
+	}
+
+	BeforeAll(func() {
+		for _, manifest := range manifests {
+			Expect(cluster.Apply(manifest)).To(Succeed())
+		}
+	})
+
+	AfterAll(func() {
+		resetConsole()
+		for _, manifest := range manifests {
+			Expect(cluster.Delete(manifest)).To(Succeed())
+		}
+	})
+
+	It("scales a StatefulSet through its scale subresource", func() {
+		Expect(mock.UPS("mode=battery&level=80")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(statefulSetReplicas(g, set)).To(BeEquivalentTo(0))
+		}, convergeWindow).Should(Succeed())
+
+		By("recording the baseline on the StatefulSet, so it explains itself with Reactor gone")
+		Eventually(func(g Gomega) {
+			var live appsv1.StatefulSet
+			g.Expect(cluster.GetInto(&live, "statefulset", appsNamespace, set)).To(Succeed())
+			g.Expect(live.Annotations).To(HaveKeyWithValue(annotationBaseline, "2"))
+			g.Expect(live.Annotations).To(HaveKeyWithValue(annotationClaimedBy, claimant(setClaim)))
+		}).Should(Succeed())
+
+		By("reporting the kind in the target ref, not assuming Deployment")
+		Eventually(func(g Gomega) {
+			automation := automationOf(g, setClaim)
+			g.Expect(automation.Status.Targets).To(HaveLen(1))
+			g.Expect(automation.Status.Targets[0].Ref).To(
+				Equal(fmt.Sprintf("StatefulSet/%s/%s", appsNamespace, set)))
+			g.Expect(automation.Status.Targets[0].Level).To(Equal("0 replicas"))
+		}).Should(Succeed())
+	})
+
+	It("suspends a CronJob and restores what it found on the way out", func() {
+		Eventually(func(g Gomega) {
+			g.Expect(cronJobSuspended(g, cron)).To(BeTrue())
+		}, convergeWindow).Should(Succeed())
+
+		By("recording the baseline under its own annotation, never as a replica count")
+		Eventually(func(g Gomega) {
+			var live batchv1.CronJob
+			g.Expect(cluster.GetInto(&live, "cronjob", appsNamespace, cron)).To(Succeed())
+			g.Expect(live.Annotations).To(HaveKeyWithValue(
+				"reactor.robbeverhelst.com/baseline-suspend", "false"))
+			g.Expect(live.Annotations).NotTo(HaveKey(annotationBaseline))
+		}).Should(Succeed())
+
+		By("handing both kinds back once the power returns")
+		resetConsole()
+		Eventually(func(g Gomega) {
+			g.Expect(cronJobSuspended(g, cron)).To(BeFalse())
+			g.Expect(statefulSetReplicas(g, set)).To(BeEquivalentTo(setInitial))
+		}, convergeWindow).Should(Succeed())
+	})
+})
+
+// statefulSet renders a target StatefulSet. Like workload it runs the mock's
+// image, which is already on every node, because nothing here waits for a pod.
+func statefulSet(name string, replicas int) string {
+	return fmt.Sprintf(`apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  replicas: %[3]d
+  serviceName: %[1]s
+  selector:
+    matchLabels: {app: %[1]s}
+  template:
+    metadata:
+      labels: {app: %[1]s}
+    spec:
+      containers:
+        - name: app
+          image: %[4]s
+          imagePullPolicy: Never
+`, name, appsNamespace, replicas, harness.MockImage)
+}
+
+// cronJob renders a target CronJob. The schedule is deliberately one that will
+// not fire during the suite: what is under test is spec.suspend, and a Job
+// starting would only add noise.
+func cronJob(name string) string {
+	return fmt.Sprintf(`apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  schedule: "0 3 1 1 *"
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: app
+              image: %[3]s
+              imagePullPolicy: Never
+`, name, appsNamespace, harness.MockImage)
+}
+
+// kindAutomation renders an Automation whose actions block is written out, so
+// one helper serves every action type rather than one helper per type.
+func kindAutomation(name string, when map[string]string, actions string) string {
+	var state strings.Builder
+	for key, value := range when {
+		fmt.Fprintf(&state, "      %s: %q\n", key, value)
+	}
+	return fmt.Sprintf(`apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: %s
+  namespace: %s
+spec:
+  when:
+    provider: unifi
+    state:
+%s  actions:%s
+`, name, appsNamespace, state.String(), actions)
+}
+
+func statefulSetReplicas(g Gomega, name string) int32 {
+	var live appsv1.StatefulSet
+	g.Expect(cluster.GetInto(&live, "statefulset", appsNamespace, name)).To(Succeed())
+	g.Expect(live.Spec.Replicas).NotTo(BeNil())
+	return *live.Spec.Replicas
+}
+
+func cronJobSuspended(g Gomega, name string) bool {
+	var live batchv1.CronJob
+	g.Expect(cluster.GetInto(&live, "cronjob", appsNamespace, name)).To(Succeed())
+	g.Expect(live.Spec.Suspend).NotTo(BeNil())
+	return *live.Spec.Suspend
+}


### PR DESCRIPTION
Closes #15. Closes #17. Closes #16. Closes #18.

---

## Read this first

**Two things worth your attention before the detail.**

### 1. `internal/engine` is unchanged. `engine.Resolve` did not change shape.

```
$ git diff b0cd2a2..HEAD --stat -- internal/engine/
(empty)
```

This is the headline of #15, and it is deliberate rather than incidental. #15's
level is a boolean, not a replica count, and the obvious move was to generalise
the arbiter over an ordered type parameter. **I did not, and the v1.0
arbitration core is byte-for-byte untouched:** `Intent.Level` is still `int64`,
the meet is still `min`, and `Resolve` is still the same pure function of which
conditions hold.

A switch is a two-element lattice, so embedding it in the integers as
*suspended = 0, running = 1* is order-preserving. The meet stays `min`; "most
restrictive wins" stays "suspended wins"; nothing in the fold learns a second
kind of value. And the generality would have had no case to serve: **a target
has exactly one kind, so two levels in different units never meet.**

What did change is one layer up, in `internal/controller`: a per-kind handler
now decides what a level *means* — where it is read from, where its baseline is
recorded, and how it is said out loud. Every existing action depends on the
arbiter, and the arbiter is exactly where it was. If you review one thing, make
it that diff being empty.

### 2. #18 ships `kubernetes.cordon`. It deliberately does **not** ship `kubernetes.drain`.

Not deferred behind a flag. Not built with a timeout. **Not built.** The full
argument is [below](#18--cordon-ships-drain-does-not); the one-line version is
that an eviction cannot be reversed, so a drain has no level to arbitrate and
no reversal to declare — which is the one property every other action in this
design has. The RBAC follows the decision rather than merely reflecting it:
node access grants nothing over `pods` or `pods/eviction` under any setting.

If you disagree with that call, this is the part to push back on, and nothing
else in the PR depends on it.

---

Four actions from #27's roadmap, classified against the v1.0 arbitration model
rather than bolted onto it. Two of them stress the model; one of them is
declined.

| Issue | Action | Kind | Why |
| --- | --- | --- | --- |
| #15 | `kubernetes.cronjob.suspend` | **desired-state** | `spec.suspend` is a level: reversible, idempotent, meaningful to arbitrate |
| #17 | `kubernetes.scale` on any scalable kind | **desired-state** | unchanged semantics, kind-agnostic executor |
| #16 | `kubernetes.restart` | **edge** | no value means "restarted"; at-most-once |
| #18 | `kubernetes.cordon` | **desired-state** | `spec.unschedulable` is a level |
| #18 | `kubernetes.drain` | **not shipped** | an eviction cannot be reversed, so it cannot be a level |

---

## #15 — a level that is not a replica count

The interesting question was whether to generalise `engine.Resolve` over an
ordered type parameter, or map a switch onto the existing `int64`.

**Mapped onto the scalar. `internal/engine` is untouched.** A switch is a
two-element lattice, and embedding it in the integers as *suspended = 0,
running = 1* is order-preserving — so the meet stays `min`, and "most
restrictive wins" stays "suspended wins" with no second kind of value for the
engine to learn. The generality would have had no case to serve either: a
target has exactly one kind, so two levels in different units never meet.

**The baseline annotation is not overloaded.** `baseline-replicas` is a v1.0
compatibility promise about replica counts and keeps meaning exactly that. A
CronJob records `reactor.robbeverhelst.com/baseline-suspend: "false"` instead.
A reader — a person, or a script over `kubectl get -o custom-columns` — is
entitled to keep reading `"1"` there as one replica.

Suspending stops new Jobs and does nothing to a Job already running. No
permission over Jobs is granted at all, so it could not do otherwise.

## #17 — the one that stressed the existing code most

`kubernetes.scale` reads and writes through the target's `/scale` subresource
instead of its own `spec.replicas`. `/scale` is the interface that says "this
object has a replica count" without saying where it is kept, so one executor
serves every scalable kind — and arbitration, the baseline annotation, the
release finalizer and the pre-delete sweep, all of which assumed Deployment,
needed nothing kind-specific once `targets.go` existed.

**`target.kind` stays a closed enum**, which is the trade-off #17 asks to
decide. Opening it buys nothing usable: a kind is reachable only if the chart
granted RBAC for it, and RBAC names resources explicitly — so an open field
would accept a kind the operator cannot touch, turning a typo into a
`Forbidden` discovered *during* the outage instead of a rejected write at
admission. The enum is the same decision as the chart's rule list, written
where the API server can enforce it, and it is now the entire cost of a new
kind.

## #16 — the non-idempotent one

Stamps `kubectl.kubernetes.io/restartedAt` on the pod template, so the workload
controller rolls under the update strategy and disruption budget the workload
already declares. Reactor never deletes a pod.

**At-most-once, unconditionally**, exactly as #33 reasoned. Attempted once per
transition, never retried — not inside the reconcile, and not across
reconciles, because the transition is committed to status before the action
runs, so a later reconcile sees no edge. Recorded on `maxActionAttempts`
alongside the notification and `http.request` policies.

**How debounce (#30) interacts with it, plainly:** everything else Reactor does
is safe to repeat — scaling to 0 twice is one scale, suspending a suspended
CronJob is nothing. A restart is not. The engine only acts on transitions, so a
*steady* condition never restarts twice, but a **flapping key is a stream of
transitions and each one is a real rollout**. The shipped default of
`debounce.default: 1` was chosen for `kubernetes.scale`, where a flap costs
nothing. **If a key drives a restart, raise its debounce**, at a cost of one
`pollInterval` of reaction time per extra sample. This is in the README, in
`docs/spec.md`, and in a new troubleshooting entry ("a workload keeps
restarting") whose first move is to check whether the key is flapping.

## #18 — cordon ships, drain does not

`kubernetes.cordon` is desired-state and behaves like every other level. The
baseline matters more here than anywhere else: **a node cordoned by hand for
maintenance is restored cordoned**, because a release that quietly reopened
someone's maintenance window would be worse than not releasing at all.

**`kubernetes.drain` is not implemented — not deferred behind a flag, not built
with a timeout. Not built.** Four reasons, the first decisive:

1. **An eviction cannot be reversed, so it cannot be a level.** Every action in
   this design declares a value that is a pure function of which conditions
   currently hold — that is what makes the outcome independent of reconcile
   order and a controller restart harmless. A drain has no such value, nothing
   for `spec.reversal` to declare, and nothing for a later reconcile to
   correct. A flapping key would empty the node once per flap, permanently.
2. **On a small cluster it inverts its own goal.** Draining assumes spare
   capacity. On three nodes behind one UPS the evicted pods do not move, they
   go `Pending` — so the workload is lost at the drain rather than at the
   battery. Cordoning delivers the actual benefit without that.
3. **It can evict the operator performing it**, killing the thing doing and
   reporting the work, mid-action. Nothing else here can.
4. **It hangs by design.** Eviction respects PodDisruptionBudgets; a
   single-replica workload with `minAvailable: 1` blocks indefinitely. A
   timeout bounds the call, not a half-drained node.

If an outage plan genuinely needs a drain, `kubernetes.cordon` plus a
`notification.*` telling a human to run `kubectl drain` is the honest shape.
An irreversible cluster-wide decision at 3am is the right place for a person.

---

## RBAC: what changed, and the exposure

Targets are now read as **unstructured objects through the uncached client**
(`Client.Cache.Unstructured: false` is set explicitly in `cmd/main.go` so a
library default cannot flip it). No target kind starts an informer, so none
needs `list` or `watch` — and none holds every object of its kind in the
operator's memory to answer a question asked about one of them every 15s.

| Rule | Before | After | Why |
| --- | --- | --- | --- |
| `apps/deployments` | `get,list,watch,update,patch` | `get,patch` | **narrower**; uncached reads, patch only for annotations |
| `apps/statefulsets` | — | `get,patch` | #17 |
| `apps/{deployments,statefulsets}/scale` | — | `get,update` | #17; where the replica count now lives |
| `batch/cronjobs` | — | `get,patch` | #15. No permission over Jobs, deliberately |
| `""/nodes` | — | `get,patch`, **only under `rbac.allowNodeActions`** | #18 |

**The node grant is the one to look at.** It is the only permission Reactor
asks for that reaches outside the workloads it was installed to manage:

- It is **off by default** and rendered conditionally, the same way
  `actions.allowedDestinations` gates `secrets: get`.
- Nodes are cluster-scoped, so enabling it creates a **`ClusterRole` even when
  `rbac.clusterWide: false`**. That is a real widening of a namespaced
  install's reach, not a formality, and the value's comment says so.
- Kubernetes cannot narrow `patch` to one field, so it also permits writing
  **node labels and annotations**. That is the honest cost; there is no finer
  grant available.
- It grants **nothing over `pods` or `pods/eviction`, under any setting** — the
  second lock on draining. A chart test asserts this.
- The kubebuilder markers deliberately omit it, so `config/rbac/role.yaml` and
  the **manifest bundle grant no node access at all**. Chart only.

An automation using `kubernetes.cordon` without the grant reports the node as
unreachable and *names the value to set*, rather than surfacing a bare
`Forbidden`.

## Observability and retry, per #59 and #33

Every new type reuses the established surface rather than adding a parallel
one: `reactor_actions_total{type,kind,result,on_exit}`,
`reactor_action_duration_seconds{type}`, and `reactor_arbitrations_total` for
the desired-state ones.

Events: one reason per *thing that happened*, not per kind. `TargetScaled`
becomes **`TargetHeld`**, whose note names the level in words —
`Deployment/media/qbittorrent held at 0 replicas`, `CronJob/velero/backup held
at suspended`. A per-kind reason would make
`kubectl get events --field-selector reason=...` silently stop matching each
time a kind is added. `status.targets[].level` carries the same words, because
a bare `0` stops explaining itself once a level is a switch.

Retry policy is recorded where #33 put the others, on `maxActionAttempts`:
desired-state retries via the reconcile loop; `notification.*` retries;
`http.request` retries only when idempotent; `kubernetes.restart` is
at-most-once unconditionally.

## What a v1.0 user has to change

Three items, all small, and one is a real change to a query you may have
written yesterday.

1. **The `TargetScaled` Event reason is now `TargetHeld`.** If you have an
   alert, a log filter, or a `--field-selector reason=TargetScaled`, update it.
   Renamed because the same reason now covers suspending a CronJob and
   cordoning a node, where "scaled" would be a lie; the note names the level in
   words instead. v1.0 shipped today, so the exposure window is one day.
2. **`apps/deployments` narrows from `get,list,watch,update,patch` to
   `get,patch`.** A strict reduction, and the reason is that targets are now
   read as unstructured objects through the *uncached* client — no informer, so
   no `list` and no `watch`, and no copy of every Deployment in the cluster
   sitting in the operator's memory to answer a question asked about one of
   them every fifteen seconds. `update` goes because annotations are patched
   and replicas now go through `/scale`.

   **A chart install needs no action** — the chart narrows it for you on
   upgrade. **If you wrote RBAC by hand** from the chart's v1.0 rules, you must
   add `apps/{deployments,statefulsets}/scale: get,update`, or scaling stops
   working *silently and partially*: the baseline and claim annotations still
   appear on the target, because those are a patch on the object, while the
   replica count never moves. That failure reads like an arbitration bug and is
   not one.
3. **`kubernetes.cordon` needs `rbac.allowNodeActions=true`.** New feature, so
   nothing breaks by not setting it; an automation that uses it reports the
   node as unreachable and names the value.

Not a change, but worth knowing: **new baseline annotations exist per kind** —
`baseline-suspend` on a CronJob, `baseline-unschedulable` on a Node.
`baseline-replicas` is unchanged and still means exactly a replica count. If
you excluded `reactor.robbeverhelst.com` annotations from GitOps drift with a
prefix match, you are already covered; if you listed them individually, add the
two new ones.

## Tests

- **envtest** — CronJob suspend/unsuspend, baseline separation, and a switch
  losing a fold to a more restrictive peer; StatefulSet scaling through
  `/scale` plus a mixed-kind automation; restart stamping the template on the
  transition and *only* on the transition, with no outbound destination
  configured; cordon, restoring a hand-cordoned node cordoned, and cordoned
  beating schedulable.
- **chart render** — every target kind granted in *both* RBAC modes with
  exactly the verbs claimed; node RBAC absent by default, a `ClusterRole` when
  enabled, and never any access to pods.
- **e2e (`test/e2e/reaction`)** — a new suite holding a StatefulSet and a
  CronJob against a real API server under the rendered chart's ServiceAccount.
  This is the half unit tests cannot reach: a missing `statefulsets/scale` rule
  compiles, passes everything, and then refuses the one write the automation
  existed for — the shape of both bugs these suites caught before v1.0.

  **It earned its keep immediately: the first run failed, on a real bug.** The
  cluster-scope rule was written `has(self.namespace)`, which looks right and
  passes `go vet`, every unit suite, and `helm template`. `namespace` is a CEL
  **reserved word**, so Kubernetes exposes the property only as
  `__namespace__` — and the unescaped form does not fail *validation*, it fails
  to **compile**, which the API server answers by rejecting the **entire CRD**.
  Every field, not just that rule. A chart install or upgrade would have failed
  outright.

  Nothing local could have caught it, because nothing local compiles CEL. Two
  things came out of the fix: the rule moved onto `TargetRef`, where the
  constraint actually belongs, and `TestCELRulesEscapeReservedWords` now fails
  on any generated rule that selects an unescaped CEL reserved word. All four
  new rules were then exercised against a live API server by hand — Node with a
  namespace rejected, Node without accepted, Deployment *with* one still
  accepted, and `kubernetes.scale` at a CronJob rejected.

---

## LIVE VERIFICATION

**Run locally on this branch, all green:** `make test`, `make lint`,
`make test-reaction` (254s), `make test-lifecycle` (76s). Both kind clusters
were created and deleted by the Makefile targets; no other cluster was touched.
The lifecycle suite is the one that matters most here, because the pre-delete
sweep and the release finalizer now run through the per-kind handlers.

Everything below still needs hardware or a decision this branch could not make
for you.

**Needs a node you are willing to cordon** — no automated coverage exists, and
the second item is the one with the worst consequences if it is wrong:

- [ ] `--set rbac.allowNodeActions=true`, then an automation cordoning a real
      worker. Confirm the node goes `SchedulingDisabled`, **running pods stay
      put**, `baseline-unschedulable` is recorded, and releasing restores it.
- [ ] The same against a node **you cordoned by hand first** — it must come back
      cordoned. envtest covers the logic; only a real node proves the whole
      path, and silently reopening somebody's maintenance window is the worst
      thing in this PR.
- [ ] Sanity-check that cordoning the node Reactor itself runs on is a
      non-event. It should be — cordon does not evict — but it is worth seeing
      once, because it is the scenario that killed `kubernetes.drain`.

**Needs the UniFi hardware:**

- [ ] A real UPS transition driving `kubernetes.cronjob.suspend` on an actual
      backup CronJob. In particular: a Job **already running** when the
      suspension lands must keep running to completion. The e2e suite uses a
      schedule that deliberately never fires, so this is untested against a
      real in-flight Job.
- [ ] `kubernetes.restart` under a real `wan` failover, and — the one that
      matters — under a *marginal* uplink rather than a clean failover. If
      `wan` flaps during a partial failure the workload rolls on every flap.
      That is the case debounce exists for, and the only way to find the right
      `debounce.keys.wan` for your line is to watch it misbehave once.

**A judgement call, not a test:**

- [ ] Whether `rbac.allowNodeActions` is worth it on your cluster at all. It
      grants `patch` on nodes, which Kubernetes cannot narrow to one field, so
      it also permits writing node labels and annotations. Nothing else in this
      PR depends on enabling it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
