### PR TITLE
state: observe the fleet, firmware, temperature, WiFi and PoE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1242,6 +1242,9 @@ Chart values ([full reference](charts/reactor/README.md)):
 | `unifi.ups.highLoadPercent` | `80` | draw at or above this share of the power budget reports `ups.load: high` |
 | `unifi.wan.quality.minAvailabilityPercent` | `99` | availability below this reports `wan.quality: degraded` |
 | `unifi.wan.quality.maxLatencyMs` | `150` | average latency above this reports `wan.quality: degraded` |
+| `unifi.temperature.highCelsius` | `75` | hottest adopted device at or above this reports `temperature: high` |
+| `unifi.poe.maxUtilizationPercent` | `90` | a switch delivering at or above this share of its PoE budget reports `poe: insufficient` |
+| `unifi.devices.perDeviceKeys` | `false` | also publish a `device.<name>` key per adopted device — [one more series per device](#the-fleet-devices-and-why-devicename-is-opt-in) |
 | `unifi.webhook.enabled` | `false` | webhook fast path (below) |
 | `actions.allowedDestinations` | `[]` | where outbound actions may go. Empty refuses all of them, and withholds the operator's read access to Secrets ([why](#telling-you-what-happened)) |
 | `metrics.enabled` | `false` | serve `/metrics` on `:8443` over HTTPS behind the API server's authn/authz filter ([above](#knowing-it-is-working)) |

--- a/README.md
+++ b/README.md
@@ -732,6 +732,7 @@ Each key is published only when the matching hardware is adopted by your control
 | `devices` | `all-online`, `degraded` | whether every adopted device is reachable, or at least one is not |
 | `device.<name>` | `online`, `offline` | one adopted device, by slugified name. **Opt-in** — see below |
 | `firmware` | `current`, `updates-available` | whether the console has an update waiting for anything adopted |
+| `temperature` | `normal`, `high` | the hottest adopted device against the configured threshold |
 
 `isp` is the one key whose values are not a closed set: it is the carrier name your console geolocated your public address to, lowercased with everything non-alphanumeric turned into a hyphen. Look it up before matching on it —
 
@@ -901,6 +902,53 @@ it does not transition, so an Automation matching it would sit permanently
 matched, which is a report rather than a reaction. It is counted in the log line
 above, and a key for it is a decision to argue for separately.
 
+### `temperature` is the hottest device, bucketed
+
+A switch cooking in a warm rack degrades before it fails. `temperature` reports
+`high` when the hottest adopted device is at or above a threshold **you
+configure**, or when the console itself says a device is overheating:
+
+```yaml
+unifi:
+  temperature:
+    highCelsius: 75
+```
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      temperature: high    # stop the transcode job before the rack gets worse
+```
+
+The console's own `overheating` flag outranks the threshold: the firmware knows
+what that model tolerates and a number in this repository does not. Otherwise the
+hottest *sensor* on the hottest *device* decides — a board is as hot as its
+hottest part, and averaging would let one cool sensor hide a cooking one.
+
+Like [`wan.quality`](#internet-is-the-one-wan-cannot-express) and `ups.load`, this
+is a **bucketed measurement**, and for the same two reasons: `spec.when` compares
+strings, so a number cannot be a state value, and one metric series per distinct
+reading is unbounded. The readings themselves are a `V(1)` log line — which is
+where you find out what your rack actually runs at before setting the threshold:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'unifi-temperature'   # needs log.level=debug
+# temperature temperature=normal hottestCelsius=58.5 hottestDevice=switch-48 thresholdCelsius=75 devicesFanless=2
+```
+
+The default of 75 °C is set **against the debounce**, not in isolation, the same
+way [`ups.runtime`'s thresholds are](#charge-is-a-poor-shutdown-trigger-runtime-is-a-better-one): UniFi switches and APs
+normally sit at 40–60 °C, so 75 °C plus 3 samples means a reading that genuinely
+held for 90 seconds rather than a fan spinning up late. Lower it towards the
+normal operating range and that hysteresis stops meaning anything, because the
+reading will cross the line and stay there. Move one and you have moved the other.
+
+A device reporting no temperature is **not a device at 0 °C** — it publishes
+nothing, and a fleet where nothing is instrumented publishes no `temperature` key
+at all. Reading a missing sensor as zero would make the rack look coldest exactly
+when a sensor stops answering.
+
 If a provider stops reporting a key at all — the hardware dropped off the controller — Reactor holds the last known state and reports `Ready=False` with `StateKeyUnavailable` rather than treating lost visibility as a condition that ended ([what to do about it](docs/troubleshooting.md#2-statekeyunavailable-and-held-state)).
 
 ### Settling a noisy signal
@@ -921,6 +969,7 @@ unifi:
       devices: 2        # ...and don't believe one missed heartbeat
       device.*: 2       # a trailing * covers keys named after your hardware
       firmware: 3       # ...and nothing about an update is urgent
+      temperature: 3    # ...and a measurement hovers on its threshold
 ```
 
 Each extra sample costs one `pollInterval` of reaction time, so the default is `1`: a WAN failover and a power cut both deserve an immediate reaction, and neither flaps. `ups.battery` ships at `2` because it is a threshold crossing — a charge hovering at 30% would otherwise report `low`, `normal`, `low` — and because a battery drains over minutes, so spending one more poll to be sure costs nothing. At the default 30s poll that makes a battery-level escalation react in 60s worst case instead of 30s.
@@ -938,6 +987,8 @@ Debounce is also the whole of the flap control for `wan.quality`, and that is wo
 `devices` and `device.*` ship at `2`. A device's state is a switch position like `wan`, but it is the *console's* judgement about a heartbeat rather than a wire it can see, and a busy console that misses one beat must not be a reason to page anyone. One extra sample is 60 seconds at the default poll, which is nothing against the failure this key exists for — an AP that has been dead for days.
 
 `firmware` ships at `3`, and here the reason is that nothing is lost by it. The key is not derived from your hardware at all but from the console's lookup against Ubiquiti's release catalogue, which can refresh, blip or briefly disagree with itself — and *no* firmware update needs reacting to within 30 seconds. Extra samples are free when reaction time does not matter, so it takes the most of any key.
+
+`temperature` ships at `3` because it is a measurement that hovers: thermals move with the room, the fan and the load, and a reading sitting near the threshold would otherwise report `high`, `normal`, `high`. Debounce is the whole of the flap control here, exactly as it is for `wan.quality` — three consecutive identical readings, or the key holds what it had.
 
 `device.*` is the one entry here that is a pattern rather than a key. Per-device key names come from your hardware, so no list written here could name them; a trailing `*` matches every key with that prefix. An exact key always wins over a pattern, and the longest matching prefix wins between patterns, so `device.ap-attic: 5` pulls one device out of the group it belongs to.
 

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ on, and `unifi.devices.perDeviceKeys` is the only setting on this page that
 changes how *much* Reactor publishes rather than what it means.
 
 Per-device keys are also never labelled by value in Prometheus, for the same
-reason `isp` is not — see [Cardinality](#what-is-measured). Which device is down
+reason `isp` is not — see [Cardinality](#cardinality-on-purpose). Which device is down
 is in the Automation's `status.observedState`, in an Event, and in a `V(1)` log
 line naming the device and the console's own disconnection reason.
 
@@ -980,6 +980,25 @@ interference — that counter rises instead of the derivation quietly being wron
 
 A site with **no** adopted access points publishes no `wifi` key: there is no WiFi
 there to be healthy, which is not the same as WiFi that is fine.
+
+The three values are alternatives, not steps of a ladder — the same shape
+[`internet`](#internet-is-the-one-wan-cannot-express) has. An automation matching
+`wifi: warning` **stops** matching when the value moves to `error`, and reverses,
+because those are two different values of one key. Match the value you mean, or
+write one automation per value:
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      wifi: error         # every access point is gone, not just one
+```
+
+This is not the `ups`/`ups.battery` trap it resembles. There, one *fact* (on
+battery) escalated into a second fact (the charge), and splitting them was the
+fix. Here all three values answer a single question — how much WiFi is left — so
+one key with three values is the right shape, and choosing between them is the
+automation author's job.
 
 ### `poe` is headroom, before it becomes an outage
 
@@ -1172,7 +1191,7 @@ Everything here was built against one setup, and this table says which one. "Ver
 | | Verified | Expected to work | Known not to work |
 | --- | --- | --- | --- |
 | UniFi Network | 10.5.67 | 10.x | — |
-| Console | UDM Pro (gateway firmware 5.1.26) | UDM/UDM SE/UDR/UXG, Cloud Key with a gateway adopted | a site with no gateway and no UniFi UPS: nothing to observe |
+| Console | UDM Pro (gateway firmware 5.1.26) | UDM/UDM SE/UDR/UXG, Cloud Key with a gateway adopted. A site with no gateway and no UniFi UPS now observes the fleet keys — `devices`, `wifi` and whichever of `firmware`/`temperature`/`poe` the hardware reports — but none of `wan`, `isp` or `ups` | a site with nothing adopted at all: nothing to observe |
 | UPS | UniFi UPS 2U (`USWDA26`, firmware 1.6.1) | any UniFi UPS reporting `vbms_table` | third-party UPS over NUT — a separate provider, not this one |
 | Kubernetes | CI: envtest 1.36 API server, and the current kind default node image for e2e | 1.25+ — only long-stable APIs are used (`apps/v1` scale, `policy/v1`, `apiextensions/v1`, leases) | — |
 | Helm | 3.x | — | — |
@@ -1188,6 +1207,20 @@ kubectl -n reactor-system logs deploy/reactor | grep -E 'version detected|tested
 Outside the range above it warns and **carries on**. Refusing to start against a console that would have worked fine is a worse failure than a log line, and most of them will work fine — the warning exists so that a missing state key reads as an incompatibility rather than as a configuration mistake. If your console is not in the table and it works, [say so](https://github.com/robbeverhelst/unifi-reactor/issues/new/choose): every row here started as somebody's report.
 
 State keys degrade one at a time, so a console with no UniFi UPS still reports `wan` and `isp`, and a gateway whose fields have moved still reports `ups`. That holds across endpoints too: an observation reads `stat/device` and `stat/health`, and a console that answers one but not the other publishes the keys it can. Only observing nothing at all is an error.
+
+### Three keys are parsed against a documented shape, not a capture
+
+Every parser here is written against a real captured response — except three, and this is where that is said plainly rather than in a commit message:
+
+| Key | Fields it needs | Status |
+| --- | --- | --- |
+| `firmware` | `upgradable`, `upgrade_to_firmware`, `model_in_eol` | **no capture contains them.** The committed records carry `version` and nothing else about upgrades |
+| `temperature` | `has_temperature`, `overheating`, `temperatures[]`, `general_temperature` | **no capture contains them.** The UniFi UPS 2U reports no thermals at all |
+| `poe` | `total_max_power`, `port_table[].poe_power` | **no capture contains them.** No switch record exists in this repository |
+
+They are written to the shape UniFi's own API documents, every field is in the [capture allowlist](testdata/unifi/README.md) so the next real capture settles them, and each fails by **publishing nothing** rather than by publishing a reassuring value: no `upgradable` anywhere means no `firmware` key, not `current`; no thermals means no `temperature` key, not `normal`; an unreadable switch is left out rather than counted as having headroom.
+
+If you run a UniFi switch or an access point, `./hack/capture-unifi.sh` now writes `stat-device-switch.json` and `stat-device-ap.json`, and one of each would settle all three at once.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -731,6 +731,7 @@ Each key is published only when the matching hardware is adopted by your control
 | `ups.load` | `normal`, `high` | draw as a fraction of the UPS's power budget |
 | `devices` | `all-online`, `degraded` | whether every adopted device is reachable, or at least one is not |
 | `device.<name>` | `online`, `offline` | one adopted device, by slugified name. **Opt-in** — see below |
+| `firmware` | `current`, `updates-available` | whether the console has an update waiting for anything adopted |
 
 `isp` is the one key whose values are not a closed set: it is the carrier name your console geolocated your public address to, lowercased with everything non-alphanumeric turned into a hyphen. Look it up before matching on it —
 
@@ -862,6 +863,44 @@ devices whose names slugify to the same key — `AP 1` and `ap-1` — publish
 *neither*, because picking one would be arbitrary and the arbitrary pick could be
 the one hiding the dead device. `devices` still counts both.
 
+### `firmware` turns "I should check for updates sometime" into something that pages
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      firmware: updates-available
+  then:
+    - type: notification.ntfy      # or http.request, to open a ticket
+```
+
+One key for the whole fleet: `updates-available` while the console has an update
+waiting for **any** adopted device, `current` when it does not. Which devices, and
+what would move from which version to which, is a `V(1)` log line — a version
+string is not something `spec.when` could match, and one metric series per version
+is the cardinality failure [`isp` would have been](#cardinality-on-purpose).
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'unifi-firmware'   # needs log.level=debug
+# firmware firmware=updates-available devicesReporting=6 devicesUpgradable=ap-attic=6.6.65->7.0.50 modelsPastEOL=1
+```
+
+**Reactor will not upgrade anything.** Observing is in scope and applying is not:
+a firmware upgrade reboots hardware, and an operator choosing when that happens is
+the whole point of being told it is available.
+
+A device that does not report the field is not a device that is up to date, so a
+console where *nothing* answers publishes no `firmware` key at all rather than
+`current` — and the committed captures are exactly that case, which is why this
+parser is [not yet verified](#compatibility). Devices that stay silent while
+others answer are named in the same log line rather than assumed current.
+
+`model_in_eol` is read and deliberately **not** published as a key, though it is
+arguably the more valuable fact. It is an inventory property rather than a state:
+it does not transition, so an Automation matching it would sit permanently
+matched, which is a report rather than a reaction. It is counted in the log line
+above, and a key for it is a decision to argue for separately.
+
 If a provider stops reporting a key at all — the hardware dropped off the controller — Reactor holds the last known state and reports `Ready=False` with `StateKeyUnavailable` rather than treating lost visibility as a condition that ended ([what to do about it](docs/troubleshooting.md#2-statekeyunavailable-and-held-state)).
 
 ### Settling a noisy signal
@@ -881,6 +920,7 @@ unifi:
       wan.quality: 3
       devices: 2        # ...and don't believe one missed heartbeat
       device.*: 2       # a trailing * covers keys named after your hardware
+      firmware: 3       # ...and nothing about an update is urgent
 ```
 
 Each extra sample costs one `pollInterval` of reaction time, so the default is `1`: a WAN failover and a power cut both deserve an immediate reaction, and neither flaps. `ups.battery` ships at `2` because it is a threshold crossing — a charge hovering at 30% would otherwise report `low`, `normal`, `low` — and because a battery drains over minutes, so spending one more poll to be sure costs nothing. At the default 30s poll that makes a battery-level escalation react in 60s worst case instead of 30s.
@@ -896,6 +936,8 @@ Each extra sample costs one `pollInterval` of reaction time, so the default is `
 Debounce is also the whole of the flap control for `wan.quality`, and that is worth being explicit about, because bucketing a measurement is where a threshold usually needs hysteresis. It does not need it here: debounce promotes a value only after N *consecutive* identical observations, so a measurement hovering on a threshold produces `good`, `degraded`, `good` and is never promoted at all — the key simply holds what it had. A second, differently-shaped flap control in the provider would be a second thing to reason about for a problem the engine already solves for every key.
 
 `devices` and `device.*` ship at `2`. A device's state is a switch position like `wan`, but it is the *console's* judgement about a heartbeat rather than a wire it can see, and a busy console that misses one beat must not be a reason to page anyone. One extra sample is 60 seconds at the default poll, which is nothing against the failure this key exists for — an AP that has been dead for days.
+
+`firmware` ships at `3`, and here the reason is that nothing is lost by it. The key is not derived from your hardware at all but from the console's lookup against Ubiquiti's release catalogue, which can refresh, blip or briefly disagree with itself — and *no* firmware update needs reacting to within 30 seconds. Extra samples are free when reaction time does not matter, so it takes the most of any key.
 
 `device.*` is the one entry here that is a pattern rather than a key. Per-device key names come from your hardware, so no list written here could name them; a trailing `*` matches every key with that prefix. An exact key always wins over a pattern, and the longest matching prefix wins between patterns, so `device.ap-attic: 5` pulls one device out of the group it belongs to.
 

--- a/README.md
+++ b/README.md
@@ -733,6 +733,7 @@ Each key is published only when the matching hardware is adopted by your control
 | `device.<name>` | `online`, `offline` | one adopted device, by slugified name. **Opt-in** — see below |
 | `firmware` | `current`, `updates-available` | whether the console has an update waiting for anything adopted |
 | `temperature` | `normal`, `high` | the hottest adopted device against the configured threshold |
+| `wifi` | `ok`, `warning`, `error` | the WiFi subsystem as a whole, from the console's AP counts |
 
 `isp` is the one key whose values are not a closed set: it is the carrier name your console geolocated your public address to, lowercased with everything non-alphanumeric turned into a hyphen. Look it up before matching on it —
 
@@ -949,6 +950,36 @@ nothing, and a fleet where nothing is instrumented publishes no `temperature` ke
 at all. Reading a missing sensor as zero would make the rack look coldest exactly
 when a sensor stops answering.
 
+### `wifi` is the subsystem, not any one AP
+
+`devices: degraded` says something in the rack stopped answering. `wifi` says how
+much of your *WiFi* is left, which is a different question and often the one that
+matters to whoever is complaining:
+
+| Value | When |
+| --- | --- |
+| `ok` | every adopted access point is connected |
+| `warning` | at least one is disconnected, but not all of them |
+| `error` | **every** adopted access point is disconnected |
+
+It is derived from the console's own `num_disconnected` and `num_adopted` counts
+rather than from the `wlan` subsystem's `status` string, and #9 asked for that
+choice to be documented rather than left mysterious. The counts are a fact that can
+be explained — "1 of 3 access points is disconnected" is an answer; "UniFi said
+warning" is not — and they make `error` *derivable*, where mapping the vendor
+string through would have been inference: no capture has ever shown any subsystem
+saying `error`. In the one capture there is, the two agree exactly (`warning`, with
+1 of 3 APs disconnected), so this sharpens the console's verdict rather than
+contradicting it.
+
+The status string is still read, and a mismatch is counted as
+`reactor_provider_signal_disagreements_total{signal="wifi-status-disagrees"}` and
+logged. If UniFi's `warning` turns out to mean something else — airtime, channel
+interference — that counter rises instead of the derivation quietly being wrong.
+
+A site with **no** adopted access points publishes no `wifi` key: there is no WiFi
+there to be healthy, which is not the same as WiFi that is fine.
+
 If a provider stops reporting a key at all — the hardware dropped off the controller — Reactor holds the last known state and reports `Ready=False` with `StateKeyUnavailable` rather than treating lost visibility as a condition that ended ([what to do about it](docs/troubleshooting.md#2-statekeyunavailable-and-held-state)).
 
 ### Settling a noisy signal
@@ -970,6 +1001,7 @@ unifi:
       device.*: 2       # a trailing * covers keys named after your hardware
       firmware: 3       # ...and nothing about an update is urgent
       temperature: 3    # ...and a measurement hovers on its threshold
+      wifi: 2           # ...and an AP heartbeat can miss a beat
 ```
 
 Each extra sample costs one `pollInterval` of reaction time, so the default is `1`: a WAN failover and a power cut both deserve an immediate reaction, and neither flaps. `ups.battery` ships at `2` because it is a threshold crossing — a charge hovering at 30% would otherwise report `low`, `normal`, `low` — and because a battery drains over minutes, so spending one more poll to be sure costs nothing. At the default 30s poll that makes a battery-level escalation react in 60s worst case instead of 30s.
@@ -989,6 +1021,8 @@ Debounce is also the whole of the flap control for `wan.quality`, and that is wo
 `firmware` ships at `3`, and here the reason is that nothing is lost by it. The key is not derived from your hardware at all but from the console's lookup against Ubiquiti's release catalogue, which can refresh, blip or briefly disagree with itself — and *no* firmware update needs reacting to within 30 seconds. Extra samples are free when reaction time does not matter, so it takes the most of any key.
 
 `temperature` ships at `3` because it is a measurement that hovers: thermals move with the room, the fan and the load, and a reading sitting near the threshold would otherwise report `high`, `normal`, `high`. Debounce is the whole of the flap control here, exactly as it is for `wan.quality` — three consecutive identical readings, or the key holds what it had.
+
+`wifi` ships at `2` for the same reason `devices` does, and from the same underlying fact: an AP count is the console's judgement about heartbeats, and one missed beat on a busy console must not fire an automation.
 
 `device.*` is the one entry here that is a pattern rather than a key. Per-device key names come from your hardware, so no list written here could name them; a trailing `*` matches every key with that prefix. An exact key always wins over a pattern, and the longest matching prefix wins between patterns, so `device.ap-attic: 5` pulls one device out of the group it belongs to.
 

--- a/README.md
+++ b/README.md
@@ -729,6 +729,8 @@ Each key is published only when the matching hardware is adopted by your control
 | `ups.battery` | `normal`, `low`, `critical` | remaining charge against the configured thresholds |
 | `ups.runtime` | `ample`, `short`, `critical` | how long the UPS says it can carry its current load |
 | `ups.load` | `normal`, `high` | draw as a fraction of the UPS's power budget |
+| `devices` | `all-online`, `degraded` | whether every adopted device is reachable, or at least one is not |
+| `device.<name>` | `online`, `offline` | one adopted device, by slugified name. **Opt-in** — see below |
 
 `isp` is the one key whose values are not a closed set: it is the carrier name your console geolocated your public address to, lowercased with everything non-alphanumeric turned into a hyphen. Look it up before matching on it —
 
@@ -806,6 +808,60 @@ Both are separate keys for the same reason `ups.battery` is: they are independen
 
 > ⚠️ `timeToRemain`'s unit is **inferred** to be seconds, from a single observation on a UPS that was not discharging. Nothing in Reactor depended on it before this key existed. Confirm it against a real outage before letting `ups.runtime: critical` shut anything down — [#7](https://github.com/robbeverhelst/unifi-reactor/issues/7) has the procedure.
 
+### The fleet: `devices`, and why `device.<name>` is opt-in
+
+An access point can sit dead for days with nothing telling you. `devices` is the
+one-value answer to "is anything down": `all-online` while every adopted device
+is in contact with the console, `degraded` the moment one is not.
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      devices: degraded    # something in the rack stopped answering
+```
+
+`device.<name>` is the same observation per device, keyed by the device's name
+lowercased with everything non-alphanumeric turned into a hyphen — `US 48`
+becomes `device.us-48`. **It is off by default**, and that is a deliberate
+asymmetry rather than caution:
+
+```yaml
+unifi:
+  devices:
+    perDeviceKeys: true    # one key, and one metric series, per adopted device
+```
+
+Every other key here is bounded by what is compiled in. `device.<name>` is the
+first whose *name* comes from your network, so turning it on means one state key,
+one `reactor_state_transitions_total` series, and one more thing an Automation
+can hold state for **per adopted device** — forty devices, forty of each. The
+aggregate costs one series whatever the fleet size, so it ships on and the
+per-device keys are something you ask for. Reactor logs at startup when they are
+on, and `unifi.devices.perDeviceKeys` is the only setting on this page that
+changes how *much* Reactor publishes rather than what it means.
+
+Per-device keys are also never labelled by value in Prometheus, for the same
+reason `isp` is not — see [Cardinality](#what-is-measured). Which device is down
+is in the Automation's `status.observedState`, in an Event, and in a `V(1)` log
+line naming the device and the console's own disconnection reason.
+
+Three things are excluded on purpose. **Unadopted and pending devices**: the
+console can see your neighbour's AP, and it is not your fleet. **A device
+reporting a state this provider does not recognise** — UniFi documents
+provisioning, upgrading and heartbeat-missed states that no capture has ever
+shown — because reading an unfamiliar state as `offline` would report a firmware
+upgrade as a fleet outage. **A device reporting no state at all**, which is
+absence, not zero.
+
+Renaming a device on the console makes its old key *vanish* rather than report
+`offline`, which Reactor treats as lost visibility: the last known state is held
+and `Ready=False` reports `StateKeyUnavailable`, so nothing fires `onExit`
+because you retitled a switch. The same is true of a device you remove. And two
+devices whose names slugify to the same key — `AP 1` and `ap-1` — publish
+*neither*, because picking one would be arbitrary and the arbitrary pick could be
+the one hiding the dead device. `devices` still counts both.
+
 If a provider stops reporting a key at all — the hardware dropped off the controller — Reactor holds the last known state and reports `Ready=False` with `StateKeyUnavailable` rather than treating lost visibility as a condition that ended ([what to do about it](docs/troubleshooting.md#2-statekeyunavailable-and-held-state)).
 
 ### Settling a noisy signal
@@ -823,6 +879,8 @@ unifi:
       isp: 2            # ...and let a re-geolocated carrier settle
       internet: 3       # ...and don't believe one bad probe round
       wan.quality: 3
+      devices: 2        # ...and don't believe one missed heartbeat
+      device.*: 2       # a trailing * covers keys named after your hardware
 ```
 
 Each extra sample costs one `pollInterval` of reaction time, so the default is `1`: a WAN failover and a power cut both deserve an immediate reaction, and neither flaps. `ups.battery` ships at `2` because it is a threshold crossing — a charge hovering at 30% would otherwise report `low`, `normal`, `low` — and because a battery drains over minutes, so spending one more poll to be sure costs nothing. At the default 30s poll that makes a battery-level escalation react in 60s worst case instead of 30s.
@@ -836,6 +894,10 @@ Each extra sample costs one `pollInterval` of reaction time, so the default is `
 `internet` and `wan.quality` ship at `3`, the highest in the chart, because they are the two keys derived from probes to the outside world rather than from anything on your desk. A single poll in which a probe target rate-limits or a resolver blips must not shed a cluster's load. At the default 30s poll that is 90 seconds before either an outage or a recovery is believed — deliberately symmetric, because a link flapping in and out is exactly when repeatedly scaling workloads up and down does the most damage.
 
 Debounce is also the whole of the flap control for `wan.quality`, and that is worth being explicit about, because bucketing a measurement is where a threshold usually needs hysteresis. It does not need it here: debounce promotes a value only after N *consecutive* identical observations, so a measurement hovering on a threshold produces `good`, `degraded`, `good` and is never promoted at all — the key simply holds what it had. A second, differently-shaped flap control in the provider would be a second thing to reason about for a problem the engine already solves for every key.
+
+`devices` and `device.*` ship at `2`. A device's state is a switch position like `wan`, but it is the *console's* judgement about a heartbeat rather than a wire it can see, and a busy console that misses one beat must not be a reason to page anyone. One extra sample is 60 seconds at the default poll, which is nothing against the failure this key exists for — an AP that has been dead for days.
+
+`device.*` is the one entry here that is a pattern rather than a key. Per-device key names come from your hardware, so no list written here could name them; a trailing `*` matches every key with that prefix. An exact key always wins over a pattern, and the longest matching prefix wins between patterns, so `device.ap-attic: 5` pulls one device out of the group it belongs to.
 
 Debouncing happens in the shared state store, so every automation sees the same settled value. Two automations can never disagree about the current state and fight over a workload they share.
 
@@ -884,6 +946,8 @@ Reconcile counts, queue depth and reconcile latency are controller-runtime's own
 `isp` is the first state key whose values are an **open set** — a carrier slug derived from whatever public address your gateway currently holds. So `reactor_state_info` is published only for keys whose provider declares a closed value set, and `isp` is deliberately not one of them. The transition counter is not labelled by `from`/`to` for the same reason. What a key currently holds is always in `status.observedState` and in an `Event`; what Prometheus keeps is bounded at compile time.
 
 Declaring the vocabulary is also what lets the gauge report `0` for the values a key does *not* hold. Without that, the series for a value it used to hold goes stale at `1` rather than dropping, and every graph built on it lies. All values `0` means the key is not currently observable — the metric side of [`StateKeyUnavailable`](docs/troubleshooting.md#2-statekeyunavailable-and-held-state).
+
+`device.<name>` is the other side of the same coin, and the reason [it is opt-in](#the-fleet-devices-and-why-devicename-is-opt-in). Its *values* are closed — two of them — but its **key name** comes from your network, so the set of keys is open. It is therefore never in `reactor_state_info` at all, and turning the keys on adds one `reactor_state_transitions_total` series per adopted device: a bounded number, chosen by you, rather than one this repository can promise. `devices` is one series regardless of fleet size, which is why it is the one that ships on.
 
 ### Alerts and the dashboard
 

--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ Each key is published only when the matching hardware is adopted by your control
 | `firmware` | `current`, `updates-available` | whether the console has an update waiting for anything adopted |
 | `temperature` | `normal`, `high` | the hottest adopted device against the configured threshold |
 | `wifi` | `ok`, `warning`, `error` | the WiFi subsystem as a whole, from the console's AP counts |
+| `poe` | `ok`, `insufficient` | PoE headroom on the worst switch, against the configured threshold |
 
 `isp` is the one key whose values are not a closed set: it is the carrier name your console geolocated your public address to, lowercased with everything non-alphanumeric turned into a hyphen. Look it up before matching on it —
 
@@ -980,6 +981,41 @@ interference — that counter rises instead of the derivation quietly being wron
 A site with **no** adopted access points publishes no `wifi` key: there is no WiFi
 there to be healthy, which is not the same as WiFi that is fine.
 
+### `poe` is headroom, before it becomes an outage
+
+An overloaded PoE budget silently drops APs and cameras. `poe` reports
+`insufficient` when the worst switch is delivering at or above a share of its
+budget **you configure**:
+
+```yaml
+unifi:
+  poe:
+    maxUtilizationPercent: 90
+```
+
+`insufficient` means *the headroom is gone*, not that a port has already been
+denied power — by the time the console refuses a port, the camera is off. The
+worst switch decides, because one switch out of headroom drops the cameras on
+that switch whatever the rest of the rack has spare.
+
+Another [bucketed measurement](#temperature-is-the-hottest-device-bucketed), with
+the watts in a `V(1)` log line:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'unifi-poe'   # needs log.level=debug
+# poe poe=ok worstUtilizationPercent=32.5 worstSwitch=switch-48 draws=switch-48=63.5/195W
+```
+
+The interesting rule here is what happens to a port that is **powering something
+and will not say how much**: it makes that whole switch unreadable, and the switch
+is left out rather than counted as drawing nothing. Counting it as 0 W would report
+headroom that is not there — under-counting the draw is the one direction that
+hides the exact failure this key exists to catch. Other switches are still
+measured, so one unreadable switch does not take the key with it.
+
+A switch reporting no budget is likewise not a switch with no budget, and never a
+denominator. A fleet with no readable PoE switch publishes no `poe` key at all.
+
 If a provider stops reporting a key at all — the hardware dropped off the controller — Reactor holds the last known state and reports `Ready=False` with `StateKeyUnavailable` rather than treating lost visibility as a condition that ended ([what to do about it](docs/troubleshooting.md#2-statekeyunavailable-and-held-state)).
 
 ### Settling a noisy signal
@@ -1002,6 +1038,7 @@ unifi:
       firmware: 3       # ...and nothing about an update is urgent
       temperature: 3    # ...and a measurement hovers on its threshold
       wifi: 2           # ...and an AP heartbeat can miss a beat
+      poe: 3            # ...and a PoE draw moves when a radio comes up
 ```
 
 Each extra sample costs one `pollInterval` of reaction time, so the default is `1`: a WAN failover and a power cut both deserve an immediate reaction, and neither flaps. `ups.battery` ships at `2` because it is a threshold crossing — a charge hovering at 30% would otherwise report `low`, `normal`, `low` — and because a battery drains over minutes, so spending one more poll to be sure costs nothing. At the default 30s poll that makes a battery-level escalation react in 60s worst case instead of 30s.
@@ -1023,6 +1060,8 @@ Debounce is also the whole of the flap control for `wan.quality`, and that is wo
 `temperature` ships at `3` because it is a measurement that hovers: thermals move with the room, the fan and the load, and a reading sitting near the threshold would otherwise report `high`, `normal`, `high`. Debounce is the whole of the flap control here, exactly as it is for `wan.quality` — three consecutive identical readings, or the key holds what it had.
 
 `wifi` ships at `2` for the same reason `devices` does, and from the same underlying fact: an AP count is the console's judgement about heartbeats, and one missed beat on a busy console must not fire an automation.
+
+`poe` ships at `3`, the same argument as `ups.load`: it is an instantaneous measurement, and an AP's radios or a camera's heater coming up move the draw by tens of watts within one poll. Its 90% default assumes those three samples — raise the threshold towards 100 and there is no headroom left to react in during them.
 
 `device.*` is the one entry here that is a pattern rather than a key. Per-device key names come from your hardware, so no list written here could name them; a trailing `*` matches every key with that prefix. An exact key always wins over a pattern, and the longest matching prefix wins between patterns, so `device.ap-attic: 5` pulls one device out of the group it belongs to.
 

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -384,6 +384,11 @@ signal disagreement and logged, rather than either being silently trusted.
 
 A site with no adopted access points publishes no key at all.
 
+The three values are alternatives rather than steps of a ladder, the same shape
+`internet` has: an automation matching `wifi: warning` stops matching — and reverses —
+when the value moves to `error`. Match the value you mean, or write one automation per
+value.
+
 ### `poe`
 
 `insufficient` when the worst switch is delivering at or above a share of its PoE

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -254,6 +254,7 @@ hardware is adopted by the controller.
 | `device.<name>` | `online`, `offline` | one adopted device's `state`, by slugified name. **Opt-in** |
 | `firmware` | `current`, `updates-available` | whether the console has an update waiting for any adopted device |
 | `temperature` | `normal`, `high` | the hottest adopted device vs. the configured threshold |
+| `wifi` | `ok`, `warning`, `error` | the `wlan` subsystem's AP counts: some disconnected, or all of them |
 
 `isp` is the only key with an open value set — it is your carrier's name, lowercased with
 non-alphanumerics turned into hyphens. Read it off a state transition line before matching on it.
@@ -368,6 +369,19 @@ and a fleet where nothing is instrumented publishes no key at all.
 > ⚠️ The thermal fields are **not in any committed capture** — the UPS 2U reports
 > none — so this parser is written to the shape UniFi documents and is unverified,
 > including whether the readings are Celsius.
+
+### `wifi`
+
+`ok` while every adopted access point is connected, `warning` while some are
+disconnected, `error` when **all** of them are. There is nothing to configure.
+
+It is derived from the `wlan` subsystem's `num_disconnected` and `num_adopted`
+counts rather than from its `status` string: the counts are a fact that can be
+explained, and they make `error` derivable where the vendor string would have been
+inference. The status is still read and cross-checked — a mismatch is counted as a
+signal disagreement and logged, rather than either being silently trusted.
+
+A site with no adopted access points publishes no key at all.
 
 ### `internet` and `wan.quality`
 
@@ -784,7 +798,7 @@ was told, while the workload was still scaled and the Automation is still
 
 `reactor_state_info{provider,key,value}` is published **only for state keys
 whose value set the provider declares closed** — `wan`, `wan.quality`,
-`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`, `firmware`, `temperature`. `isp` is not one of them: its values are
+`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`, `firmware`, `temperature`, `wifi`. `isp` is not one of them: its values are
 carrier slugs derived from whatever public address your gateway holds, so
 labelling by them would add one permanent time series per carrier ever seen.
 `reactor_state_transitions_total` is not labelled by `from`/`to` for the same
@@ -897,7 +911,7 @@ publishing — which fails as silence rather than as an error.
 | `unifi.devices.perDeviceKeys` | `false` | also publish a `device.<name>` key per adopted device; one more series per device |
 | `unifi.temperature.highCelsius` | `75` | hottest adopted device at or above this reports `temperature: high` |
 | `unifi.debounce.default` | `1` | consecutive observations a changed value needs before Reactor acts; each extra sample costs one `pollInterval` of reaction time |
-| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3, temperature: 3}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
+| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3, temperature: 3, wifi: 2}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
 | `unifi.webhook.enabled` | `false` | Run the webhook receiver; a delivery triggers a poll, never a state change |
 | `unifi.webhook.port` | `9090` | Port the receiver listens on inside the pod |
 | `unifi.webhook.path` | `/webhooks/unifi` | URL path deliveries are accepted on |

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -252,6 +252,7 @@ hardware is adopted by the controller.
 | `ups.load` | `normal`, `high` | output as a share of the UPS's power budget |
 | `devices` | `all-online`, `degraded` | whether every adopted device is in contact with the console |
 | `device.<name>` | `online`, `offline` | one adopted device's `state`, by slugified name. **Opt-in** |
+| `firmware` | `current`, `updates-available` | whether the console has an update waiting for any adopted device |
 
 `isp` is the only key with an open value set — it is your carrier's name, lowercased with
 non-alphanumerics turned into hyphens. Read it off a state transition line before matching on it.
@@ -324,6 +325,26 @@ Names are slugified — `US 48` publishes `device.us-48`. Renaming a device make
 old key vanish rather than report `offline`, so `Ready=False`/`StateKeyUnavailable`
 holds the last known state instead of firing `onExit`. Two devices whose names
 slugify to one key publish neither, and the disagreement counter records it.
+
+### `firmware`
+
+`updates-available` while the console has an update waiting for **any** adopted
+device, `current` when it does not. There is nothing to configure. Which devices,
+and which version would move where, is a debug log line rather than a state value —
+a version string is not something `spec.when` can match, and one series per version
+is a cardinality problem.
+
+**Reactor never applies an upgrade.** Observing is in scope; rebooting your hardware
+is your decision.
+
+A device that does not report `upgradable` is not a device that is up to date, so a
+console where nothing answers publishes no `firmware` key at all. `model_in_eol` is
+read and counted in that same log line, and deliberately not a key: it is an
+inventory fact that never transitions.
+
+> ⚠️ The upgrade fields are **not in any committed capture**, so this parser is
+> written to the shape UniFi documents and is unverified. It fails by publishing
+> nothing rather than by publishing `current`.
 
 ### `internet` and `wan.quality`
 
@@ -740,7 +761,7 @@ was told, while the workload was still scaled and the Automation is still
 
 `reactor_state_info{provider,key,value}` is published **only for state keys
 whose value set the provider declares closed** — `wan`, `wan.quality`,
-`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`. `isp` is not one of them: its values are
+`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`, `firmware`. `isp` is not one of them: its values are
 carrier slugs derived from whatever public address your gateway holds, so
 labelling by them would add one permanent time series per carrier ever seen.
 `reactor_state_transitions_total` is not labelled by `from`/`to` for the same
@@ -852,7 +873,7 @@ publishing — which fails as silence rather than as an error.
 | `unifi.wan.quality.maxLatencyMs` | `150` | average latency above this reports `wan.quality: degraded` |
 | `unifi.devices.perDeviceKeys` | `false` | also publish a `device.<name>` key per adopted device; one more series per device |
 | `unifi.debounce.default` | `1` | consecutive observations a changed value needs before Reactor acts; each extra sample costs one `pollInterval` of reaction time |
-| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
+| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
 | `unifi.webhook.enabled` | `false` | Run the webhook receiver; a delivery triggers a poll, never a state change |
 | `unifi.webhook.port` | `9090` | Port the receiver listens on inside the pod |
 | `unifi.webhook.path` | `/webhooks/unifi` | URL path deliveries are accepted on |

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -253,6 +253,7 @@ hardware is adopted by the controller.
 | `devices` | `all-online`, `degraded` | whether every adopted device is in contact with the console |
 | `device.<name>` | `online`, `offline` | one adopted device's `state`, by slugified name. **Opt-in** |
 | `firmware` | `current`, `updates-available` | whether the console has an update waiting for any adopted device |
+| `temperature` | `normal`, `high` | the hottest adopted device vs. the configured threshold |
 
 `isp` is the only key with an open value set — it is your carrier's name, lowercased with
 non-alphanumerics turned into hyphens. Read it off a state transition line before matching on it.
@@ -345,6 +346,28 @@ inventory fact that never transitions.
 > ⚠️ The upgrade fields are **not in any committed capture**, so this parser is
 > written to the shape UniFi documents and is unverified. It fails by publishing
 > nothing rather than by publishing `current`.
+
+### `temperature`
+
+The hottest adopted device, bucketed against a threshold you set. The console's own
+`overheating` flag reports `high` regardless of it — the firmware knows what a model
+tolerates and a default here does not.
+
+| Value | Default | Description |
+| --- | --- | --- |
+| `unifi.temperature.highCelsius` | `75` | hottest reading at or above this reports `high` |
+
+Set against the debounce this key ships with, not in isolation: UniFi switches and
+APs normally sit at 40–60 °C, so 75 °C plus 3 samples is a reading that held for 90
+seconds rather than a fan spinning up late. The per-device readings are in a debug
+log line, which is where to look before choosing your own number.
+
+A device reporting no temperature is not a device at 0 °C: it contributes nothing,
+and a fleet where nothing is instrumented publishes no key at all.
+
+> ⚠️ The thermal fields are **not in any committed capture** — the UPS 2U reports
+> none — so this parser is written to the shape UniFi documents and is unverified,
+> including whether the readings are Celsius.
 
 ### `internet` and `wan.quality`
 
@@ -761,7 +784,7 @@ was told, while the workload was still scaled and the Automation is still
 
 `reactor_state_info{provider,key,value}` is published **only for state keys
 whose value set the provider declares closed** — `wan`, `wan.quality`,
-`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`, `firmware`. `isp` is not one of them: its values are
+`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`, `firmware`, `temperature`. `isp` is not one of them: its values are
 carrier slugs derived from whatever public address your gateway holds, so
 labelling by them would add one permanent time series per carrier ever seen.
 `reactor_state_transitions_total` is not labelled by `from`/`to` for the same
@@ -872,8 +895,9 @@ publishing — which fails as silence rather than as an error.
 | `unifi.wan.quality.minAvailabilityPercent` | `99` | availability below this reports `wan.quality: degraded` |
 | `unifi.wan.quality.maxLatencyMs` | `150` | average latency above this reports `wan.quality: degraded` |
 | `unifi.devices.perDeviceKeys` | `false` | also publish a `device.<name>` key per adopted device; one more series per device |
+| `unifi.temperature.highCelsius` | `75` | hottest adopted device at or above this reports `temperature: high` |
 | `unifi.debounce.default` | `1` | consecutive observations a changed value needs before Reactor acts; each extra sample costs one `pollInterval` of reaction time |
-| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
+| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3, temperature: 3}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
 | `unifi.webhook.enabled` | `false` | Run the webhook receiver; a delivery triggers a poll, never a state change |
 | `unifi.webhook.port` | `9090` | Port the receiver listens on inside the pod |
 | `unifi.webhook.path` | `/webhooks/unifi` | URL path deliveries are accepted on |

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -255,6 +255,7 @@ hardware is adopted by the controller.
 | `firmware` | `current`, `updates-available` | whether the console has an update waiting for any adopted device |
 | `temperature` | `normal`, `high` | the hottest adopted device vs. the configured threshold |
 | `wifi` | `ok`, `warning`, `error` | the `wlan` subsystem's AP counts: some disconnected, or all of them |
+| `poe` | `ok`, `insufficient` | the worst switch's PoE draw vs. its budget and the configured threshold |
 
 `isp` is the only key with an open value set — it is your carrier's name, lowercased with
 non-alphanumerics turned into hyphens. Read it off a state transition line before matching on it.
@@ -382,6 +383,29 @@ inference. The status is still read and cross-checked — a mismatch is counted 
 signal disagreement and logged, rather than either being silently trusted.
 
 A site with no adopted access points publishes no key at all.
+
+### `poe`
+
+`insufficient` when the worst switch is delivering at or above a share of its PoE
+budget — meaning the headroom is gone, not that a port has already been denied
+power. By the time the console refuses a port, the camera is off.
+
+| Value | Default | Description |
+| --- | --- | --- |
+| `unifi.poe.maxUtilizationPercent` | `90` | draw at or above this share of the budget reports `insufficient` |
+
+Set against the debounce this key ships with: PoE draw is instantaneous, so it
+settles over 3 samples, and 90% leaves roughly one powered device's worth of
+headroom during those 90 seconds.
+
+A port that is powering something and reports no wattage makes that whole switch
+unreadable rather than contributing zero — under-counting the draw would report
+headroom that is not there. Other switches are still measured; a fleet with no
+readable switch publishes no key.
+
+> ⚠️ The PoE fields are **not in any committed capture** — no switch record exists
+> at all — so this parser is written to the shape UniFi documents and is
+> unverified, including that `poe_power` arrives as a string.
 
 ### `internet` and `wan.quality`
 
@@ -798,7 +822,7 @@ was told, while the workload was still scaled and the Automation is still
 
 `reactor_state_info{provider,key,value}` is published **only for state keys
 whose value set the provider declares closed** — `wan`, `wan.quality`,
-`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`, `firmware`, `temperature`, `wifi`. `isp` is not one of them: its values are
+`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`, `firmware`, `temperature`, `wifi`, `poe`. `isp` is not one of them: its values are
 carrier slugs derived from whatever public address your gateway holds, so
 labelling by them would add one permanent time series per carrier ever seen.
 `reactor_state_transitions_total` is not labelled by `from`/`to` for the same
@@ -910,8 +934,9 @@ publishing — which fails as silence rather than as an error.
 | `unifi.wan.quality.maxLatencyMs` | `150` | average latency above this reports `wan.quality: degraded` |
 | `unifi.devices.perDeviceKeys` | `false` | also publish a `device.<name>` key per adopted device; one more series per device |
 | `unifi.temperature.highCelsius` | `75` | hottest adopted device at or above this reports `temperature: high` |
+| `unifi.poe.maxUtilizationPercent` | `90` | a switch delivering at or above this share of its PoE budget reports `poe: insufficient` |
 | `unifi.debounce.default` | `1` | consecutive observations a changed value needs before Reactor acts; each extra sample costs one `pollInterval` of reaction time |
-| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3, temperature: 3, wifi: 2}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
+| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3, temperature: 3, wifi: 2, poe: 3}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
 | `unifi.webhook.enabled` | `false` | Run the webhook receiver; a delivery triggers a poll, never a state change |
 | `unifi.webhook.port` | `9090` | Port the receiver listens on inside the pod |
 | `unifi.webhook.path` | `/webhooks/unifi` | URL path deliveries are accepted on |

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -250,6 +250,8 @@ hardware is adopted by the controller.
 | `ups.battery` | `normal`, `low`, `critical` | remaining charge vs. the configured thresholds |
 | `ups.runtime` | `ample`, `short`, `critical` | `timeToRemain` vs. the configured thresholds |
 | `ups.load` | `normal`, `high` | output as a share of the UPS's power budget |
+| `devices` | `all-online`, `degraded` | whether every adopted device is in contact with the console |
+| `device.<name>` | `online`, `offline` | one adopted device's `state`, by slugified name. **Opt-in** |
 
 `isp` is the only key with an open value set — it is your carrier's name, lowercased with
 non-alphanumerics turned into hyphens. Read it off a state transition line before matching on it.
@@ -296,6 +298,32 @@ goes, and that is worth knowing while the lights are still on.
 > ⚠️ `timeToRemain`'s unit is **inferred** to be seconds, from a single
 > observation on a UPS that was not discharging. Confirm it against a real
 > outage before letting `ups.runtime: critical` shut anything down.
+
+### `devices`, and why `device.<name>` is opt-in
+
+`devices` is the fleet in one value: `all-online` while every adopted device is in
+contact with the console, `degraded` the moment one is not. Unadopted and pending
+devices are excluded — the console can see hardware it does not manage — as is any
+device reporting a state this provider does not recognise, because UniFi documents
+provisioning and upgrading states no capture has shown and reading one as `offline`
+would report a firmware upgrade as an outage.
+
+| Value | Default | Description |
+| --- | --- | --- |
+| `unifi.devices.perDeviceKeys` | `false` | also publish a `device.<name>` key per adopted device |
+
+This is the only value in this chart that changes how *much* Reactor publishes
+rather than what any of it means. Every other state key is bounded by what is
+compiled in; a per-device key's name comes from your network, so turning this on
+costs one state key, one `reactor_state_transitions_total` series, and one more key
+an Automation can hold state for **per adopted device**. The aggregate costs one
+series whatever the fleet size, which is why it is the one that ships on. Reactor
+logs a line at startup when per-device keys are enabled.
+
+Names are slugified — `US 48` publishes `device.us-48`. Renaming a device makes its
+old key vanish rather than report `offline`, so `Ready=False`/`StateKeyUnavailable`
+holds the last known state instead of firing `onExit`. Two devices whose names
+slugify to one key publish neither, and the disagreement counter records it.
 
 ### `internet` and `wan.quality`
 
@@ -712,11 +740,18 @@ was told, while the workload was still scaled and the Automation is still
 
 `reactor_state_info{provider,key,value}` is published **only for state keys
 whose value set the provider declares closed** — `wan`, `wan.quality`,
-`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`. `isp` is not one of them: its values are
+`internet`, `ups`, `ups.battery`, `ups.runtime`, `ups.load`, `devices`. `isp` is not one of them: its values are
 carrier slugs derived from whatever public address your gateway holds, so
 labelling by them would add one permanent time series per carrier ever seen.
 `reactor_state_transitions_total` is not labelled by `from`/`to` for the same
 reason.
+
+`device.<name>` is left out for the mirror-image reason: its *values* are closed,
+and its **key name** is not, because it comes from your device names. It is
+therefore never in `reactor_state_info`, and enabling `unifi.devices.perDeviceKeys`
+adds one `reactor_state_transitions_total` series per adopted device — a number
+bounded by your rack rather than by this chart, which is exactly why you have to
+ask for it.
 
 `wan.quality` and `ups.load` are in that list only because they were bucketed.
 The availability, latency and wattage behind them are continuous, and
@@ -815,8 +850,9 @@ publishing — which fails as silence rather than as an error.
 | `unifi.ups.highLoadPercent` | `80` | draw at or above this share of the power budget reports `ups.load: high` |
 | `unifi.wan.quality.minAvailabilityPercent` | `99` | availability below this reports `wan.quality: degraded` |
 | `unifi.wan.quality.maxLatencyMs` | `150` | average latency above this reports `wan.quality: degraded` |
+| `unifi.devices.perDeviceKeys` | `false` | also publish a `device.<name>` key per adopted device; one more series per device |
 | `unifi.debounce.default` | `1` | consecutive observations a changed value needs before Reactor acts; each extra sample costs one `pollInterval` of reaction time |
-| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3}` | per-key overrides for signals that settle rather than switch |
+| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
 | `unifi.webhook.enabled` | `false` | Run the webhook receiver; a delivery triggers a poll, never a state change |
 | `unifi.webhook.port` | `9090` | Port the receiver listens on inside the pod |
 | `unifi.webhook.path` | `/webhooks/unifi` | URL path deliveries are accepted on |

--- a/charts/reactor/templates/deployment.yaml
+++ b/charts/reactor/templates/deployment.yaml
@@ -95,6 +95,8 @@ spec:
               value: {{ .Values.unifi.wan.quality.maxLatencyMs | quote }}
             - name: UNIFI_TEMPERATURE_HIGH_CELSIUS
               value: {{ .Values.unifi.temperature.highCelsius | quote }}
+            - name: UNIFI_POE_MAX_UTILIZATION_PERCENT
+              value: {{ .Values.unifi.poe.maxUtilizationPercent | quote }}
             - name: UNIFI_PER_DEVICE_KEYS
               value: {{ .Values.unifi.devices.perDeviceKeys | quote }}
             - name: UNIFI_DEBOUNCE_DEFAULT

--- a/charts/reactor/templates/deployment.yaml
+++ b/charts/reactor/templates/deployment.yaml
@@ -93,6 +93,8 @@ spec:
               value: {{ .Values.unifi.wan.quality.minAvailabilityPercent | quote }}
             - name: UNIFI_WAN_QUALITY_MAX_LATENCY_MS
               value: {{ .Values.unifi.wan.quality.maxLatencyMs | quote }}
+            - name: UNIFI_TEMPERATURE_HIGH_CELSIUS
+              value: {{ .Values.unifi.temperature.highCelsius | quote }}
             - name: UNIFI_PER_DEVICE_KEYS
               value: {{ .Values.unifi.devices.perDeviceKeys | quote }}
             - name: UNIFI_DEBOUNCE_DEFAULT

--- a/charts/reactor/templates/deployment.yaml
+++ b/charts/reactor/templates/deployment.yaml
@@ -93,6 +93,8 @@ spec:
               value: {{ .Values.unifi.wan.quality.minAvailabilityPercent | quote }}
             - name: UNIFI_WAN_QUALITY_MAX_LATENCY_MS
               value: {{ .Values.unifi.wan.quality.maxLatencyMs | quote }}
+            - name: UNIFI_PER_DEVICE_KEYS
+              value: {{ .Values.unifi.devices.perDeviceKeys | quote }}
             - name: UNIFI_DEBOUNCE_DEFAULT
               value: {{ .Values.unifi.debounce.default | quote }}
             {{- with .Values.unifi.debounce.keys }}

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -124,6 +124,9 @@ unifi:
     # threshold would otherwise report high/normal/high. Its default threshold
     # is set against these 3 samples.
     #
+    # wifi takes 2 for the same reason devices does, and from the same
+    # underlying fact: an AP count is the console's judgement about heartbeats.
+    #
     # firmware takes 3, and nothing is lost by it: the key comes from the
     # console's lookup against Ubiquiti's release catalogue rather than from
     # your hardware, and no firmware update needs reacting to within 30
@@ -145,6 +148,7 @@ unifi:
       device.*: 2
       firmware: 3
       temperature: 3
+      wifi: 2
   # Name of an existing Secret containing the key UNIFI_API_KEY.
   # Create it with:
   #   kubectl -n <namespace> create secret generic unifi-reactor-credentials \

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -104,6 +104,11 @@ unifi:
     # anyone. 60s at the default poll is nothing against the failure the key
     # exists for — a device that has been dead for days.
     #
+    # firmware takes 3, and nothing is lost by it: the key comes from the
+    # console's lookup against Ubiquiti's release catalogue rather than from
+    # your hardware, and no firmware update needs reacting to within 30
+    # seconds. Extra samples are free when reaction time does not matter.
+    #
     # An entry may end in "*", which matches every key with that prefix. It is
     # how a group whose key names come from your hardware gets settled at all:
     # no list here could name them. Exact keys win over patterns, and the
@@ -118,6 +123,7 @@ unifi:
       wan.quality: 3
       devices: 2
       device.*: 2
+      firmware: 3
   # Name of an existing Secret containing the key UNIFI_API_KEY.
   # Create it with:
   #   kubectl -n <namespace> create secret generic unifi-reactor-credentials \

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -73,6 +73,18 @@ unifi:
     # The per-device readings are in a debug log line — that is where to look
     # before choosing your own number.
     highCelsius: 75
+  poe:
+    # Share (%) of a switch's PoE budget at or above which poe reports
+    # "insufficient" — meaning the headroom is gone, not that a port has
+    # already been denied power. The worst switch in the fleet decides.
+    #
+    # Set against the debounce poe ships with. PoE draw is an instantaneous
+    # measurement like ups.load — an AP's radios coming up move it by tens of
+    # watts within one poll — so it settles over 3 samples, and 90% leaves
+    # roughly one powered device's worth of headroom during those 90s. Raise it
+    # towards 100 and there is no headroom left to react in; lower it and a
+    # switch with a full complement of APs reports insufficient forever.
+    maxUtilizationPercent: 90
   wan:
     # Thresholds for wan.quality, which buckets how well the *live* uplink is
     # performing into "good" or "degraded". Both numbers are averages the
@@ -124,6 +136,10 @@ unifi:
     # threshold would otherwise report high/normal/high. Its default threshold
     # is set against these 3 samples.
     #
+    # poe takes 3, the same argument as ups.load: an instantaneous measurement
+    # that moves when a radio or a camera heater comes up. Its threshold is set
+    # against these 3 samples.
+    #
     # wifi takes 2 for the same reason devices does, and from the same
     # underlying fact: an AP count is the console's judgement about heartbeats.
     #
@@ -149,6 +165,7 @@ unifi:
       firmware: 3
       temperature: 3
       wifi: 2
+      poe: 3
   # Name of an existing Secret containing the key UNIFI_API_KEY.
   # Create it with:
   #   kubectl -n <namespace> create secret generic unifi-reactor-credentials \

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -42,6 +42,22 @@ unifi:
     # Draw as a percentage of the UPS's power budget at or above which ups.load
     # reports "high".
     highLoadPercent: 80
+  devices:
+    # Publish a device.<name> key per adopted device, alongside the aggregate
+    # devices key that is always published.
+    #
+    # Off by default, and this is the one setting here that changes how MUCH
+    # Reactor publishes rather than what any of it means. Every other state key
+    # is bounded by what is compiled in; a per-device key's name comes from your
+    # network, so turning this on costs one state key, one transition series,
+    # and one more key an Automation can hold state for PER ADOPTED DEVICE.
+    # Forty devices is forty of each. The aggregate answers "is anything down"
+    # on one series whatever the fleet size.
+    #
+    # Names are slugified: "US 48" publishes device.us-48. Renaming a device on
+    # the console makes its old key vanish, which Reactor holds state through
+    # rather than treating as a recovery.
+    perDeviceKeys: false
   wan:
     # Thresholds for wan.quality, which buckets how well the *live* uplink is
     # performing into "good" or "degraded". Both numbers are averages the
@@ -82,6 +98,17 @@ unifi:
     # thresholds are set to leave headroom for exactly that delay. ups.load is
     # the only key derived from an instantaneous measurement that moves second
     # to second (a server spinning up shifts the draw), so it takes 3.
+    # devices and device.* take 2. A device's state is a switch position like
+    # wan, but it is the console's judgement about a heartbeat rather than a
+    # wire it can see, and one missed beat on a busy console must not page
+    # anyone. 60s at the default poll is nothing against the failure the key
+    # exists for — a device that has been dead for days.
+    #
+    # An entry may end in "*", which matches every key with that prefix. It is
+    # how a group whose key names come from your hardware gets settled at all:
+    # no list here could name them. Exact keys win over patterns, and the
+    # longest prefix wins between patterns, so `device.ap-attic: 5` pulls one
+    # device out of the group.
     keys:
       ups.battery: 2
       ups.runtime: 2
@@ -89,6 +116,8 @@ unifi:
       isp: 2
       internet: 3
       wan.quality: 3
+      devices: 2
+      device.*: 2
   # Name of an existing Secret containing the key UNIFI_API_KEY.
   # Create it with:
   #   kubectl -n <namespace> create secret generic unifi-reactor-credentials \

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -58,6 +58,21 @@ unifi:
     # the console makes its old key vanish, which Reactor holds state through
     # rather than treating as a recovery.
     perDeviceKeys: false
+  temperature:
+    # Reading (°C) at or above which the hottest adopted device makes
+    # temperature report "high". The console's own overheating flag reports
+    # "high" regardless of this number: the firmware knows what a model
+    # tolerates and a default here does not.
+    #
+    # Set against the debounce temperature ships with, not in isolation. UniFi
+    # switches and APs normally sit at 40-60 °C, so 75 plus 3 samples means a
+    # reading that held for 90s at the default pollInterval rather than a fan
+    # spinning up late. Lower this towards the normal operating range and that
+    # hysteresis stops meaning anything.
+    #
+    # The per-device readings are in a debug log line — that is where to look
+    # before choosing your own number.
+    highCelsius: 75
   wan:
     # Thresholds for wan.quality, which buckets how well the *live* uplink is
     # performing into "good" or "degraded". Both numbers are averages the
@@ -104,6 +119,11 @@ unifi:
     # anyone. 60s at the default poll is nothing against the failure the key
     # exists for — a device that has been dead for days.
     #
+    # temperature takes 3 because it is a measurement that hovers: thermals
+    # move with the room, the fan and the load, and a reading sitting on the
+    # threshold would otherwise report high/normal/high. Its default threshold
+    # is set against these 3 samples.
+    #
     # firmware takes 3, and nothing is lost by it: the key comes from the
     # console's lookup against Ubiquiti's release catalogue rather than from
     # your hardware, and no firmware update needs reacting to within 30
@@ -124,6 +144,7 @@ unifi:
       devices: 2
       device.*: 2
       firmware: 3
+      temperature: 3
   # Name of an existing Secret containing the key UNIFI_API_KEY.
   # Create it with:
   #   kubectl -n <namespace> create secret generic unifi-reactor-credentials \

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -481,6 +481,7 @@ func setupUniFi(
 	unifiClient.MinAvailabilityPercent = cfg.MinAvailabilityPercent
 	unifiClient.MaxLatencyMs = cfg.MaxLatencyMs
 	unifiClient.HighTemperatureCelsius = cfg.HighTemperatureCelsius
+	unifiClient.MaxPoEUtilizationPercent = cfg.MaxPoEUtilizationPercent
 	unifiClient.PerDeviceKeys = cfg.PerDeviceKeys
 
 	// What this provider's keys can hold, so reactor_state_info can report 0 for

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -480,12 +480,21 @@ func setupUniFi(
 	unifiClient.HighLoadPercent = cfg.HighLoadPercent
 	unifiClient.MinAvailabilityPercent = cfg.MinAvailabilityPercent
 	unifiClient.MaxLatencyMs = cfg.MaxLatencyMs
+	unifiClient.PerDeviceKeys = cfg.PerDeviceKeys
 
 	// What this provider's keys can hold, so reactor_state_info can report 0 for
 	// the values a key does not currently have instead of leaving a stale series
 	// at 1. Handed over as opaque data: the metrics package never learns what any
 	// of it means, only how many series there can be.
 	metrics.SetVocabulary(unifi.ProviderName, unifi.StateVocabulary())
+
+	// The one setting that changes how much Reactor publishes rather than what
+	// it means, so it says so at startup: the key names are your device names,
+	// which means the series count is your fleet size.
+	if cfg.PerDeviceKeys {
+		setupLog.Info("Per-device state keys are on: expect one device.<name> key, and one transition " +
+			"series, per adopted device. The aggregate devices key is published either way")
+	}
 
 	// What the console is running, logged once at startup. It is added before
 	// the poller so that when a moved field makes an observation come back

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -480,6 +480,7 @@ func setupUniFi(
 	unifiClient.HighLoadPercent = cfg.HighLoadPercent
 	unifiClient.MinAvailabilityPercent = cfg.MinAvailabilityPercent
 	unifiClient.MaxLatencyMs = cfg.MaxLatencyMs
+	unifiClient.HighTemperatureCelsius = cfg.HighTemperatureCelsius
 	unifiClient.PerDeviceKeys = cfg.PerDeviceKeys
 
 	// What this provider's keys can hold, so reactor_state_info can report 0 for

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -245,6 +245,33 @@ numbers stay in a debug log line, where they are diagnostics rather than API.
 Decide the bucket boundaries with the user's automation in mind — two levels
 they can act on beats five they have to reason about.
 
+**A key whose NAME is open is opt-in.** The rule above is about values; this one
+is about the other half of the label pair, and it is the harder case. `devices`
+and `device.<name>` are the worked example: the aggregate is one key with two
+values, while the per-device form derives its *key name* from a device name, so
+the set of keys only exists at runtime and grows with someone's rack. That cannot
+be enumerated in `StateVocabulary()` — the map is returned once at startup — and
+enumerating it would be the wrong thing to want, because one series per device
+is a cost the operator has to choose rather than discover.
+
+So: publish the aggregate by default, put the per-entity keys behind a config
+flag that defaults off, leave them out of `StateVocabulary()` entirely, and log a
+line at startup when they are on. The aggregate is nearly always the key people
+should be matching on anyway — "is anything down" is the question; "which one" is
+answered by `status.observedState`, an Event, and a `V(1)` log line. Do the same
+for `client.<name>` when it lands.
+
+Two details fall out of it. Give the derived name a **slug rule** (the UniFi
+provider reuses `isp`'s) so the key is always writable in YAML, and decide what a
+**collision** does: two devices whose names slugify alike publish neither key and
+count a disagreement, because picking one is arbitrary and the arbitrary pick can
+be the one that hides the failure.
+
+The other detail is debounce, and it needs the engine rather than the provider:
+a `PerKey` entry may end in `*`, so `device.*: 2` settles a group whose members
+are not known when the chart is written. The engine still learns nothing — it
+matches a string against a pattern it was handed as data.
+
 **Key names are a compatibility promise.** They appear in user YAML. Renaming one breaks every Automation using it. Choose as if you cannot rename — because you cannot.
 
 ## Fixtures: capture, allowlist, commit
@@ -259,7 +286,7 @@ For a new provider, add a `hack/capture-<provider>.sh` in the same shape as `hac
 
 **Write a `testdata/<provider>/README.md`** recording what hardware and what software version produced the captures, which fields each file documents, and which mappings are *inferred* rather than observed. The UniFi one flags that the `wan` mapping has never seen a real failover, and that honesty is worth more than the fixture.
 
-**Consider a mock.** `hack/mock-unifi/` serves the captured payloads over HTTP and exposes endpoints to drive transitions by hand (`POST /flip`, `POST /ups?mode=battery&level=80`, `POST /internet?status=error`, `POST /quality?availability=97`). It is what makes `make dev-mock` work without hardware, and the e2e suites drive the same endpoints, so a key that cannot be rehearsed by hand also cannot be rehearsed in CI. Do it for any provider whose hardware is not on every contributor's desk.
+**Consider a mock.** `hack/mock-unifi/` serves the captured payloads over HTTP and exposes endpoints to drive transitions by hand (`POST /flip`, `POST /ups?mode=battery&level=80`, `POST /internet?status=error`, `POST /quality?availability=97`, `POST /device?name=…&state=offline`). It is what makes `make dev-mock` work without hardware, and the e2e suites drive the same endpoints, so a key that cannot be rehearsed by hand also cannot be rehearsed in CI. Do it for any provider whose hardware is not on every contributor's desk.
 
 ## Tests
 
@@ -288,7 +315,7 @@ Three layers, all runnable with `make test` and none needing hardware:
 
 Some things genuinely belong in the core, and the test is whether the engine would have to learn a provider's vocabulary:
 
-- **Debounce** — requiring N consecutive identical observations before a value is reported. This lives in `StateStore.Observe`, not in your provider, so that every Automation reads the same value. Configuration arrives from the provider as an opaque key → sample-count map; the engine never learns that `ups` should react fast. Supply yours with `engine.WithDebounce(ProviderName, ...)`, and if you also have an inbound trigger, see the `Proving` note above.
+- **Debounce** — requiring N consecutive identical observations before a value is reported. This lives in `StateStore.Observe`, not in your provider, so that every Automation reads the same value. Configuration arrives from the provider as an opaque key → sample-count map; the engine never learns that `ups` should react fast. Supply yours with `engine.WithDebounce(ProviderName, ...)`, and if you also have an inbound trigger, see the `Proving` note above. An entry may end in `*` to cover a group of keys whose names are only known at runtime (`device.*`); exact entries win over patterns, and the longest prefix wins between patterns. That was the one engine change the per-device keys needed, and it is still opaque data — a string matched against a pattern, with no idea what either means.
 - **A webhook fast path** — a receiver that triggers an immediate re-observation. It never executes actions and never bypasses the poller; it just makes the next observation happen sooner. This one turned out **not** to need the engine at all: `internal/providers/unifi/receiver.go` is an HTTP `Runnable` that authenticates a delivery, discards its body without reading it, and sends on the poller's `Nudge` channel. Because no state is derived from a payload, a dropped, duplicated, replayed or forged delivery costs at most one extra observation. If your upstream can push, copy that shape rather than parsing what it pushes.
 
 And some things are a different extension point entirely. **Action types are not providers.** A provider observes; an action acts. Adding `kubernetes.restart` or an HTTP action means extending the action side of the reconciler and the `Action` type's enum, and touches none of the above.

--- a/docs/development.md
+++ b/docs/development.md
@@ -108,7 +108,10 @@ curl -X POST 'http://localhost:9443/firmware?upgradable=true'  # an update is wa
 curl -X POST 'http://localhost:9443/temperature?celsius=82'    # a device runs hot
 curl -X POST 'http://localhost:9443/poe?watts=55&budget=60'    # the PoE budget fills up
 curl -X POST 'http://localhost:9443/poe?silent=true'           # a powered port reports no wattage
+curl -X POST 'http://localhost:9443/poe?port=7&name=re-patched' # ...and the write path's identity check
 ```
+
+`/poe` drives both halves of the PoE story, because the mock has one synthetic switch and one `port_table` and they are the same one: `watts`/`budget`/`silent` move what the `poe` **state key** measures, while `port`/`name`/`uplink`/`poe` break the identity checks the `unifi.poe.cycle` **action** makes. That switch is adopted and online, so it is part of the fleet `devices` counts and is addressable as `mock-switch` through `/device`.
 
 > **`/firmware`, `/temperature` and `/poe` serve fields no capture contains.** The committed records carry no upgrade flags, no thermals and no `port_table`, so those three endpoints render the shape UniFi's API *documents* — including `poe_power` as a string, which is the form most likely to break a parser. Driving them exercises the derivation; it does not confirm a console reports any of it. Until one does, the mock's honest default is what the captures show: those keys are simply absent, and `present=false` puts each back to that state. See [the capture notes](../testdata/unifi/README.md#what-is-not-captured-yet).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -95,7 +95,26 @@ curl -X POST 'http://localhost:9443/internet?present=false'    # the www subsyst
 curl -X POST 'http://localhost:9443/quality?availability=97'   # the live uplink gets flaky
 curl -X POST 'http://localhost:9443/quality?latency=400'       # ...or just slow
 curl -X POST 'http://localhost:9443/quality?reset=true'        # back to the capture
+
+curl http://localhost:9443/device                              # what the capture holds, and each device's key
+curl -X POST 'http://localhost:9443/device?name=ups-2u&state=offline'    # a device dies
+curl -X POST 'http://localhost:9443/device?name=ups-2u&rename=Rack+UPS'  # ...or is renamed
+curl -X POST 'http://localhost:9443/device?reset=true'         # back to the capture
+
+curl -X POST 'http://localhost:9443/wifi?disconnected=1'       # one access point drops
+curl -X POST 'http://localhost:9443/wifi?disconnected=3'       # all of them: wifi error
+
+curl -X POST 'http://localhost:9443/firmware?upgradable=true'  # an update is waiting
+curl -X POST 'http://localhost:9443/temperature?celsius=82'    # a device runs hot
+curl -X POST 'http://localhost:9443/poe?watts=55&budget=60'    # the PoE budget fills up
+curl -X POST 'http://localhost:9443/poe?silent=true'           # a powered port reports no wattage
 ```
+
+> **`/firmware`, `/temperature` and `/poe` serve fields no capture contains.** The committed records carry no upgrade flags, no thermals and no `port_table`, so those three endpoints render the shape UniFi's API *documents* — including `poe_power` as a string, which is the form most likely to break a parser. Driving them exercises the derivation; it does not confirm a console reports any of it. Until one does, the mock's honest default is what the captures show: those keys are simply absent, and `present=false` puts each back to that state. See [the capture notes](../testdata/unifi/README.md#what-is-not-captured-yet).
+
+Per-device keys are opt-in in Reactor (`unifi.devices.perDeviceKeys`), so `device.<name>` will not appear until you ask for it — `devices` is published either way. A device is addressed by the slug of the name it was *captured* under even after `rename=`, which is what makes the rename rehearsal reversible: renaming makes the old key **vanish**, and the reconciler holds the last known state rather than treating it as a recovery.
+
+`/wifi` drives the `wlan` subsystem's AP counts, because that is what `wifi` is derived from. `?status=` moves the console's own wording *without* moving the counts, which is how you rehearse the disagreement Reactor reports rather than silently resolving.
 
 `present=false` removes the UPS from the device list rather than reporting a value for it, so the `ups` keys vanish entirely. That is the case an Automation has to distinguish from "the outage ended", and the one the reconciler answers with `StateKeyUnavailable`. `/internet?present=false` does the same for the `www` health subsystem.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -618,6 +618,39 @@ kubectl -n reactor-system logs deploy/reactor | grep 'state observed'   # needs 
 
 ---
 
+## 10b. `devices` or a `device.<name>` key is missing or unexpected
+
+`device.<name>` keys are **off by default**. If none of them appear, that is the
+default doing its job — one key per adopted device is one metric series per
+adopted device, so you have to ask:
+
+```sh
+helm upgrade ... --set unifi.devices.perDeviceKeys=true
+kubectl -n reactor-system logs deploy/reactor | grep 'Per-device state keys are on'
+```
+
+The aggregate `devices` key is published either way. With `log.level=debug` one
+line per poll says what the fleet looks like and names the devices behind it:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'device fleet'
+# device fleet devices=degraded adopted=6 offline=1 offlineDevices=ap-attic=inactive perDeviceKeys=false
+```
+
+| What you see | What it means |
+| --- | --- |
+| No `devices` key at all | Nothing in the device list is adopted *and* reporting a recognisable state. `No adopted device reported a recognisable state` at debug level confirms it |
+| A device you own is not in `offlineDevices` and has no key | `Skipping a device that is not adopted`, or `An adopted device reports no state`. An absent `state` is never read as offline |
+| `A device reports a state this provider does not recognise` | Provisioning, upgrading or heartbeat-missed. It counts towards neither key on purpose — a firmware upgrade is not a fleet outage. **Please report the number**, it is what would extend the mapping |
+| `Two or more devices share one key after slugifying their names` | `AP 1` and `ap-1` both want `device.ap-1`, so neither is published. Rename one on the console. `devices` still counts both |
+| A key vanished and `Ready=False`/`StateKeyUnavailable` | The device was renamed, removed or unadopted. Reactor holds the last known state rather than firing `onExit`, which is why retitling a switch does not scale a workload back up. Update the Automation to the new slug |
+
+A `device.<name>` key has no `reactor_state_info` series and never will — its key
+name comes from your network, so it is not a metric label. Use
+`status.observedState` on the Automation, or the debug line above.
+
+---
+
 ## 11. Reactor warns about your UniFi Network version
 
 ```text

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -706,6 +706,31 @@ samples, and the 75 °C default assumes a normal operating range of 40–60 °C;
 the threshold into that range and 90 seconds of hysteresis stops meaning anything,
 because the reading crosses the line and stays there.
 
+## 10e. `poe` never appears
+
+The third parser written against fields no capture contains. Same first move:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'unifi-poe'   # needs log.level=debug
+# poe poe=ok worstUtilizationPercent=32.5 worstSwitch=switch-48 draws=switch-48=63.5/195W
+```
+
+| What you see | What it means |
+| --- | --- |
+| `No adopted switch reports a readable PoE budget` with an empty `switchesUnreadable` | Nothing reports `total_max_power` and a `port_table`. A gateway, an AP and a UniFi UPS all legitimately report neither; if a PoE switch is adopted, the field names differ on your firmware and [#14](https://github.com/robbeverhelst/unifi-reactor/issues/14) wants to know |
+| `switchesUnreadable=switch-48=port3(class Class 4) of 4 powered ports report no wattage` | A port is powering something and will not say how much, so that switch is left out entirely rather than counted as drawing nothing. Under-counting the draw would report headroom that is not there |
+| `poe: ok` on a switch you know is full | Check `draws` against what the UniFi UI shows for the same switch. If the watts are far too low, `poe_power` is arriving in a form this parser did not expect — it accepts a number and a numeric string, and treats anything else as no reading |
+
+```sh
+curl -sk -H "X-API-KEY: $UNIFI_API_KEY" \
+  "$UNIFI_URL/proxy/network/api/s/default/stat/device" \
+  | jq '[.data[] | select(.total_max_power) | {name, total_max_power,
+        ports: [.port_table[] | select(.poe_enable) | {port_idx, poe_power, poe_class}]}]'
+```
+
+That output is exactly what the parser reads. Post it on #14 — with the device
+name removed — if it does not match what Reactor logged.
+
 ---
 
 ## 11. Reactor warns about your UniFi Network version

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -649,6 +649,31 @@ A `device.<name>` key has no `reactor_state_info` series and never will — its 
 name comes from your network, so it is not a metric label. Use
 `status.observedState` on the Automation, or the debug line above.
 
+## 10c. `firmware` never appears
+
+The field it is derived from — `upgradable` — is **not in any capture this project
+has**, so the parser is written to the shape UniFi documents and is unverified. It
+is built to fail by publishing nothing rather than by publishing `current`:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'unifi-firmware'   # needs log.level=debug
+# No adopted device reports whether it is upgradable; firmware will not be published devicesSilent=udmpro,ups-2u
+```
+
+If you see that line, your console names the field something else — or does not
+report it — and [#12](https://github.com/robbeverhelst/unifi-reactor/issues/12) is
+where the finding belongs. Dump one device record and look for it:
+
+```sh
+curl -sk -H "X-API-KEY: $UNIFI_API_KEY" \
+  "$UNIFI_URL/proxy/network/api/s/default/stat/device" \
+  | jq '[.data[] | {name, version, upgradable, upgrade_to_firmware, model_in_eol}]'
+```
+
+`devicesSilent` in the healthy version of that line is not a problem: the field is
+per device type, and the devices that *do* answer are enough to publish the key.
+Nothing silent is ever assumed to be current.
+
 ---
 
 ## 11. Reactor warns about your UniFi Network version

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -674,6 +674,28 @@ curl -sk -H "X-API-KEY: $UNIFI_API_KEY" \
 per device type, and the devices that *do* answer are enough to publish the key.
 Nothing silent is ever assumed to be current.
 
+## 10d. `temperature` never appears, or reports `high` on a cool rack
+
+Like `firmware`, this key is derived from fields **no capture in this project
+contains**, so start by looking at what the parser actually saw:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'unifi-temperature'   # needs log.level=debug
+# temperature temperature=normal hottestCelsius=58.5 hottestDevice=switch-48 thresholdCelsius=75 devicesInstrumented=4
+```
+
+| What you see | What it means |
+| --- | --- |
+| `No adopted device reports its thermals` | Nothing in the fleet reports `has_temperature`, a reading, or `overheating`. A UniFi UPS genuinely has none; if a switch or an AP is adopted, the field names differ on your firmware and [#11](https://github.com/robbeverhelst/unifi-reactor/issues/11) wants to know |
+| `A device claims temperature reporting but published no reading` | Instrumented and silent. It keeps the key alive and contributes no number — it is **not** counted as 0 °C |
+| `high` at a `hottestCelsius` that looks cool | Either the console set `overheating` (check `devicesOverheating` — its verdict outranks the threshold), or **the readings are not Celsius**. That unit is unverified. Compare `hottestCelsius` against what the UniFi UI shows for the same device |
+| `normal` on a rack you know is hot | Your threshold is above what the hardware reports. Read `hottestCelsius` over a day, then set `unifi.temperature.highCelsius` a little above it |
+
+Change the threshold and the debounce together. `temperature` settles over 3
+samples, and the 75 °C default assumes a normal operating range of 40–60 °C; move
+the threshold into that range and 90 seconds of hysteresis stops meaning anything,
+because the reading crosses the line and stays there.
+
 ---
 
 ## 11. Reactor warns about your UniFi Network version

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -600,6 +600,16 @@ kubectl -n reactor-system logs deploy/reactor | grep -E 'unifi-health|unifi-obse
 | `The live uplink's health entry reports no availability` (at `log.level=debug`) | The console reported the uplink but no numbers for it, so `wan.quality` is withheld rather than guessed at zero |
 | Neither key ever appears, and no line above | `wan` itself is not derivable, which withholds `wan.quality` too — `internet` should still be there. Start at [§13](#13-reactor-is-running-but-nothing-is-reacting) |
 
+`wifi` comes from the same response and degrades the same way. It is derived from
+the `wlan` subsystem's AP counts rather than from its `status` string, so:
+
+| What you see | What it means |
+| --- | --- |
+| `The wlan subsystem reports no AP counts` (debug) | `num_adopted` or `num_disconnected` is missing. Neither is read as zero, so the key is withheld |
+| `No access point is adopted` (debug) | Zero adopted APs — there is no WiFi here to be healthy. Not the same as `ok` |
+| `wifi: warning` you cannot explain | The debug line names the numbers: `wifi wifi=warning adopted=3 disconnected=1 connected=2`. One of your APs is out of contact — `devices` and the per-device keys say which |
+| `The console's own wlan status and the value derived from its AP counts disagree` | UniFi's own wording and the counts have parted company. The counts are what `wifi` reports. If this fires steadily, UniFi's `warning` means something the counts do not — worth reporting on [#9](https://github.com/robbeverhelst/unifi-reactor/issues/9) |
+
 The same granularity applies to the UPS keys. `ups.runtime` is published only
 when the UPS reports a `timeToRemain` above zero, and `ups.load` only when it
 reports both an output and a non-zero budget — so a UPS that reports charge but

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -40,6 +40,8 @@ DEVICE='{
   disconnection_reason,
   upgradable, upgrade_to_firmware, required_version, safe_for_autoupgrade,
   model_in_eol, model_in_lts,
+  has_temperature, has_fan, overheating, general_temperature,
+  temperatures: (if .temperatures then [.temperatures[] | {name, type, value}] else null end),
   wan1: (if .wan1 then (.wan1 | '"$WAN"') else null end),
   wan2: (if .wan2 then (.wan2 | '"$WAN"') else null end),
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),
@@ -55,6 +57,36 @@ jq '{meta: {rc: "ok"}, data: [.data[] | select(.model == "UDMPRO") | '"$DEVICE"'
   /tmp/cap-device.json > "$OUT/stat-device-gateway.json"
 jq '{meta: {rc: "ok"}, data: [.data[] | select(.vbms_table != null) | '"$DEVICE"' | .mac = "'"$MAC"'"]}' \
   /tmp/cap-device.json > "$OUT/stat-device-ups.json"
+
+# A switch and an access point. Neither has ever been captured, and between them
+# they are the ground truth for temperature (#11), PoE (#14) and the firmware
+# flags (#12) — the three parsers currently written to a documented shape rather
+# than to an observation. The UPS 2U reports no thermals and no PoE, so it
+# cannot settle any of them.
+#
+# Only the first of each is kept: one record is enough to learn a field's shape,
+# and every extra one is another device name and another 8KB to sanitize.
+#
+# Their names are replaced with placeholders, unlike the gateway's and the UPS's
+# — those two kept the console's own defaults for that hardware, while a switch
+# or an AP is usually named after a room or a person. A device name is the
+# `device.<name>` state key, so it is API-shaped and belongs in a fixture; whose
+# room it is does not.
+echo "capturing stat/device -> switch + access point"
+jq '{meta: {rc: "ok"}, data: [[.data[] | select(.type == "usw" and .vbms_table == null)][0] | select(. != null) | '"$DEVICE"' | .mac = "'"$MAC"'" | .name = "Switch"]}' \
+  /tmp/cap-device.json > /tmp/cap-switch.json
+jq '{meta: {rc: "ok"}, data: [[.data[] | select(.type == "uap")][0] | select(. != null) | '"$DEVICE"' | .mac = "'"$MAC"'" | .name = "Access Point"]}' \
+  /tmp/cap-device.json > /tmp/cap-ap.json
+for pair in "switch:/tmp/cap-switch.json" "ap:/tmp/cap-ap.json"; do
+  kind="${pair%%:*}"; file="${pair#*:}"
+  if [ "$(jq '.data | length' "$file")" -eq 0 ]; then
+    echo "  no $kind adopted on this site; stat-device-$kind.json not written"
+    rm -f "$file"
+    continue
+  fi
+  mv "$file" "$OUT/stat-device-$kind.json"
+  echo "  wrote stat-device-$kind.json"
+done
 
 echo "capturing stat/health"
 api stat/health | jq '{meta: {rc: "ok"}, data: [.data[] | {

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -35,6 +35,17 @@ WAN='{is_uplink, up, ifname, name, speed, ip: (if .ip then "'"$PUB_IP"'" else nu
 
 # A device record. vbms_table is pure battery telemetry with no identifiers,
 # so it is kept whole; everything else is named explicitly.
+#
+# The port_table projection carries what BOTH port readers need: poe_enable,
+# poe_power and poe_class for the poe state key, and is_uplink, port_poe and a
+# name for the write path's guard on a power-cycle. Keeping only one set would
+# make the first switch capture useless to the other half and look like evidence
+# that its fields do not exist.
+#
+# Port names are replaced with their index, for the reason the switch's own name
+# is replaced: a port is usually named after the room or the person on the end
+# of it. The write path matches on that name, so what a fixture needs to carry
+# is the shape and the correlation with port_idx, not somebody's study.
 DEVICE='{
   model, type, name, state, adopted, version, displayable_version,
   disconnection_reason,
@@ -43,7 +54,10 @@ DEVICE='{
   has_temperature, has_fan, overheating, general_temperature,
   temperatures: (if .temperatures then [.temperatures[] | {name, type, value}] else null end),
   total_max_power,
-  port_table: (if .port_table then [.port_table[] | {port_idx, poe_enable, poe_power, poe_class}] else null end),
+  port_table: (if .port_table then [.port_table[] | {
+    port_idx, poe_enable, poe_power, poe_class, is_uplink, port_poe,
+    name: ("port-" + (.port_idx | tostring))
+  }] else null end),
   wan1: (if .wan1 then (.wan1 | '"$WAN"') else null end),
   wan2: (if .wan2 then (.wan2 | '"$WAN"') else null end),
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -42,6 +42,8 @@ DEVICE='{
   model_in_eol, model_in_lts,
   has_temperature, has_fan, overheating, general_temperature,
   temperatures: (if .temperatures then [.temperatures[] | {name, type, value}] else null end),
+  total_max_power,
+  port_table: (if .port_table then [.port_table[] | {port_idx, poe_enable, poe_power, poe_class}] else null end),
   wan1: (if .wan1 then (.wan1 | '"$WAN"') else null end),
   wan2: (if .wan2 then (.wan2 | '"$WAN"') else null end),
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -37,6 +37,7 @@ WAN='{is_uplink, up, ifname, name, speed, ip: (if .ip then "'"$PUB_IP"'" else nu
 # so it is kept whole; everything else is named explicitly.
 DEVICE='{
   model, type, name, state, adopted, version, displayable_version,
+  disconnection_reason,
   wan1: (if .wan1 then (.wan1 | '"$WAN"') else null end),
   wan2: (if .wan2 then (.wan2 | '"$WAN"') else null end),
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -38,6 +38,8 @@ WAN='{is_uplink, up, ifname, name, speed, ip: (if .ip then "'"$PUB_IP"'" else nu
 DEVICE='{
   model, type, name, state, adopted, version, displayable_version,
   disconnection_reason,
+  upgradable, upgrade_to_firmware, required_version, safe_for_autoupgrade,
+  model_in_eol, model_in_lts,
   wan1: (if .wan1 then (.wan1 | '"$WAN"') else null end),
   wan2: (if .wan2 then (.wan2 | '"$WAN"') else null end),
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -89,6 +89,17 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/firmware?present=false'   # the field is not reported at all
 //	curl -X POST 'http://localhost:9443/firmware?reset=true'
 //
+// Rehearse a device cooking. No capture carries any thermal field — the UPS 2U
+// has none and the gateway record was allowlisted before this was parsed — so
+// this serves the shape UniFi documents, in both of its forms:
+//
+//	curl -X POST 'http://localhost:9443/temperature?celsius=82'
+//	curl -X POST 'http://localhost:9443/temperature?celsius=82&name=ups-2u'  # one device
+//	curl -X POST 'http://localhost:9443/temperature?overheating=true'        # the console's own verdict
+//	curl -X POST 'http://localhost:9443/temperature?celsius=55&general=true' # the single-value form
+//	curl -X POST 'http://localhost:9443/temperature?present=false'           # no thermals reported
+//	curl -X POST 'http://localhost:9443/temperature?reset=true'
+//
 // Rehearse the UPS dropping off the console entirely — the ups keys vanish
 // from the state rather than reporting a value, which is what an Automation
 // holding its last known state has to cope with:
@@ -226,6 +237,7 @@ const (
 	valueCaptured = "captured"
 	fieldDevices  = "devices"
 	fieldPresent  = "present"
+	paramName     = "name"
 
 	// What a variant says wan1/wan2 is_uplink do when the backup takes over.
 	uplinkMoves   = "moves"
@@ -296,6 +308,12 @@ type deviceOverride struct {
 	// means the field is not served at all, which is what every capture shows.
 	upgradable *bool
 	eol        *bool
+	// celsius, overheating and general inject the thermal fields, which no
+	// capture carries either. general switches between the two documented
+	// forms: a per-sensor temperatures table, or one general_temperature.
+	celsius     *float64
+	overheating *bool
+	general     bool
 }
 
 // mockUpgradeVersion is what this mock claims a device would upgrade TO. It is
@@ -469,6 +487,7 @@ func main() {
 	mux.HandleFunc("GET /device", m.describeFleet)
 	mux.HandleFunc("POST /device", m.setDevice)
 	mux.HandleFunc("POST /firmware", m.setFirmware)
+	mux.HandleFunc("POST /temperature", m.setTemperature)
 
 	// The write path: the Network application under /proxy/network, but
 	// authenticated the UniFi OS way — a session cookie plus the csrf header.
@@ -553,7 +572,7 @@ func cloneJSON(value map[string]any) map[string]any {
 // rewriteFleet applies one device's overrides and reports whether it should
 // still appear in the list at all.
 func (m *mock) rewriteFleet(device map[string]any) bool {
-	name, _ := device["name"].(string)
+	name, _ := device[paramName].(string)
 	override := m.deviceOverrides[slugifyName(name)]
 	if override == nil {
 		return true
@@ -579,7 +598,35 @@ func (m *mock) rewriteFleet(device map[string]any) bool {
 	if override.eol != nil {
 		device["model_in_eol"] = *override.eol
 	}
+	m.rewriteThermals(device, override)
 	return true
+}
+
+// rewriteThermals injects the temperature fields. Nothing is injected until
+// /temperature is called: the honest default is a device that reports no
+// thermals, because that is what every capture shows.
+func (m *mock) rewriteThermals(device map[string]any, override *deviceOverride) {
+	if override.celsius == nil && override.overheating == nil {
+		return
+	}
+	device["has_temperature"] = true
+	device["has_fan"] = false
+	if override.overheating != nil {
+		device["overheating"] = *override.overheating
+	}
+	if override.celsius == nil {
+		return
+	}
+	if override.general {
+		device["general_temperature"] = *override.celsius
+		return
+	}
+	// The per-sensor form, with a null-valued sensor beside the real one: a
+	// sensor that reports nothing is a case the parser must not read as 0 °C.
+	device["temperatures"] = []any{
+		map[string]any{"name": "CPU", "type": "cpu", "value": *override.celsius},
+		map[string]any{"name": "System", "type": "board", "value": nil},
+	}
 }
 
 // rewriteBattPool applies the runtime and load overrides. A runtime of exactly
@@ -988,7 +1035,7 @@ func (m *mock) setFirmware(w http.ResponseWriter, r *http.Request) {
 	defer m.mu.Unlock()
 
 	targets := m.capturedSlugs()
-	if name := slugifyName(query.Get("name")); name != "" {
+	if name := slugifyName(query.Get(paramName)); name != "" {
 		if !slices.Contains(targets, name) {
 			http.Error(w, fmt.Sprintf("no captured device named %q; try one of: %s\n",
 				name, strings.Join(targets, ", ")), http.StatusBadRequest)
@@ -1057,6 +1104,82 @@ func (m *mock) describeFirmware(slugs []string) string {
 	return strings.Join(described, "; ")
 }
 
+// setTemperature drives the thermal fields, which the temperature key buckets.
+// Without a name the change applies to every captured device.
+func (m *mock) setTemperature(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	targets := m.capturedSlugs()
+	if name := slugifyName(query.Get(paramName)); name != "" {
+		if !slices.Contains(targets, name) {
+			http.Error(w, fmt.Sprintf("no captured device named %q; try one of: %s\n",
+				name, strings.Join(targets, ", ")), http.StatusBadRequest)
+			return
+		}
+		targets = []string{name}
+	}
+
+	clear := query.Get("reset") != ""
+	if raw := query.Get(fieldPresent); raw != "" {
+		present, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "present must be a boolean", http.StatusBadRequest)
+			return
+		}
+		clear = clear || !present
+	}
+	if clear {
+		for _, slug := range targets {
+			override := m.overrideFor(slug)
+			override.celsius, override.overheating, override.general = nil, nil, false
+		}
+		log.Printf("thermal overrides cleared on %s", strings.Join(targets, ","))
+		writeJSON(w, map[string]any{fieldDevices: m.describeDevices()})
+		return
+	}
+
+	var celsius *float64
+	if raw := query.Get("celsius"); raw != "" {
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			http.Error(w, "celsius must be a number", http.StatusBadRequest)
+			return
+		}
+		celsius = &value
+	}
+	var overheating *bool
+	if raw := query.Get("overheating"); raw != "" {
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "overheating must be a boolean", http.StatusBadRequest)
+			return
+		}
+		overheating = &value
+	}
+	general := query.Get("general") == "true"
+
+	for _, slug := range targets {
+		override := m.overrideFor(slug)
+		if celsius != nil {
+			override.celsius, override.general = celsius, general
+		}
+		if overheating != nil {
+			override.overheating = overheating
+		}
+	}
+
+	log.Printf("thermals on %s: celsius=%s overheating=%s form=%s", strings.Join(targets, ","),
+		describeFloat(celsius), describeBool(overheating),
+		map[bool]string{false: "temperatures[]", true: "general_temperature"}[general])
+	writeJSON(w, map[string]any{
+		fieldDevices: m.describeDevices(),
+		fieldNote: "no capture carries any thermal field; this serves the shape UniFi documents, " +
+			"which is enough to drive the parser and not evidence that a console reports it",
+	})
+}
+
 // setDevice drives one device's fleet fields, which is what the devices and
 // device.<name> keys are derived from.
 //
@@ -1075,7 +1198,7 @@ func (m *mock) setDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slug := slugifyName(query.Get("name"))
+	slug := slugifyName(query.Get(paramName))
 	if slug == "" {
 		http.Error(w, "name is required; GET /device lists what the capture holds", http.StatusBadRequest)
 		return
@@ -1140,11 +1263,11 @@ func (m *mock) describeDevices() []any {
 		if !ok {
 			continue
 		}
-		name, _ := device["name"].(string)
+		name, _ := device[paramName].(string)
 		described = append(described, map[string]any{
-			"name":  name,
-			"key":   "device." + slugifyName(name),
-			"state": device["state"],
+			paramName: name,
+			"key":     "device." + slugifyName(name),
+			"state":   device["state"],
 			// The handle to address it by, which does not move when it is
 			// renamed: every response is rebuilt from the capture.
 			"adopted": device["adopted"],
@@ -1166,7 +1289,7 @@ func (m *mock) capturedSlugs() []string {
 		if !ok {
 			continue
 		}
-		if name, ok := device["name"].(string); ok {
+		if name, ok := device[paramName].(string); ok {
 			slugs = append(slugs, slugifyName(name))
 		}
 	}

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -67,6 +67,18 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/ups?output=850'           # a heavy load on the same budget
 //	curl -X POST 'http://localhost:9443/ups?output=310&budget=1000'  # back to the capture
 //
+// Rehearse the WiFi subsystem degrading. wifi is derived from the wlan
+// subsystem's AP counts rather than from its status wording, so these drive the
+// counts — and ?status= drives the console's own wording, which Reactor
+// cross-checks against them and disagrees with out loud:
+//
+//	curl -X POST 'http://localhost:9443/wifi?disconnected=1'       # some APs gone
+//	curl -X POST 'http://localhost:9443/wifi?disconnected=3'       # all of them: error
+//	curl -X POST 'http://localhost:9443/wifi?adopted=0'            # no APs at all: no key
+//	curl -X POST 'http://localhost:9443/wifi?status=ok'            # make the two disagree
+//	curl -X POST 'http://localhost:9443/wifi?present=false'        # wlan subsystem gone
+//	curl -X POST 'http://localhost:9443/wifi?reset=true'           # back to the capture
+//
 // Rehearse a device dying, which is the case #8 exists for: an AP can sit dead
 // for days with nothing surfacing it. GET /device lists what the capture holds
 // and the key each device would publish under:
@@ -194,6 +206,7 @@ const (
 	// named exactly as the capture spells them.
 	subsystemWWW     = "www"
 	subsystemWAN     = "wan"
+	subsystemWLAN    = "wlan"
 	uptimeKeyPrimary = "WAN"
 	uptimeKeyBackup  = "WAN2"
 
@@ -238,6 +251,7 @@ const (
 	fieldDevices  = "devices"
 	fieldPresent  = "present"
 	paramName     = "name"
+	paramAdopted  = "adopted"
 
 	// What a variant says wan1/wan2 is_uplink do when the backup takes over.
 	uplinkMoves   = "moves"
@@ -378,6 +392,15 @@ type mock struct {
 	availability *float64
 	latency      *float64
 	noQuality    bool
+	// The wlan subsystem's AP counts, which the wifi key is derived from, and
+	// the console's own status wording, which Reactor cross-checks against
+	// them. Nil means "serve whatever the capture has" (3 adopted, 1
+	// disconnected, 2 connected, status warning); noWLAN drops the subsystem.
+	apAdopted      *int
+	apDisconnected *int
+	wlanStatus     string
+	noWLAN         bool
+
 	// noUPS drops the UPS from the device list, as an unadopted or powered-off
 	// one would be. The provider then publishes no ups keys at all rather than
 	// a placeholder value, which is the case that must not be read as "the
@@ -488,6 +511,7 @@ func main() {
 	mux.HandleFunc("POST /device", m.setDevice)
 	mux.HandleFunc("POST /firmware", m.setFirmware)
 	mux.HandleFunc("POST /temperature", m.setTemperature)
+	mux.HandleFunc("POST /wifi", m.setWiFi)
 
 	// The write path: the Network application under /proxy/network, but
 	// authenticated the UniFi OS way — a session cookie plus the csrf header.
@@ -584,7 +608,7 @@ func (m *mock) rewriteFleet(device map[string]any) bool {
 		device["state"] = *override.state
 	}
 	if override.adopted != nil {
-		device["adopted"] = *override.adopted
+		device[paramAdopted] = *override.adopted
 	}
 	if override.rename != "" {
 		device["name"] = override.rename
@@ -712,6 +736,11 @@ func (m *mock) health() []any {
 				continue
 			}
 			subsystem["status"] = m.wwwStatus
+		case subsystemWLAN:
+			if m.noWLAN {
+				continue
+			}
+			m.rewriteWLAN(subsystem)
 		case subsystemWAN:
 			m.rewriteUptimeStats(subsystem)
 		}
@@ -750,6 +779,97 @@ func (m *mock) rewriteUptimeStats(subsystem map[string]any) {
 	if m.latency != nil {
 		entry[fieldLatency] = *m.latency
 	}
+}
+
+// rewriteWLAN applies the AP-count overrides, keeping num_ap consistent with
+// them: the capture has 2 connected alongside 3 adopted and 1 disconnected, and
+// a mock that broke that arithmetic would be rehearsing a console nobody has.
+func (m *mock) rewriteWLAN(subsystem map[string]any) {
+	if m.apAdopted != nil {
+		subsystem["num_adopted"] = *m.apAdopted
+	}
+	if m.apDisconnected != nil {
+		subsystem["num_disconnected"] = *m.apDisconnected
+	}
+	if m.wlanStatus != "" {
+		subsystem["status"] = m.wlanStatus
+	}
+	adopted, adoptedOK := subsystem["num_adopted"].(float64)
+	disconnected, disconnectedOK := subsystem["num_disconnected"].(float64)
+	if !adoptedOK {
+		adopted, adoptedOK = toFloat(subsystem["num_adopted"])
+	}
+	if !disconnectedOK {
+		disconnected, disconnectedOK = toFloat(subsystem["num_disconnected"])
+	}
+	if adoptedOK && disconnectedOK {
+		subsystem["num_ap"] = max(0, int(adopted)-int(disconnected))
+	}
+}
+
+// toFloat reads a number that may have arrived as an int from an override
+// rather than as JSON's float64.
+func toFloat(value any) (float64, bool) {
+	switch v := value.(type) {
+	case float64:
+		return v, true
+	case int:
+		return float64(v), true
+	}
+	return 0, false
+}
+
+// setWiFi drives the wlan subsystem. present=false removes it entirely, so the
+// wifi key vanishes rather than reporting a value.
+func (m *mock) setWiFi(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if query.Get("reset") != "" {
+		m.apAdopted, m.apDisconnected, m.wlanStatus, m.noWLAN = nil, nil, "", false
+		log.Print("wlan subsystem back to the capture")
+		writeJSON(w, map[string]any{"wlan": valueCaptured})
+		return
+	}
+	for _, field := range []struct {
+		name   string
+		target **int
+	}{
+		{paramAdopted, &m.apAdopted},
+		{"disconnected", &m.apDisconnected},
+	} {
+		raw := query.Get(field.name)
+		if raw == "" {
+			continue
+		}
+		value, err := strconv.Atoi(raw)
+		if err != nil || value < 0 {
+			http.Error(w, field.name+" must be a non-negative integer", http.StatusBadRequest)
+			return
+		}
+		*field.target = &value
+	}
+	if status := query.Get("status"); status != "" {
+		m.wlanStatus = status
+	}
+	if raw := query.Get(fieldPresent); raw != "" {
+		present, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "present must be a boolean", http.StatusBadRequest)
+			return
+		}
+		m.noWLAN = !present
+	}
+
+	log.Printf("wlan subsystem: adopted=%s disconnected=%s status=%q present=%v",
+		describeInt(m.apAdopted), describeInt(m.apDisconnected), m.wlanStatus, !m.noWLAN)
+	writeJSON(w, map[string]any{
+		paramAdopted: m.apAdopted, "disconnected": m.apDisconnected,
+		"status": m.wlanStatus, fieldPresent: !m.noWLAN,
+		fieldNote: "wifi is derived from the counts, not from status; setting only status makes " +
+			"Reactor report a disagreement, which is the point of it",
+	})
 }
 
 func (m *mock) serveHealth(w http.ResponseWriter, _ *http.Request) {
@@ -1229,7 +1349,7 @@ func (m *mock) setDevice(w http.ResponseWriter, r *http.Request) {
 		}
 		override.state = &state
 	}
-	if raw := query.Get("adopted"); raw != "" {
+	if raw := query.Get(paramAdopted); raw != "" {
 		adopted, err := strconv.ParseBool(raw)
 		if err != nil {
 			http.Error(w, "adopted must be a boolean", http.StatusBadRequest)
@@ -1270,7 +1390,7 @@ func (m *mock) describeDevices() []any {
 			"state":   device["state"],
 			// The handle to address it by, which does not move when it is
 			// renamed: every response is rebuilt from the capture.
-			"adopted": device["adopted"],
+			paramAdopted: device[paramAdopted],
 		})
 	}
 	return described

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -112,6 +112,17 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/temperature?present=false'           # no thermals reported
 //	curl -X POST 'http://localhost:9443/temperature?reset=true'
 //
+// Rehearse a PoE budget running out. No capture carries a port_table or a PoE
+// budget — the UPS 2U is a switch-type device with neither — so this serves the
+// shape UniFi documents, with poe_power as the STRING that firmware is
+// documented to use:
+//
+//	curl -X POST 'http://localhost:9443/poe?watts=55&budget=60'   # almost no headroom
+//	curl -X POST 'http://localhost:9443/poe?watts=12&budget=60'   # comfortable
+//	curl -X POST 'http://localhost:9443/poe?silent=true'          # a powered port reporting no wattage
+//	curl -X POST 'http://localhost:9443/poe?present=false'        # no PoE switch at all
+//	curl -X POST 'http://localhost:9443/poe?reset=true'
+//
 // Rehearse the UPS dropping off the console entirely — the ups keys vanish
 // from the state rather than reporting a value, which is what an Automation
 // holding its last known state has to cope with:
@@ -252,6 +263,7 @@ const (
 	fieldPresent  = "present"
 	paramName     = "name"
 	paramAdopted  = "adopted"
+	paramBudget   = "budget"
 
 	// What a variant says wan1/wan2 is_uplink do when the backup takes over.
 	uplinkMoves   = "moves"
@@ -330,6 +342,11 @@ type deviceOverride struct {
 	general     bool
 }
 
+// defaultMockPoEBudget is the budget served when a draw is asked for without
+// one. It is a plausible small-switch figure and it is invented, like every
+// other PoE number this mock serves.
+const defaultMockPoEBudget = 60.0
+
 // mockUpgradeVersion is what this mock claims a device would upgrade TO. It is
 // invented — no capture has ever carried upgrade_to_firmware — and deliberately
 // implausible so it cannot be mistaken for an observation.
@@ -400,6 +417,15 @@ type mock struct {
 	apDisconnected *int
 	wlanStatus     string
 	noWLAN         bool
+
+	// poeWatts and poeBudget inject a port_table and a PoE budget onto the
+	// switch-type device in the capture. Nil means no PoE fields at all, which
+	// is what the capture actually shows. poeSilent makes a powered port report
+	// no wattage — the case that must make the switch unreadable rather than
+	// look like free headroom.
+	poeWatts  *float64
+	poeBudget *float64
+	poeSilent bool
 
 	// noUPS drops the UPS from the device list, as an unadopted or powered-off
 	// one would be. The provider then publishes no ups keys at all rather than
@@ -512,6 +538,7 @@ func main() {
 	mux.HandleFunc("POST /firmware", m.setFirmware)
 	mux.HandleFunc("POST /temperature", m.setTemperature)
 	mux.HandleFunc("POST /wifi", m.setWiFi)
+	mux.HandleFunc("POST /poe", m.setPoE)
 
 	// The write path: the Network application under /proxy/network, but
 	// authenticated the UniFi OS way — a session cookie plus the csrf header.
@@ -598,11 +625,14 @@ func cloneJSON(value map[string]any) map[string]any {
 func (m *mock) rewriteFleet(device map[string]any) bool {
 	name, _ := device[paramName].(string)
 	override := m.deviceOverrides[slugifyName(name)]
+	if override != nil && override.absent {
+		return false
+	}
+	// PoE is set for the whole mock rather than per device, so it applies
+	// whether or not this device has overrides of its own.
+	m.rewritePoE(device)
 	if override == nil {
 		return true
-	}
-	if override.absent {
-		return false
 	}
 	if override.state != nil {
 		device["state"] = *override.state
@@ -624,6 +654,96 @@ func (m *mock) rewriteFleet(device map[string]any) bool {
 	}
 	m.rewriteThermals(device, override)
 	return true
+}
+
+// rewritePoE injects a PoE budget and a two-port table onto switch-type
+// devices. poe_power is served as a string, because that is the form UniFi is
+// documented to use and the form most likely to break a parser.
+func (m *mock) rewritePoE(device map[string]any) {
+	if m.poeBudget == nil || device["type"] != "usw" {
+		return
+	}
+	device["total_max_power"] = *m.poeBudget
+	watts := 0.0
+	if m.poeWatts != nil {
+		watts = *m.poeWatts
+	}
+	powered := map[string]any{
+		"port_idx": 1, "poe_enable": true, "poe_class": "Class 4",
+		"poe_power": strconv.FormatFloat(watts, 'f', 2, 64),
+	}
+	if m.poeSilent {
+		// Powering something and refusing to say how much.
+		delete(powered, "poe_power")
+	}
+	device["port_table"] = []any{
+		powered,
+		map[string]any{"port_idx": 2, "poe_enable": false, "poe_power": "0.00", "poe_class": "Unknown"},
+	}
+}
+
+// setPoE drives the PoE budget and draw, which the poe key buckets.
+func (m *mock) setPoE(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	clear := query.Get("reset") != ""
+	if raw := query.Get(fieldPresent); raw != "" {
+		present, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "present must be a boolean", http.StatusBadRequest)
+			return
+		}
+		clear = clear || !present
+	}
+	if clear {
+		m.poeWatts, m.poeBudget, m.poeSilent = nil, nil, false
+		log.Print("PoE fields are no longer served, as in the capture")
+		writeJSON(w, map[string]any{"poe": "absent"})
+		return
+	}
+
+	for _, field := range []struct {
+		name   string
+		target **float64
+	}{
+		{"watts", &m.poeWatts},
+		{paramBudget, &m.poeBudget},
+	} {
+		raw := query.Get(field.name)
+		if raw == "" {
+			continue
+		}
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			http.Error(w, field.name+" must be a number of watts", http.StatusBadRequest)
+			return
+		}
+		*field.target = &value
+	}
+	if raw := query.Get("silent"); raw != "" {
+		silent, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "silent must be a boolean", http.StatusBadRequest)
+			return
+		}
+		m.poeSilent = silent
+	}
+	// A draw with no budget beside it is not a fraction of anything, so asking
+	// for one implies the other.
+	if m.poeBudget == nil && m.poeWatts != nil {
+		budget := defaultMockPoEBudget
+		m.poeBudget = &budget
+	}
+
+	log.Printf("PoE: watts=%s budget=%s silent=%v",
+		describeFloat(m.poeWatts), describeFloat(m.poeBudget), m.poeSilent)
+	writeJSON(w, map[string]any{
+		"watts": m.poeWatts, paramBudget: m.poeBudget, "silent": m.poeSilent,
+		fieldNote: "no capture carries a port_table or a PoE budget; this serves the shape UniFi " +
+			"documents, with poe_power as the string that firmware is documented to use",
+	})
 }
 
 // rewriteThermals injects the temperature fields. Nothing is injected until
@@ -1107,7 +1227,7 @@ func (m *mock) setUPS(w http.ResponseWriter, r *http.Request) {
 		target **float64
 	}{
 		{"output", &m.output},
-		{"budget", &m.budget},
+		{paramBudget, &m.budget},
 	} {
 		raw := r.URL.Query().Get(field.name)
 		if raw == "" {
@@ -1129,7 +1249,7 @@ func (m *mock) setUPS(w http.ResponseWriter, r *http.Request) {
 		state, m.battLvl, describeInt(m.runtime), describeFloat(m.output), describeFloat(m.budget))
 	writeJSON(w, map[string]any{
 		"ups": state, "battery": m.battLvl,
-		"runtime": m.runtime, "output": m.output, "budget": m.budget,
+		"runtime": m.runtime, "output": m.output, paramBudget: m.budget,
 	})
 }
 

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -1432,8 +1432,18 @@ func (m *mock) setDevice(w http.ResponseWriter, r *http.Request) {
 	defer m.mu.Unlock()
 
 	if raw := query.Get("reset"); raw != "" {
-		m.deviceOverrides = map[string]*deviceOverride{}
-		log.Print("device overrides cleared")
+		// Only what /device drives. One device has one override record, shared
+		// with /firmware and /temperature, and wiping the whole thing here
+		// would make two other endpoints' fields disappear behind the caller's
+		// back — which is exactly the "a key vanished" case Reactor holds its
+		// claim through, so a teardown that reset devices last would hang
+		// waiting for a workload it had just frozen. Each endpoint resets its
+		// own; that is why /firmware and /temperature have resets of their own.
+		for _, override := range m.deviceOverrides {
+			override.state, override.adopted = nil, nil
+			override.rename, override.absent = "", false
+		}
+		log.Print("device overrides cleared (firmware and thermal fields left alone)")
 		writeJSON(w, map[string]any{fieldDevices: m.describeDevices()})
 		return
 	}

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -79,6 +79,16 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/device?name=ups-2u&present=false'  # gone from the list
 //	curl -X POST 'http://localhost:9443/device?reset=true'
 //
+// Rehearse a firmware update becoming available. The captures carry no upgrade
+// fields at all, so what this serves is the shape UniFi documents — enough to
+// drive the parser, not evidence that a console reports it this way:
+//
+//	curl -X POST 'http://localhost:9443/firmware?upgradable=true'
+//	curl -X POST 'http://localhost:9443/firmware?upgradable=true&name=ups-2u'  # one device only
+//	curl -X POST 'http://localhost:9443/firmware?eol=true'
+//	curl -X POST 'http://localhost:9443/firmware?present=false'   # the field is not reported at all
+//	curl -X POST 'http://localhost:9443/firmware?reset=true'
+//
 // Rehearse the UPS dropping off the console entirely — the ups keys vanish
 // from the state rather than reporting a value, which is what an Automation
 // holding its last known state has to cope with:
@@ -215,6 +225,7 @@ const (
 	// carries is keyNote above.
 	valueCaptured = "captured"
 	fieldDevices  = "devices"
+	fieldPresent  = "present"
 
 	// What a variant says wan1/wan2 is_uplink do when the backup takes over.
 	uplinkMoves   = "moves"
@@ -281,7 +292,16 @@ type deviceOverride struct {
 	rename string
 	// absent removes the device from the list entirely.
 	absent bool
+	// upgradable and eol inject the upgrade fields the firmware key reads. Nil
+	// means the field is not served at all, which is what every capture shows.
+	upgradable *bool
+	eol        *bool
 }
+
+// mockUpgradeVersion is what this mock claims a device would upgrade TO. It is
+// invented — no capture has ever carried upgrade_to_firmware — and deliberately
+// implausible so it cannot be mistaken for an observation.
+const mockUpgradeVersion = "9.9.9.99999"
 
 // slugifyName is the mock's copy of the provider's slug rule, so /device can be
 // addressed by the same name a state key is spelled with. It is duplicated
@@ -448,6 +468,7 @@ func main() {
 	mux.HandleFunc("POST /quality", m.setQuality)
 	mux.HandleFunc("GET /device", m.describeFleet)
 	mux.HandleFunc("POST /device", m.setDevice)
+	mux.HandleFunc("POST /firmware", m.setFirmware)
 
 	// The write path: the Network application under /proxy/network, but
 	// authenticated the UniFi OS way — a session cookie plus the csrf header.
@@ -548,6 +569,15 @@ func (m *mock) rewriteFleet(device map[string]any) bool {
 	}
 	if override.rename != "" {
 		device["name"] = override.rename
+	}
+	if override.upgradable != nil {
+		device["upgradable"] = *override.upgradable
+		if *override.upgradable {
+			device["upgrade_to_firmware"] = mockUpgradeVersion
+		}
+	}
+	if override.eol != nil {
+		device["model_in_eol"] = *override.eol
 	}
 	return true
 }
@@ -712,7 +742,7 @@ func (m *mock) setInternet(w http.ResponseWriter, r *http.Request) {
 		m.noWWW = !present
 	}
 	log.Printf("www subsystem is now %s (present=%v)", m.wwwStatus, !m.noWWW)
-	writeJSON(w, map[string]any{"status": m.wwwStatus, "present": !m.noWWW})
+	writeJSON(w, map[string]any{"status": m.wwwStatus, fieldPresent: !m.noWWW})
 }
 
 // setQuality drives the live uplink's uptime_stats, which is what wan.quality
@@ -757,7 +787,7 @@ func (m *mock) setQuality(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{
 		paramAvailability: m.availability,
 		paramLatency:      m.latency,
-		"present":         !m.noQuality,
+		fieldPresent:      !m.noQuality,
 		keyNote:           "both are averages over the console's uptime window (time_period, 86400s in the capture)",
 	})
 }
@@ -936,6 +966,97 @@ func (m *mock) setUPS(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// overrideFor is the rewrite record for one captured device, created on first
+// use. Callers hold the lock.
+func (m *mock) overrideFor(slug string) *deviceOverride {
+	override := m.deviceOverrides[slug]
+	if override == nil {
+		override = &deviceOverride{}
+		m.deviceOverrides[slug] = override
+	}
+	return override
+}
+
+// setFirmware drives the upgrade fields, which the firmware key is derived from.
+//
+// Nothing is injected until this is called, because the captures carry no
+// upgrade fields at all — so the mock's default is the honest one: no firmware
+// key. Without a name the change applies to every captured device.
+func (m *mock) setFirmware(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	targets := m.capturedSlugs()
+	if name := slugifyName(query.Get("name")); name != "" {
+		if !slices.Contains(targets, name) {
+			http.Error(w, fmt.Sprintf("no captured device named %q; try one of: %s\n",
+				name, strings.Join(targets, ", ")), http.StatusBadRequest)
+			return
+		}
+		targets = []string{name}
+	}
+
+	if raw := query.Get("reset"); raw != "" {
+		for _, slug := range targets {
+			override := m.overrideFor(slug)
+			override.upgradable, override.eol = nil, nil
+		}
+		log.Print("firmware overrides cleared")
+		writeJSON(w, map[string]any{fieldDevices: m.describeDevices()})
+		return
+	}
+
+	for _, field := range []struct {
+		name   string
+		assign func(*deviceOverride, *bool)
+	}{
+		{"upgradable", func(o *deviceOverride, v *bool) { o.upgradable = v }},
+		{"eol", func(o *deviceOverride, v *bool) { o.eol = v }},
+		// present=false removes the upgrade field entirely, which is the state
+		// every committed capture is in.
+		{"present", func(o *deviceOverride, v *bool) {
+			if v != nil && !*v {
+				o.upgradable = nil
+			}
+		}},
+	} {
+		raw := query.Get(field.name)
+		if raw == "" {
+			continue
+		}
+		value, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, field.name+" must be a boolean", http.StatusBadRequest)
+			return
+		}
+		for _, slug := range targets {
+			field.assign(m.overrideFor(slug), &value)
+		}
+	}
+
+	log.Printf("firmware fields on %s: %s", strings.Join(targets, ","), m.describeFirmware(targets))
+	writeJSON(w, map[string]any{
+		fieldDevices: m.describeDevices(),
+		keyNote: "the upgrade fields are NOT in any capture; this serves the shape UniFi documents, " +
+			"which is enough to drive the parser and not evidence that a console reports it",
+	})
+}
+
+// describeFirmware summarises what is being injected, for the log line.
+func (m *mock) describeFirmware(slugs []string) string {
+	var described []string
+	for _, slug := range slugs {
+		override := m.deviceOverrides[slug]
+		if override == nil {
+			continue
+		}
+		described = append(described, slug+": upgradable="+describeBool(override.upgradable)+
+			" eol="+describeBool(override.eol))
+	}
+	return strings.Join(described, "; ")
+}
+
 // setDevice drives one device's fleet fields, which is what the devices and
 // device.<name> keys are derived from.
 //
@@ -964,11 +1085,7 @@ func (m *mock) setDevice(w http.ResponseWriter, r *http.Request) {
 			slug, strings.Join(m.capturedSlugs(), ", ")), http.StatusBadRequest)
 		return
 	}
-	override := m.deviceOverrides[slug]
-	if override == nil {
-		override = &deviceOverride{}
-		m.deviceOverrides[slug] = override
-	}
+	override := m.overrideFor(slug)
 
 	// state accepts the two values the provider recognises by name, and any
 	// integer besides, so a state nobody has captured can be rehearsed too.

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -67,6 +67,18 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/ups?output=850'           # a heavy load on the same budget
 //	curl -X POST 'http://localhost:9443/ups?output=310&budget=1000'  # back to the capture
 //
+// Rehearse a device dying, which is the case #8 exists for: an AP can sit dead
+// for days with nothing surfacing it. GET /device lists what the capture holds
+// and the key each device would publish under:
+//
+//	curl http://localhost:9443/device
+//	curl -X POST 'http://localhost:9443/device?name=ups-2u&state=offline'
+//	curl -X POST 'http://localhost:9443/device?name=ups-2u&state=5'        # an unrecognised state
+//	curl -X POST 'http://localhost:9443/device?name=ups-2u&adopted=false'  # not our fleet
+//	curl -X POST 'http://localhost:9443/device?name=ups-2u&rename=Rack+UPS'
+//	curl -X POST 'http://localhost:9443/device?name=ups-2u&present=false'  # gone from the list
+//	curl -X POST 'http://localhost:9443/device?reset=true'
+//
 // Rehearse the UPS dropping off the console entirely — the ups keys vanish
 // from the state rather than reporting a value, which is what an Automation
 // holding its last known state has to cope with:
@@ -198,6 +210,12 @@ const (
 	// Reactor does with them; it does not confirm a console ever sends them.
 	statusHealthOK = "ok"
 
+	// What a field says when nothing overrides the capture, and the key the
+	// fleet listing answers under. The caveat sentence every dev endpoint
+	// carries is keyNote above.
+	valueCaptured = "captured"
+	fieldDevices  = "devices"
+
 	// What a variant says wan1/wan2 is_uplink do when the backup takes over.
 	uplinkMoves   = "moves"
 	uplinkPinned  = "pinned"
@@ -247,6 +265,45 @@ var failoverVariants = map[string]failoverVariant{
 }
 
 func variantNames() []string { return slices.Sorted(maps.Keys(failoverVariants)) }
+
+// deviceOverride is what /device rewrites on one captured device. Every field
+// is a pointer or a zero value meaning "leave the capture alone", so a request
+// that sets one thing does not silently assert the others.
+type deviceOverride struct {
+	// state replaces the console's own state field. It is an int rather than a
+	// bool so that a state nobody has captured — provisioning, upgrading — can
+	// be served too: the provider is supposed to publish nothing for those.
+	state *int
+	// adopted turns a device into one the console sees but does not manage.
+	adopted *bool
+	// rename is the case #8 raises: the old key vanishes rather than reporting
+	// offline, and nothing may treat that as a recovery.
+	rename string
+	// absent removes the device from the list entirely.
+	absent bool
+}
+
+// slugifyName is the mock's copy of the provider's slug rule, so /device can be
+// addressed by the same name a state key is spelled with. It is duplicated
+// rather than shared because the provider's is deliberately unexported: the key
+// vocabulary lives in one file and nothing outside that package spells it.
+func slugifyName(name string) string {
+	var b strings.Builder
+	pendingHyphen := false
+	for _, r := range strings.ToLower(strings.TrimSpace(name)) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			if pendingHyphen && b.Len() > 0 {
+				b.WriteByte('-')
+			}
+			pendingHyphen = false
+			b.WriteRune(r)
+		default:
+			pendingHyphen = true
+		}
+	}
+	return b.String()
+}
 
 type mock struct {
 	mu sync.Mutex
@@ -299,6 +356,12 @@ type mock struct {
 	switchDevice map[string]any
 	cycles       []string
 
+	// deviceOverrides rewrites the fleet fields of individual captured devices,
+	// keyed by the slug of the name they were captured under — which is the
+	// same slug the device.<name> state key uses, so what is addressed here and
+	// what appears in an Automation are spelled the same way.
+	deviceOverrides map[string]*deviceOverride
+
 	// delivery is the synthetic body /alarm-fire posts. It is a stand-in, not
 	// a capture: no real Alarm Manager delivery has been recorded yet.
 	delivery []byte
@@ -317,15 +380,15 @@ func main() {
 	flag.Parse()
 
 	m := &mock{
-		battLvl:   100,
-		link:      linkPrimary,
-		variant:   defaultVariant,
-		backupISP: defaultBackupISP,
-		wwwStatus: statusHealthOK,
-		rules:     map[string]map[string]any{},
-		wlans:     mockWLANs(),
-
-		switchDevice: mockSwitch(),
+		battLvl:         100,
+		link:            linkPrimary,
+		variant:         defaultVariant,
+		backupISP:       defaultBackupISP,
+		wwwStatus:       statusHealthOK,
+		rules:           map[string]map[string]any{},
+		wlans:           mockWLANs(),
+		switchDevice:    mockSwitch(),
+		deviceOverrides: map[string]*deviceOverride{},
 	}
 	if raw, err := os.ReadFile(*deliveryFile); err == nil {
 		m.delivery = raw
@@ -383,6 +446,8 @@ func main() {
 	mux.HandleFunc("POST /ups", m.setUPS)
 	mux.HandleFunc("POST /internet", m.setInternet)
 	mux.HandleFunc("POST /quality", m.setQuality)
+	mux.HandleFunc("GET /device", m.describeFleet)
+	mux.HandleFunc("POST /device", m.setDevice)
 
 	// The write path: the Network application under /proxy/network, but
 	// authenticated the UniFi OS way — a session cookie plus the csrf header.
@@ -426,6 +491,9 @@ func (m *mock) devices() []any {
 		if _, isUPS := device["vbms_table"]; isUPS && m.noUPS {
 			continue
 		}
+		if !m.rewriteFleet(device) {
+			continue
+		}
 		visible = append(visible, d)
 		if _, isGateway := device["wan1"]; isGateway && m.link == linkBackup {
 			m.failover(device)
@@ -459,6 +527,29 @@ func cloneJSON(value map[string]any) map[string]any {
 		return nil
 	}
 	return clone
+}
+
+// rewriteFleet applies one device's overrides and reports whether it should
+// still appear in the list at all.
+func (m *mock) rewriteFleet(device map[string]any) bool {
+	name, _ := device["name"].(string)
+	override := m.deviceOverrides[slugifyName(name)]
+	if override == nil {
+		return true
+	}
+	if override.absent {
+		return false
+	}
+	if override.state != nil {
+		device["state"] = *override.state
+	}
+	if override.adopted != nil {
+		device["adopted"] = *override.adopted
+	}
+	if override.rename != "" {
+		device["name"] = override.rename
+	}
+	return true
 }
 
 // rewriteBattPool applies the runtime and load overrides. A runtime of exactly
@@ -673,7 +764,7 @@ func (m *mock) setQuality(w http.ResponseWriter, r *http.Request) {
 
 func describeFloat(value *float64) string {
 	if value == nil {
-		return "captured"
+		return valueCaptured
 	}
 	return strconv.FormatFloat(*value, 'f', -1, 64)
 }
@@ -845,9 +936,149 @@ func (m *mock) setUPS(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// setDevice drives one device's fleet fields, which is what the devices and
+// device.<name> keys are derived from.
+//
+// A device is addressed by the slug of the name it was CAPTURED under, even
+// after a rename: every response is rebuilt from the capture, so the original
+// name is the stable handle and reset=true undoes everything.
+func (m *mock) setDevice(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if raw := query.Get("reset"); raw != "" {
+		m.deviceOverrides = map[string]*deviceOverride{}
+		log.Print("device overrides cleared")
+		writeJSON(w, map[string]any{fieldDevices: m.describeDevices()})
+		return
+	}
+
+	slug := slugifyName(query.Get("name"))
+	if slug == "" {
+		http.Error(w, "name is required; GET /device lists what the capture holds", http.StatusBadRequest)
+		return
+	}
+	if !slices.Contains(m.capturedSlugs(), slug) {
+		http.Error(w, fmt.Sprintf("no captured device named %q; try one of: %s\n",
+			slug, strings.Join(m.capturedSlugs(), ", ")), http.StatusBadRequest)
+		return
+	}
+	override := m.deviceOverrides[slug]
+	if override == nil {
+		override = &deviceOverride{}
+		m.deviceOverrides[slug] = override
+	}
+
+	// state accepts the two values the provider recognises by name, and any
+	// integer besides, so a state nobody has captured can be rehearsed too.
+	if raw := query.Get("state"); raw != "" {
+		state := 0
+		switch raw {
+		case "online":
+			state = 1
+		case "offline":
+			state = 0
+		default:
+			parsed, err := strconv.Atoi(raw)
+			if err != nil {
+				http.Error(w, `state must be "online", "offline", or an integer`, http.StatusBadRequest)
+				return
+			}
+			state = parsed
+		}
+		override.state = &state
+	}
+	if raw := query.Get("adopted"); raw != "" {
+		adopted, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "adopted must be a boolean", http.StatusBadRequest)
+			return
+		}
+		override.adopted = &adopted
+	}
+	if raw := query.Get("rename"); raw != "" {
+		override.rename = raw
+	}
+	if raw := query.Get("present"); raw != "" {
+		present, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "present must be a boolean", http.StatusBadRequest)
+			return
+		}
+		override.absent = !present
+	}
+
+	log.Printf("device %s: state=%s adopted=%s rename=%q present=%v",
+		slug, describeInt(override.state), describeBool(override.adopted), override.rename, !override.absent)
+	writeJSON(w, map[string]any{fieldDevices: m.describeDevices()})
+}
+
+// describeDevices reports each captured device, the key it publishes under, and
+// what is currently being served for it.
+func (m *mock) describeDevices() []any {
+	var described []any
+	for _, d := range m.devices() {
+		device, ok := d.(map[string]any)
+		if !ok {
+			continue
+		}
+		name, _ := device["name"].(string)
+		described = append(described, map[string]any{
+			"name":  name,
+			"key":   "device." + slugifyName(name),
+			"state": device["state"],
+			// The handle to address it by, which does not move when it is
+			// renamed: every response is rebuilt from the capture.
+			"adopted": device["adopted"],
+		})
+	}
+	return described
+}
+
+// capturedSlugs are the handles /device accepts, taken from the capture rather
+// than from the current response so a renamed device is still addressable.
+func (m *mock) capturedSlugs() []string {
+	var devices []any
+	if err := json.Unmarshal(m.pristine, &devices); err != nil {
+		return nil
+	}
+	var slugs []string
+	for _, d := range devices {
+		device, ok := d.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, ok := device["name"].(string); ok {
+			slugs = append(slugs, slugifyName(name))
+		}
+	}
+	slices.Sort(slugs)
+	return slugs
+}
+
+func (m *mock) describeFleet(w http.ResponseWriter, _ *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	writeJSON(w, map[string]any{
+		fieldDevices: m.describeDevices(),
+		"handles":    m.capturedSlugs(),
+		"note":       "address a device by the slug of the name it was captured under, even after a rename",
+		"perKeys":    "device.<name> keys are opt-in in Reactor (unifi.devices.perDeviceKeys)",
+		"aggregate":  "devices is published either way",
+	})
+}
+
+func describeBool(value *bool) string {
+	if value == nil {
+		return valueCaptured
+	}
+	return strconv.FormatBool(*value)
+}
+
 func describeInt(value *int) string {
 	if value == nil {
-		return "captured"
+		return valueCaptured
 	}
 	return strconv.Itoa(*value)
 }

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -91,6 +91,10 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/device?name=ups-2u&present=false'  # gone from the list
 //	curl -X POST 'http://localhost:9443/device?reset=true'
 //
+// The synthetic PoE switch the write path cycles is part of that fleet too —
+// adopted, online, and addressable as mock-switch — because a switch Reactor
+// may cut power to is one the console manages.
+//
 // Rehearse a firmware update becoming available. The captures carry no upgrade
 // fields at all, so what this serves is the shape UniFi documents — enough to
 // drive the parser, not evidence that a console reports it this way:
@@ -112,15 +116,16 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/temperature?present=false'           # no thermals reported
 //	curl -X POST 'http://localhost:9443/temperature?reset=true'
 //
-// Rehearse a PoE budget running out. No capture carries a port_table or a PoE
-// budget — the UPS 2U is a switch-type device with neither — so this serves the
-// shape UniFi documents, with poe_power as the STRING that firmware is
-// documented to use:
+// Rehearse a PoE budget running out, on the same synthetic switch and the same
+// port table the write path guards — there is one switch here and both halves
+// read it. No capture carries a PoE budget or a port_table at all, so this
+// serves the shape UniFi documents, with poe_power as the STRING that firmware
+// is documented to use:
 //
 //	curl -X POST 'http://localhost:9443/poe?watts=55&budget=60'   # almost no headroom
 //	curl -X POST 'http://localhost:9443/poe?watts=12&budget=60'   # comfortable
 //	curl -X POST 'http://localhost:9443/poe?silent=true'          # a powered port reporting no wattage
-//	curl -X POST 'http://localhost:9443/poe?present=false'        # no PoE switch at all
+//	curl -X POST 'http://localhost:9443/poe?present=false'        # no budget served at all
 //	curl -X POST 'http://localhost:9443/poe?reset=true'
 //
 // Rehearse the UPS dropping off the console entirely — the ups keys vanish
@@ -247,6 +252,21 @@ const (
 	fieldIsUplink  = "is_uplink"
 	fieldPortPoE   = "port_poe"
 	fieldPoEEnable = "poe_enable"
+	fieldPortTable = "port_table"
+	// The two fields the poe STATE key reads on that same table: what a port is
+	// delivering, and the switch's whole budget. Named beside the others
+	// because they describe one structure — the write path guards a port and
+	// the state key measures the budget, and both read this port_table.
+	fieldPoEPower = "poe_power"
+	fieldMaxPower = "total_max_power"
+	// paramSilent is a powered port that will not say what it is delivering,
+	// and fieldType is how a device record spells what kind of thing it is.
+	paramSilent = "silent"
+	paramWatts  = "watts"
+	fieldType   = "type"
+	// zeroWatts is a port delivering nothing, which is a reading rather than a
+	// missing one. UniFi is documented to report this field as a string.
+	zeroWatts = "0.00"
 
 	// statusHealthOK is what the capture's www subsystem reports. The other
 	// values this mock will happily serve — "warning", "error" — are the ones
@@ -261,7 +281,6 @@ const (
 	valueCaptured = "captured"
 	fieldDevices  = "devices"
 	fieldPresent  = "present"
-	paramName     = "name"
 	paramAdopted  = "adopted"
 	paramBudget   = "budget"
 
@@ -538,7 +557,6 @@ func main() {
 	mux.HandleFunc("POST /firmware", m.setFirmware)
 	mux.HandleFunc("POST /temperature", m.setTemperature)
 	mux.HandleFunc("POST /wifi", m.setWiFi)
-	mux.HandleFunc("POST /poe", m.setPoE)
 
 	// The write path: the Network application under /proxy/network, but
 	// authenticated the UniFi OS way — a session cookie plus the csrf header.
@@ -600,10 +618,19 @@ func (m *mock) devices() []any {
 	}
 	// The synthetic switch is appended rather than substituted: the captured
 	// records are the ground truth and this one is not, so it never replaces
-	// anything that came off a console. The state parser ignores it — it has
-	// neither WAN ports nor a vbms_table — which is what makes it safe to serve
-	// on the same endpoint.
-	return append(visible, cloneJSON(m.switchDevice))
+	// anything that came off a console.
+	//
+	// It now goes through the same override path as the captured devices, which
+	// it did not need to before this batch: it has neither WAN ports nor a
+	// vbms_table, so the state parser had nothing to read on it. It has a port
+	// table the poe key measures and an adoption the fleet keys count, so
+	// leaving it outside would make the one switch here invisible to the one
+	// state key about switches.
+	switchDevice := cloneJSON(m.switchDevice)
+	if switchDevice != nil && m.rewriteFleet(switchDevice) {
+		visible = append(visible, switchDevice)
+	}
+	return visible
 }
 
 // cloneJSON deep-copies a decoded document, so a handler cannot hand a caller a
@@ -623,7 +650,7 @@ func cloneJSON(value map[string]any) map[string]any {
 // rewriteFleet applies one device's overrides and reports whether it should
 // still appear in the list at all.
 func (m *mock) rewriteFleet(device map[string]any) bool {
-	name, _ := device[paramName].(string)
+	name, _ := device[fieldName].(string)
 	override := m.deviceOverrides[slugifyName(name)]
 	if override != nil && override.absent {
 		return false
@@ -656,35 +683,68 @@ func (m *mock) rewriteFleet(device map[string]any) bool {
 	return true
 }
 
-// rewritePoE injects a PoE budget and a two-port table onto switch-type
-// devices. poe_power is served as a string, because that is the form UniFi is
-// documented to use and the form most likely to break a parser.
+// rewritePoE puts a budget and a per-port draw on the synthetic switch, which
+// is the only device here with a port table.
+//
+// It writes into THAT table rather than inventing one, and that is the whole
+// point of doing it here: the write path guards a port by reading the same
+// table, so a mock carrying two port tables would be rehearsing two different
+// switches and letting the two halves of the PoE story drift apart. Nothing is
+// injected until /poe names a budget, because no capture carries one.
 func (m *mock) rewritePoE(device map[string]any) {
-	if m.poeBudget == nil || device["type"] != "usw" {
+	if device["mac"] != mockSwitchMAC || m.poeBudget == nil {
 		return
 	}
-	device["total_max_power"] = *m.poeBudget
+	device[fieldMaxPower] = *m.poeBudget
 	watts := 0.0
 	if m.poeWatts != nil {
 		watts = *m.poeWatts
 	}
-	powered := map[string]any{
-		"port_idx": 1, "poe_enable": true, "poe_class": "Class 4",
-		"poe_power": strconv.FormatFloat(watts, 'f', 2, 64),
+	table, ok := device[fieldPortTable].([]any)
+	if !ok {
+		return
 	}
-	if m.poeSilent {
-		// Powering something and refusing to say how much.
-		delete(powered, "poe_power")
-	}
-	device["port_table"] = []any{
-		powered,
-		map[string]any{"port_idx": 2, "poe_enable": false, "poe_power": "0.00", "poe_class": "Unknown"},
+	// The whole draw goes on the first powered port that is not the uplink, so
+	// the arithmetic in the log is the one that was asked for rather than a
+	// figure spread across ports. An uplink port powers nothing.
+	assigned := false
+	for _, entry := range table {
+		port, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		powered, _ := port[fieldPoEEnable].(bool)
+		uplink, _ := port[fieldIsUplink].(bool)
+		switch {
+		case !powered || uplink || assigned:
+			port[fieldPoEPower] = zeroWatts
+		case m.poeSilent:
+			// Powering something and refusing to say how much, which makes the
+			// whole switch unreadable rather than looking like free headroom.
+			delete(port, fieldPoEPower)
+			assigned = true
+		default:
+			port[fieldPoEPower] = strconv.FormatFloat(watts, 'f', 2, 64)
+			assigned = true
+		}
 	}
 }
 
-// setPoE drives the PoE budget and draw, which the poe key buckets.
-func (m *mock) setPoE(w http.ResponseWriter, r *http.Request) {
+// setPoEBudget drives the budget and draw the poe STATE key buckets, and
+// reports whether the request was one of its own. It is the half of POST /poe
+// that addresses the switch rather than one of its ports.
+func (m *mock) setPoEBudget(w http.ResponseWriter, r *http.Request) bool {
 	query := r.URL.Query()
+	named := false
+	for _, param := range []string{paramWatts, paramBudget, paramSilent, fieldPresent, "reset"} {
+		if query.Get(param) != "" {
+			named = true
+		}
+	}
+	if !named {
+		return false
+	}
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
@@ -693,7 +753,7 @@ func (m *mock) setPoE(w http.ResponseWriter, r *http.Request) {
 		present, err := strconv.ParseBool(raw)
 		if err != nil {
 			http.Error(w, "present must be a boolean", http.StatusBadRequest)
-			return
+			return true
 		}
 		clear = clear || !present
 	}
@@ -701,14 +761,14 @@ func (m *mock) setPoE(w http.ResponseWriter, r *http.Request) {
 		m.poeWatts, m.poeBudget, m.poeSilent = nil, nil, false
 		log.Print("PoE fields are no longer served, as in the capture")
 		writeJSON(w, map[string]any{"poe": "absent"})
-		return
+		return true
 	}
 
 	for _, field := range []struct {
 		name   string
 		target **float64
 	}{
-		{"watts", &m.poeWatts},
+		{paramWatts, &m.poeWatts},
 		{paramBudget, &m.poeBudget},
 	} {
 		raw := query.Get(field.name)
@@ -718,15 +778,15 @@ func (m *mock) setPoE(w http.ResponseWriter, r *http.Request) {
 		value, err := strconv.ParseFloat(raw, 64)
 		if err != nil {
 			http.Error(w, field.name+" must be a number of watts", http.StatusBadRequest)
-			return
+			return true
 		}
 		*field.target = &value
 	}
-	if raw := query.Get("silent"); raw != "" {
+	if raw := query.Get(paramSilent); raw != "" {
 		silent, err := strconv.ParseBool(raw)
 		if err != nil {
-			http.Error(w, "silent must be a boolean", http.StatusBadRequest)
-			return
+			http.Error(w, paramSilent+" must be a boolean", http.StatusBadRequest)
+			return true
 		}
 		m.poeSilent = silent
 	}
@@ -740,10 +800,11 @@ func (m *mock) setPoE(w http.ResponseWriter, r *http.Request) {
 	log.Printf("PoE: watts=%s budget=%s silent=%v",
 		describeFloat(m.poeWatts), describeFloat(m.poeBudget), m.poeSilent)
 	writeJSON(w, map[string]any{
-		"watts": m.poeWatts, paramBudget: m.poeBudget, "silent": m.poeSilent,
-		fieldNote: "no capture carries a port_table or a PoE budget; this serves the shape UniFi " +
+		paramWatts: m.poeWatts, paramBudget: m.poeBudget, paramSilent: m.poeSilent,
+		keyNote: "no capture carries a port_table or a PoE budget; this serves the shape UniFi " +
 			"documents, with poe_power as the string that firmware is documented to use",
 	})
+	return true
 }
 
 // rewriteThermals injects the temperature fields. Nothing is injected until
@@ -987,7 +1048,7 @@ func (m *mock) setWiFi(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, map[string]any{
 		paramAdopted: m.apAdopted, "disconnected": m.apDisconnected,
 		"status": m.wlanStatus, fieldPresent: !m.noWLAN,
-		fieldNote: "wifi is derived from the counts, not from status; setting only status makes " +
+		keyNote: "wifi is derived from the counts, not from status; setting only status makes " +
 			"Reactor report a disagreement, which is the point of it",
 	})
 }
@@ -1275,7 +1336,7 @@ func (m *mock) setFirmware(w http.ResponseWriter, r *http.Request) {
 	defer m.mu.Unlock()
 
 	targets := m.capturedSlugs()
-	if name := slugifyName(query.Get(paramName)); name != "" {
+	if name := slugifyName(query.Get(fieldName)); name != "" {
 		if !slices.Contains(targets, name) {
 			http.Error(w, fmt.Sprintf("no captured device named %q; try one of: %s\n",
 				name, strings.Join(targets, ", ")), http.StatusBadRequest)
@@ -1352,7 +1413,7 @@ func (m *mock) setTemperature(w http.ResponseWriter, r *http.Request) {
 	defer m.mu.Unlock()
 
 	targets := m.capturedSlugs()
-	if name := slugifyName(query.Get(paramName)); name != "" {
+	if name := slugifyName(query.Get(fieldName)); name != "" {
 		if !slices.Contains(targets, name) {
 			http.Error(w, fmt.Sprintf("no captured device named %q; try one of: %s\n",
 				name, strings.Join(targets, ", ")), http.StatusBadRequest)
@@ -1415,7 +1476,7 @@ func (m *mock) setTemperature(w http.ResponseWriter, r *http.Request) {
 		map[bool]string{false: "temperatures[]", true: "general_temperature"}[general])
 	writeJSON(w, map[string]any{
 		fieldDevices: m.describeDevices(),
-		fieldNote: "no capture carries any thermal field; this serves the shape UniFi documents, " +
+		keyNote: "no capture carries any thermal field; this serves the shape UniFi documents, " +
 			"which is enough to drive the parser and not evidence that a console reports it",
 	})
 }
@@ -1448,7 +1509,7 @@ func (m *mock) setDevice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slug := slugifyName(query.Get(paramName))
+	slug := slugifyName(query.Get(fieldName))
 	if slug == "" {
 		http.Error(w, "name is required; GET /device lists what the capture holds", http.StatusBadRequest)
 		return
@@ -1513,9 +1574,9 @@ func (m *mock) describeDevices() []any {
 		if !ok {
 			continue
 		}
-		name, _ := device[paramName].(string)
+		name, _ := device[fieldName].(string)
 		described = append(described, map[string]any{
-			paramName: name,
+			fieldName: name,
 			"key":     "device." + slugifyName(name),
 			"state":   device["state"],
 			// The handle to address it by, which does not move when it is
@@ -1533,13 +1594,16 @@ func (m *mock) capturedSlugs() []string {
 	if err := json.Unmarshal(m.pristine, &devices); err != nil {
 		return nil
 	}
-	var slugs []string
+	// The synthetic switch is part of the fleet the state keys describe, so it
+	// is addressable here too — it is simply not a capture, which is what the
+	// name says.
+	slugs := []string{mockSwitchName}
 	for _, d := range devices {
 		device, ok := d.(map[string]any)
 		if !ok {
 			continue
 		}
-		if name, ok := device[paramName].(string); ok {
+		if name, ok := device[fieldName].(string); ok {
 			slugs = append(slugs, slugifyName(name))
 		}
 	}
@@ -1753,14 +1817,24 @@ func (m *mock) setWLAN(w http.ResponseWriter, r *http.Request) {
 // prefix on committed fixtures; this file is not one, and follows it anyway.
 const mockSwitchMAC = "aa:bb:cc:00:11:33"
 
+// mockSwitchName is what the switch is called, and therefore the key
+// device.<name> publishes it under and the handle /device addresses it by. It
+// slugifies to itself on purpose.
+const mockSwitchName = "mock-switch"
+
 // mockSwitch builds a PoE switch. NOT A CAPTURE: no switch record has ever been
 // recorded from a console, so this carries only the port_table fields the PoE
 // check reads. The four ports are the four cases worth rehearsing — a normal
 // PoE port, the uplink, a port with no PoE, and a port whose power is off.
 func mockSwitch() map[string]any {
 	return map[string]any{
-		"mac": mockSwitchMAC, "model": "MOCKPOE", "type": "usw", fieldName: "mock-switch",
-		"port_table": []any{
+		"mac": mockSwitchMAC, "model": "MOCKPOE", fieldType: "usw", fieldName: mockSwitchName,
+		// Adopted and online, because a switch Reactor may cut power to is a
+		// switch the console manages — and because the fleet keys (devices,
+		// device.<name>) count only devices that say so. Nothing read either
+		// field before this batch.
+		"state": 1, "adopted": true,
+		fieldPortTable: []any{
 			map[string]any{
 				fieldPortIndex: 1, fieldName: "mock-uplink",
 				fieldIsUplink: true, fieldPortPoE: true, fieldPoEEnable: true,
@@ -1853,22 +1927,46 @@ func (m *mock) portByIndex(index int) (map[string]any, bool) {
 func (m *mock) describePoE(w http.ResponseWriter, _ *http.Request) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	// The switch as stat/device would serve it, decorations included: what this
+	// endpoint reports and what Reactor reads have to be the same switch.
+	served := cloneJSON(m.switchDevice)
+	if served != nil {
+		m.rewritePoE(served)
+	}
 	writeJSON(w, map[string]any{
-		"switch": m.switchDevice,
+		"switch": served,
 		"cycles": m.cycles,
+		// The state half of the same switch: what it is delivering against what
+		// it can, which is what the poe key buckets. Nil means no budget is
+		// being served at all, which is the state every capture is in.
+		paramWatts: m.poeWatts, paramBudget: m.poeBudget, paramSilent: m.poeSilent,
 		keyNote: "synthetic, not a capture: no switch record has ever been recorded from a console, " +
-			"and no power-cycle command has ever been sent to one. See docs/unifi-write-api.md.",
+			"no power-cycle command has ever been sent to one, and no capture carries a PoE budget. " +
+			"See docs/unifi-write-api.md and testdata/unifi/README.md.",
 	})
 }
 
-// setPoEPort breaks the identity checks on purpose. Renaming a port is the
-// re-patched rack; marking one as the uplink or as non-PoE is each of the two
-// floors. All three should produce a refusal from Reactor and no cycle here.
+// setPoEPort drives both halves of the PoE story, because there is one switch
+// and one port table and they are the same one.
+//
+// Naming a port breaks the write path's identity checks on purpose — renaming a
+// port is the re-patched rack, marking one as the uplink or as non-PoE is each
+// of the two floors, and all three should produce a refusal from Reactor and no
+// cycle here. Naming watts or a budget instead drives the poe STATE key, which
+// measures the same table rather than guarding it.
 func (m *mock) setPoEPort(w http.ResponseWriter, r *http.Request) {
 	query := r.URL.Query()
+	// The budget half addresses the switch rather than a port, so it is handled
+	// before the port index is required. A request naming neither is a mistake
+	// worth reporting rather than a no-op.
+	if m.setPoEBudget(w, r) {
+		return
+	}
 	index, err := strconv.Atoi(query.Get("port"))
 	if err != nil {
-		http.Error(w, "port must be an integer index, e.g. ?port=7&name=re-patched", http.StatusBadRequest)
+		http.Error(w, "name a port to change its identity (?port=7&name=re-patched), "+
+			"or watts/budget to change what the switch is delivering (?watts=55&budget=60)",
+			http.StatusBadRequest)
 		return
 	}
 

--- a/internal/controller/arbitration.go
+++ b/internal/controller/arbitration.go
@@ -691,22 +691,9 @@ func claimTarget(
 	}
 	slices.Sort(claimants)
 
-	annotations := map[string]string{annotationClaimedBy: strings.Join(claimants, ",")}
-	if _, recorded := target.GetAnnotations()[handler.baseline]; !recorded {
-		// Recorded once, on the transition from unclaimed to claimed. Writing
-		// it again later would capture the value Reactor itself set — after a
-		// controller restart mid-outage that means recording 0 as the
-		// baseline, and the workload never comes back.
-		found, err := handler.read(ctx, c, target)
-		if err != nil {
-			return false, err
-		}
-		annotations[handler.baseline] = handler.format(found)
-		annotations[annotationClaimedAt] = metav1.Now().UTC().Format(time.RFC3339)
-	}
-	changed, err := setAnnotations(ctx, c, target, annotations)
+	changed, err := recordClaim(ctx, c, handler, target, claimants)
 	if err != nil {
-		return changed, fmt.Errorf("recording the claim on %s: %w", describeObject(target), err)
+		return changed, err
 	}
 
 	written, err := handler.apply(ctx, c, target, resolution.Level)
@@ -760,11 +747,74 @@ func releaseTarget(
 // anything that treated "not in this map" as "remove it" would erase the
 // baseline fifteen seconds after recording it, and the release would then find
 // nothing to restore.
+// recordClaim writes the claim annotations, and records the baseline if this is
+// the first claim on this target.
+//
+// The baseline is the only thing that knows what a workload was before Reactor
+// touched it, so recording it wrong is not cosmetic: the outage ends and the
+// workload comes back at the level Reactor itself set. Two things make that
+// easy to get wrong, and both are handled here.
+//
+// The test for "already recorded" reads the caller's SNAPSHOT of the target,
+// while the level being recorded comes from a live read of the scale. Two
+// Automations sharing a target reconcile concurrently — maxConcurrentReconciles
+// is 4 — so the second one can still see no baseline in its snapshot while the
+// live level is already the one the first one applied, and record that.
+//
+// So the write that records a baseline carries an optimistic lock: if the
+// target moved between the snapshot and the write, the patch is refused rather
+// than believed. On that conflict the target is re-read once and the claim is
+// written again — by then the baseline the other reconcile recorded is visible,
+// and this one leaves it alone. A second conflict is returned, because at that
+// point something other than this race is happening and a reconcile that says
+// so is better than one that keeps trying.
+func recordClaim(
+	ctx context.Context,
+	c client.Client,
+	handler targetHandler,
+	target *unstructured.Unstructured,
+	claimants []string,
+) (bool, error) {
+	for attempt := range 2 {
+		annotations := map[string]string{annotationClaimedBy: strings.Join(claimants, ",")}
+		_, recorded := target.GetAnnotations()[handler.baseline]
+		if !recorded {
+			// Recorded once, on the transition from unclaimed to claimed.
+			// Writing it again later would capture the value Reactor itself
+			// set — after a controller restart mid-outage that means recording
+			// 0 as the baseline, and the workload never comes back.
+			found, err := handler.read(ctx, c, target)
+			if err != nil {
+				return false, err
+			}
+			annotations[handler.baseline] = handler.format(found)
+			annotations[annotationClaimedAt] = metav1.Now().UTC().Format(time.RFC3339)
+		}
+
+		changed, err := setAnnotations(ctx, c, target, annotations, !recorded)
+		switch {
+		case err == nil:
+			return changed, nil
+		case recorded || !errors.IsConflict(err) || attempt > 0:
+			return changed, fmt.Errorf("recording the claim on %s: %w", describeObject(target), err)
+		}
+
+		// Someone else claimed this target first. Re-read so the baseline they
+		// recorded — from a level nobody had changed yet — is the one that
+		// stands.
+		if err := c.Get(ctx, client.ObjectKeyFromObject(target), target); err != nil {
+			return false, fmt.Errorf("re-reading %s after a claim conflict: %w", describeObject(target), err)
+		}
+	}
+	return false, fmt.Errorf("recording the claim on %s: too many conflicts", describeObject(target))
+}
+
 func setAnnotations(
 	ctx context.Context,
 	c client.Client,
 	target *unstructured.Unstructured,
 	want map[string]string,
+	guard bool,
 ) (bool, error) {
 	current := target.GetAnnotations()
 	next := maps.Clone(current)
@@ -778,7 +828,7 @@ func setAnnotations(
 			dirty = true
 		}
 	}
-	return patchAnnotations(ctx, c, target, next, dirty)
+	return patchAnnotations(ctx, c, target, next, dirty, guard)
 }
 
 // clearAnnotations removes every annotation a claim writes, which is what stops
@@ -793,20 +843,31 @@ func clearAnnotations(ctx context.Context, c client.Client, target *unstructured
 			dirty = true
 		}
 	}
-	return patchAnnotations(ctx, c, target, next, dirty)
+	// No lock: removing a claim is idempotent, and a release built from a
+	// slightly stale snapshot still removes exactly the annotations a claim
+	// writes. It is recording a value that must not be got wrong, not clearing
+	// one.
+	return patchAnnotations(ctx, c, target, next, dirty, false)
 }
 
+// guard adds an optimistic lock, so a patch built from a stale snapshot is
+// refused rather than applied. It is used where writing the wrong thing is
+// worse than failing: recording a target's baseline.
 func patchAnnotations(
 	ctx context.Context,
 	c client.Client,
 	target *unstructured.Unstructured,
 	next map[string]string,
 	dirty bool,
+	guard bool,
 ) (bool, error) {
 	if !dirty {
 		return false, nil
 	}
 	patch := client.MergeFrom(target.DeepCopy())
+	if guard {
+		patch = client.MergeFromWithOptions(target.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	}
 	target.SetAnnotations(next)
 	if err := c.Patch(ctx, target, patch); err != nil {
 		return false, err

--- a/internal/controller/baseline_race_test.go
+++ b/internal/controller/baseline_race_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/engine"
+)
+
+// The baseline records what a workload was before Reactor first touched it, and
+// it is the only thing that knows how to put it back. Recording it wrong is
+// therefore not a cosmetic bug: the outage ends and the workload comes back at
+// the level Reactor itself set.
+//
+// Two Automations sharing one target reconcile concurrently — maxConcurrentReconciles
+// is 4 — and each takes its own snapshot of the target before deciding anything.
+// The one that gets there second still sees "no baseline recorded" in ITS
+// snapshot, while the level it reads to record comes from a live read of the
+// scale subresource that the first one has already changed. So the second write
+// records the level the first one just applied.
+//
+// This is what CI caught on the arbitration spec: an Automation that had stopped
+// matching wanted its target back at 1 — the value the other claim had set —
+// rather than at the 3 it started from.
+var _ = Describe("Recording a target's baseline", func() {
+	const target = "baseline-race"
+	ctx := context.Background()
+
+	deploymentAt := func(replicas int32) *unstructured.Unstructured {
+		deployment := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{Name: target, Namespace: testNamespace},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: &replicas,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{labelApp: target}},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{labelApp: target}},
+					Spec: corev1.PodSpec{Containers: []corev1.Container{
+						{Name: target, Image: "example/" + target},
+					}},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, deployment)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, deployment) })
+
+		fetched := &unstructured.Unstructured{}
+		fetched.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: target}, fetched)).To(Succeed())
+		return fetched
+	}
+
+	// snapshot is what a second, concurrent reconcile is holding: the target as
+	// it was before the first claim wrote anything to it.
+	It("does not re-record it from a level Reactor itself has already applied", func() {
+		handler, err := handlerFor(kindDeployment)
+		Expect(err).NotTo(HaveOccurred())
+
+		stale := deploymentAt(3)
+
+		// The first claim, exactly as a reconcile would make it: baseline 3,
+		// then the level it asked for.
+		fresh := stale.DeepCopy()
+		_, err = claimTarget(ctx, k8sClient, handler, fresh,
+			engine.Resolution{Level: 1}, []engine.Intent{{Claimant: "apps/first", Level: 1}})
+		Expect(err).NotTo(HaveOccurred())
+
+		var claimed appsv1.Deployment
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: target}, &claimed)).To(Succeed())
+		Expect(claimed.Annotations).To(HaveKeyWithValue(annotationBaselineReplicas, "3"))
+		Expect(claimed.Spec.Replicas).To(HaveValue(BeEquivalentTo(1)))
+
+		// The second reconcile, still holding the snapshot it took before any
+		// of that happened. It must not conclude that the baseline is unrecorded
+		// and write the 1 it can now read off the live scale.
+		_, err = claimTarget(ctx, k8sClient, handler, stale,
+			engine.Resolution{Level: 1}, []engine.Intent{
+				{Claimant: "apps/first", Level: 1},
+				{Claimant: "apps/second", Level: 1},
+			})
+		if err != nil {
+			// A conflict is a correct outcome: the write is refused, the
+			// reconcile retries, and the retry sees the recorded baseline.
+			Expect(err.Error()).To(ContainSubstring("conflict"),
+				"the only acceptable failure here is the optimistic-lock conflict that prevents the clobber")
+		}
+
+		var after appsv1.Deployment
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: target}, &after)).To(Succeed())
+		Expect(after.Annotations).To(HaveKeyWithValue(annotationBaselineReplicas, "3"),
+			"the baseline was overwritten with the level Reactor itself applied; "+
+				"the workload would be restored to that instead of to what it was")
+	})
+})

--- a/internal/engine/state.go
+++ b/internal/engine/state.go
@@ -21,6 +21,7 @@ package engine
 
 import (
 	"maps"
+	"strings"
 	"sync"
 	"time"
 
@@ -51,7 +52,29 @@ type DebounceConfig struct {
 	// PerKey overrides Default for individual keys. The engine never authors
 	// these — providers supply them as data, so the core stays free of any
 	// knowledge of what the keys mean.
+	//
+	// An entry may end in "*", which matches every key with that prefix:
+	// "device.*" covers a fleet whose key names are only known at runtime,
+	// which is otherwise impossible to configure. Exact entries win over
+	// patterns, and the longest matching prefix wins between patterns, so a
+	// specific key can always be pulled out of the group it belongs to. This
+	// is still opaque data — the engine matches strings and learns nothing
+	// about what a prefix means.
 	PerKey map[string]int
+}
+
+// patternSamples is the sample count of the longest "prefix*" entry matching
+// key, and whether any did.
+func (d DebounceConfig) patternSamples(key string) (int, bool) {
+	best, samples := -1, 0
+	for pattern, configured := range d.PerKey {
+		prefix, wildcard := strings.CutSuffix(pattern, "*")
+		if !wildcard || !strings.HasPrefix(key, prefix) || len(prefix) <= best {
+			continue
+		}
+		best, samples = len(prefix), configured
+	}
+	return samples, best >= 0
 }
 
 // StoreOption configures a StateStore at construction.
@@ -107,6 +130,9 @@ func (s *StateStore) samplesFor(provider, key string) int {
 		return 1
 	}
 	if samples, overridden := config.PerKey[key]; overridden {
+		return samples
+	}
+	if samples, matched := config.patternSamples(key); matched {
 		return samples
 	}
 	if config.Default < 1 {

--- a/internal/engine/state_test.go
+++ b/internal/engine/state_test.go
@@ -29,6 +29,9 @@ const (
 	deviceOnline = "online"
 	keyWAN       = "wan"
 	keyBattery   = "ups.battery"
+	// keyDevice is a key whose name is only known at runtime, which is what the
+	// pattern entries below exist for.
+	keyDevice = "device.ap-1"
 )
 
 func observe(s *StateStore, state map[string]string) []Transition {
@@ -132,6 +135,47 @@ func TestStateStoreDebounceIsPerKey(t *testing.T) {
 	}
 	if got := observe(s, map[string]string{keyWAN: wanBackup, keyBattery: "low"}); len(got) != 1 {
 		t.Fatalf("second sample reported %+v, want the debounced key now", got)
+	}
+}
+
+// Some keys' names are only known at runtime — one per device in a fleet — so
+// there is no exact entry a chart could hold for them. A trailing "*" is how a
+// provider settles a group it cannot enumerate, and the engine still learns
+// nothing: it matches a string against a pattern it was handed.
+func TestStateStoreDebounceMatchesAKeyPattern(t *testing.T) {
+	s := debounced(1, map[string]int{"device.*": 2})
+	observe(s, map[string]string{keyWAN: wanPrimary, keyDevice: deviceOnline})
+
+	got := observe(s, map[string]string{keyWAN: wanBackup, keyDevice: "offline"})
+	if len(got) != 1 || got[0].Key != keyWAN {
+		t.Fatalf("transitions = %+v, want only the key the pattern does not cover", got)
+	}
+	if got := observe(s, map[string]string{keyWAN: wanBackup, keyDevice: "offline"}); len(got) != 1 {
+		t.Fatalf("second sample reported %+v, want the patterned key now", got)
+	}
+}
+
+// An exact entry wins over a pattern, and the longest prefix wins between
+// patterns, so one key can always be pulled out of the group it belongs to.
+func TestStateStoreDebouncePrefersTheMostSpecificEntry(t *testing.T) {
+	config := DebounceConfig{Default: 1, PerKey: map[string]int{
+		"device.*":        2,
+		"device.ap-*":     3,
+		"device.ap-attic": 4,
+		"devices":         5,
+	}}
+	s := NewStateStore(WithDebounce(testProvider, config))
+
+	for key, want := range map[string]int{
+		"device.switch-48": 2,
+		keyDevice:          3,
+		"device.ap-attic":  4,
+		"devices":          5,
+		keyWAN:             1,
+	} {
+		if got := s.samplesFor(testProvider, key); got != want {
+			t.Errorf("samplesFor(%q) = %d, want %d", key, got, want)
+		}
 	}
 }
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -29,21 +29,35 @@ limitations under the License.
 // value set is open turns one metric into an unbounded number of time series
 // that a Prometheus instance keeps for its whole retention period.
 //
-//   - provider, key: bounded by what is compiled in. A handful of each. Note
-//     that key stops being bounded if per-device or per-client keys ever land
-//     (device.<name>, client.<name>); that is the point at which those keys
-//     have to become opt-in rather than the point at which this is revisited.
+//   - provider, key: bounded by what is compiled in, plus whatever an operator
+//     has explicitly opted into. A handful of each.
+//
+//     This is where per-entity keys landed. device.<name> is the first key
+//     whose NAME comes from the outside world rather than from this repository,
+//     and the rule this comment set before it existed was that such keys have
+//     to become opt-in rather than that this paragraph gets revisited — so they
+//     did: the UniFi provider publishes the aggregate devices key always and
+//     the per-device keys only when asked, which is what keeps a forty-device
+//     fleet from silently becoming forty series. client.<name> takes the same
+//     shape when it lands. What is bounded here is therefore still bounded at
+//     compile time by default, and bounded by a deliberate choice otherwise.
+//
 //   - value: bounded ONLY for keys whose provider declares a closed value set,
 //     via SetVocabulary. A key with an open value set — isp, whose values are
 //     carrier names derived from whatever public address the gateway holds —
 //     is never labelled by value, because one such key is enough to blow up an
 //     instance. Its transitions are still counted, and its current value is
-//     still in the Automation's status and in a Kubernetes Event.
+//     still in the Automation's status and in a Kubernetes Event. A key with an
+//     open NAME is left out of SetVocabulary for the same reason from the other
+//     direction: device.<name>'s two values are closed, and the set of keys
+//     holding them is not, so it gets no reactor_state_info series at all.
+//
 //   - namespace, name of an Automation: unbounded in principle, self-limiting
 //     in practice — a new series appears only when a human writes another
 //     policy object, never on its own. What makes that safe is ForgetAutomation:
 //     a deleted Automation's series are dropped rather than left reporting
 //     matching forever.
+//
 //   - A target reference, a claimant, a state VALUE for an open key, and any
 //     error string are NOT labels. "How often" is this package's question;
 //     "which one" is answered by status and by Events, which cost nothing to

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -118,6 +118,10 @@ type Client struct {
 	// adopted device at or above this reports high.
 	HighTemperatureCelsius float64
 
+	// MaxPoEUtilizationPercent bounds the poe state key: a switch delivering at
+	// or above this share of its PoE budget reports insufficient.
+	MaxPoEUtilizationPercent float64
+
 	// PerDeviceKeys publishes a device.<name> key per adopted device alongside
 	// the aggregate devices key. It defaults off because it is the one setting
 	// here that changes how many things Reactor publishes rather than what they
@@ -146,17 +150,18 @@ func NewClient(baseURL string, apiKey APIKey, site string, insecureSkipVerify bo
 		apiKey = StaticAPIKey("")
 	}
 	return &Client{
-		baseURL:                baseURL,
-		apiKey:                 apiKey,
-		site:                   site,
-		LowBatteryPercent:      DefaultLowBatteryPercent,
-		CriticalBatteryPercent: DefaultCriticalBatteryPercent,
-		ShortRuntimeSeconds:    DefaultShortRuntimeSeconds,
-		CriticalRuntimeSeconds: DefaultCriticalRuntimeSeconds,
-		HighLoadPercent:        DefaultHighLoadPercent,
-		MinAvailabilityPercent: DefaultMinAvailabilityPercent,
-		MaxLatencyMs:           DefaultMaxLatencyMs,
-		HighTemperatureCelsius: DefaultHighTemperatureCelsius,
+		baseURL:                  baseURL,
+		apiKey:                   apiKey,
+		site:                     site,
+		LowBatteryPercent:        DefaultLowBatteryPercent,
+		CriticalBatteryPercent:   DefaultCriticalBatteryPercent,
+		ShortRuntimeSeconds:      DefaultShortRuntimeSeconds,
+		CriticalRuntimeSeconds:   DefaultCriticalRuntimeSeconds,
+		HighLoadPercent:          DefaultHighLoadPercent,
+		MinAvailabilityPercent:   DefaultMinAvailabilityPercent,
+		MaxLatencyMs:             DefaultMaxLatencyMs,
+		HighTemperatureCelsius:   DefaultHighTemperatureCelsius,
+		MaxPoEUtilizationPercent: DefaultMaxPoEUtilizationPercent,
 		http: &http.Client{
 			Timeout: 10 * time.Second,
 			Transport: &http.Transport{
@@ -197,6 +202,7 @@ type deviceRecord struct {
 	deviceHealthFields
 	firmwareFields
 	temperatureFields
+	poeFields
 }
 
 type wanPort struct {
@@ -265,6 +271,7 @@ type vbmsTable struct {
 //	firmware     current | updates-available
 //	temperature  normal  | high              (the hottest adopted device)
 //	wifi         ok | warning | error        (the WLAN subsystem as a whole)
+//	poe          ok | insufficient           (headroom on the worst switch)
 //
 // ups and ups.battery are deliberately independent: a `when: {ups: on-battery}`
 // automation must stay matched for the whole outage, including as the battery
@@ -353,6 +360,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	fleet := newDeviceTally()
 	var firmware firmwareTally
 	var heat temperatureTally
+	var poe poeTally
 
 	for _, d := range parsed.Data {
 		// The fleet keys are about devices the console manages, so an unadopted
@@ -363,6 +371,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 			fleet.observe(ctx, d)
 			firmware.observe(d)
 			heat.observe(ctx, d)
+			poe.observe(d)
 		} else {
 			logf.FromContext(ctx).WithName("unifi-devices").V(1).Info(
 				"Skipping a device that is not adopted", "model", d.Model, "type", d.Type)
@@ -396,6 +405,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	fleet.publish(ctx, state, c.PerDeviceKeys)
 	firmware.publish(ctx, state)
 	c.publishTemperature(ctx, state, heat)
+	c.publishPoE(ctx, state, poe)
 
 	if len(state) == 0 {
 		return nil, fmt.Errorf(

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -114,6 +114,14 @@ type Client struct {
 	MinAvailabilityPercent float64
 	MaxLatencyMs           float64
 
+	// PerDeviceKeys publishes a device.<name> key per adopted device alongside
+	// the aggregate devices key. It defaults off because it is the one setting
+	// here that changes how many things Reactor publishes rather than what they
+	// mean: a fleet of forty devices is forty more state keys, forty more
+	// transition series, and forty more keys an Automation could hold state for.
+	// The aggregate answers "is anything down" on one series.
+	PerDeviceKeys bool
+
 	// mu guards previous only.
 	mu sync.Mutex
 	// previous remembers the last WAN signals so that a change in one can be
@@ -177,6 +185,11 @@ type deviceRecord struct {
 	// including the UPS keys — down with it.
 	LastWANStatus map[string]any `json:"last_wan_status"`
 	VBMS          *vbmsTable     `json:"vbms_table"`
+
+	// The fleet-wide fields, embedded so each group lives in the file holding
+	// the parser that reads it. Embedded struct fields decode from the same
+	// flat object, so this is a grouping for readers and nothing more.
+	deviceHealthFields
 }
 
 type wanPort struct {
@@ -240,6 +253,8 @@ type vbmsTable struct {
 //	ups.battery  normal  | low | critical
 //	ups.runtime  ample   | short | critical
 //	ups.load     normal  | high
+//	devices      all-online | degraded   (the adopted fleet in one value)
+//	device.<name>  online | offline      (opt-in; see Client.PerDeviceKeys)
 //
 // ups and ups.battery are deliberately independent: a `when: {ups: on-battery}`
 // automation must stay matched for the whole outage, including as the battery
@@ -325,8 +340,19 @@ func (c *Client) get(ctx context.Context, endpoint string, out any) error {
 func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse) (map[string]string, error) {
 	state := map[string]string{}
 	gatewaySeen := false
+	fleet := newDeviceTally()
 
 	for _, d := range parsed.Data {
+		// The fleet keys are about devices the console manages, so an unadopted
+		// or pending one is skipped here while the gateway and UPS halves below
+		// are unchanged: they are about specific hardware being present, which
+		// is a different question from whether it has been adopted.
+		if d.adopted() {
+			fleet.observe(ctx, d)
+		} else {
+			logf.FromContext(ctx).WithName("unifi-devices").V(1).Info(
+				"Skipping a device that is not adopted", "model", d.Model, "type", d.Type)
+		}
 		if !gatewaySeen && (d.WAN1 != nil || d.WAN2 != nil) {
 			gatewaySeen = true
 			if wan := c.wanFrom(ctx, d); wan != "" {
@@ -353,10 +379,12 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 			}
 		}
 	}
+	fleet.publish(ctx, state, c.PerDeviceKeys)
 
 	if len(state) == 0 {
 		return nil, fmt.Errorf(
-			"no gateway reporting WAN ports and no UPS found in the device list; "+
+			"no gateway reporting WAN ports, no UPS, and no adopted device reporting a state "+
+				"were found in the device list; "+
 				"the fields this provider reads were verified on UniFi Network %s (%s), "+
 				"and another version or console model may report them differently "+
 				"— see the compatibility matrix in the README",

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -264,6 +264,7 @@ type vbmsTable struct {
 //	device.<name>  online | offline      (opt-in; see Client.PerDeviceKeys)
 //	firmware     current | updates-available
 //	temperature  normal  | high              (the hottest adopted device)
+//	wifi         ok | warning | error        (the WLAN subsystem as a whole)
 //
 // ups and ups.battery are deliberately independent: a `when: {ups: on-battery}`
 // automation must stay matched for the whole outage, including as the battery
@@ -288,7 +289,7 @@ func (c *Client) Observe(ctx context.Context) (map[string]string, error) {
 	}
 
 	// The health endpoint is a second call rather than a second parse of the
-	// first, so it fails separately. Losing it costs internet and wan.quality,
+	// first, so it fails separately. Losing it costs internet, wifi and wan.quality,
 	// which then vanish from the observation and are held as last known state
 	// by anything matching them — the same degradation a UPS dropping off the
 	// console produces, and the same reason it must not be an error here.
@@ -305,7 +306,7 @@ func (c *Client) Observe(ctx context.Context) (map[string]string, error) {
 		log.Error(deviceErr, "The device endpoint failed; the keys derived from it are unavailable this poll")
 	}
 	if healthErr != nil {
-		log.Error(healthErr, "The health endpoint failed; internet and wan.quality are unavailable this poll")
+		log.Error(healthErr, "The health endpoint failed; internet, wifi and wan.quality are unavailable this poll")
 	}
 	return state, nil
 }

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -114,6 +114,10 @@ type Client struct {
 	MinAvailabilityPercent float64
 	MaxLatencyMs           float64
 
+	// HighTemperatureCelsius bounds the temperature state key: the hottest
+	// adopted device at or above this reports high.
+	HighTemperatureCelsius float64
+
 	// PerDeviceKeys publishes a device.<name> key per adopted device alongside
 	// the aggregate devices key. It defaults off because it is the one setting
 	// here that changes how many things Reactor publishes rather than what they
@@ -152,6 +156,7 @@ func NewClient(baseURL string, apiKey APIKey, site string, insecureSkipVerify bo
 		HighLoadPercent:        DefaultHighLoadPercent,
 		MinAvailabilityPercent: DefaultMinAvailabilityPercent,
 		MaxLatencyMs:           DefaultMaxLatencyMs,
+		HighTemperatureCelsius: DefaultHighTemperatureCelsius,
 		http: &http.Client{
 			Timeout: 10 * time.Second,
 			Transport: &http.Transport{
@@ -191,6 +196,7 @@ type deviceRecord struct {
 	// flat object, so this is a grouping for readers and nothing more.
 	deviceHealthFields
 	firmwareFields
+	temperatureFields
 }
 
 type wanPort struct {
@@ -257,6 +263,7 @@ type vbmsTable struct {
 //	devices      all-online | degraded   (the adopted fleet in one value)
 //	device.<name>  online | offline      (opt-in; see Client.PerDeviceKeys)
 //	firmware     current | updates-available
+//	temperature  normal  | high              (the hottest adopted device)
 //
 // ups and ups.battery are deliberately independent: a `when: {ups: on-battery}`
 // automation must stay matched for the whole outage, including as the battery
@@ -344,6 +351,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	gatewaySeen := false
 	fleet := newDeviceTally()
 	var firmware firmwareTally
+	var heat temperatureTally
 
 	for _, d := range parsed.Data {
 		// The fleet keys are about devices the console manages, so an unadopted
@@ -353,6 +361,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 		if d.adopted() {
 			fleet.observe(ctx, d)
 			firmware.observe(d)
+			heat.observe(ctx, d)
 		} else {
 			logf.FromContext(ctx).WithName("unifi-devices").V(1).Info(
 				"Skipping a device that is not adopted", "model", d.Model, "type", d.Type)
@@ -385,6 +394,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	}
 	fleet.publish(ctx, state, c.PerDeviceKeys)
 	firmware.publish(ctx, state)
+	c.publishTemperature(ctx, state, heat)
 
 	if len(state) == 0 {
 		return nil, fmt.Errorf(

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -190,6 +190,7 @@ type deviceRecord struct {
 	// the parser that reads it. Embedded struct fields decode from the same
 	// flat object, so this is a grouping for readers and nothing more.
 	deviceHealthFields
+	firmwareFields
 }
 
 type wanPort struct {
@@ -255,6 +256,7 @@ type vbmsTable struct {
 //	ups.load     normal  | high
 //	devices      all-online | degraded   (the adopted fleet in one value)
 //	device.<name>  online | offline      (opt-in; see Client.PerDeviceKeys)
+//	firmware     current | updates-available
 //
 // ups and ups.battery are deliberately independent: a `when: {ups: on-battery}`
 // automation must stay matched for the whole outage, including as the battery
@@ -341,6 +343,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	state := map[string]string{}
 	gatewaySeen := false
 	fleet := newDeviceTally()
+	var firmware firmwareTally
 
 	for _, d := range parsed.Data {
 		// The fleet keys are about devices the console manages, so an unadopted
@@ -349,6 +352,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 		// is a different question from whether it has been adopted.
 		if d.adopted() {
 			fleet.observe(ctx, d)
+			firmware.observe(d)
 		} else {
 			logf.FromContext(ctx).WithName("unifi-devices").V(1).Info(
 				"Skipping a device that is not adopted", "model", d.Model, "type", d.Type)
@@ -380,6 +384,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 		}
 	}
 	fleet.publish(ctx, state, c.PerDeviceKeys)
+	firmware.publish(ctx, state)
 
 	if len(state) == 0 {
 		return nil, fmt.Errorf(

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -357,10 +357,12 @@ func (c *Client) get(ctx context.Context, endpoint string, out any) error {
 func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse) (map[string]string, error) {
 	state := map[string]string{}
 	gatewaySeen := false
-	fleet := newDeviceTally()
+	// One tally per fleet-wide key, each holding whatever operator configuration
+	// it needs, so that publishing takes nothing but the state map.
+	fleet := newDeviceTally(c.PerDeviceKeys)
 	var firmware firmwareTally
-	var heat temperatureTally
-	var poe poeTally
+	heat := newTemperatureTally(c.HighTemperatureCelsius)
+	poe := newPoETally(c.MaxPoEUtilizationPercent)
 
 	for _, d := range parsed.Data {
 		// The fleet keys are about devices the console manages, so an unadopted
@@ -402,10 +404,10 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 			}
 		}
 	}
-	fleet.publish(ctx, state, c.PerDeviceKeys)
+	fleet.publish(ctx, state)
 	firmware.publish(ctx, state)
-	c.publishTemperature(ctx, state, heat)
-	c.publishPoE(ctx, state, poe)
+	heat.publish(ctx, state)
+	poe.publish(ctx, state)
 
 	if len(state) == 0 {
 		return nil, fmt.Errorf(

--- a/internal/providers/unifi/config.go
+++ b/internal/providers/unifi/config.go
@@ -50,6 +50,7 @@ const (
 	envHighLoad           = "UNIFI_UPS_HIGH_LOAD_PERCENT"
 	envMinAvailability    = "UNIFI_WAN_QUALITY_MIN_AVAILABILITY_PERCENT"
 	envMaxLatency         = "UNIFI_WAN_QUALITY_MAX_LATENCY_MS"
+	envPerDeviceKeys      = "UNIFI_PER_DEVICE_KEYS"
 
 	envWebhookEnabled     = "UNIFI_WEBHOOK_ENABLED"
 	envWebhookBindAddress = "UNIFI_WEBHOOK_BIND_ADDRESS"
@@ -84,7 +85,11 @@ type Config struct {
 	HighLoadPercent        float64
 	MinAvailabilityPercent float64
 	MaxLatencyMs           float64
-	Webhook                WebhookConfig
+	// PerDeviceKeys opts into a device.<name> key per adopted device. Off by
+	// default: it is the only setting that changes how many series an install
+	// publishes rather than what any of them mean.
+	PerDeviceKeys bool
+	Webhook       WebhookConfig
 	// Actions is what this install allows Reactor to write to the console.
 	// Empty by default, which refuses every console write action. See
 	// write.go: the console is the one thing Reactor touches that is not a
@@ -151,6 +156,7 @@ func ConfigFromEnv(lookup func(string) string) (Config, bool, error) {
 		HighLoadPercent:        DefaultHighLoadPercent,
 		MinAvailabilityPercent: DefaultMinAvailabilityPercent,
 		MaxLatencyMs:           DefaultMaxLatencyMs,
+		PerDeviceKeys:          lookup(envPerDeviceKeys) == envTrue,
 		Webhook: WebhookConfig{
 			Enabled:            lookup(envWebhookEnabled) == envTrue,
 			BindAddress:        DefaultWebhookBindAddress,

--- a/internal/providers/unifi/config.go
+++ b/internal/providers/unifi/config.go
@@ -52,6 +52,7 @@ const (
 	envMaxLatency         = "UNIFI_WAN_QUALITY_MAX_LATENCY_MS"
 	envPerDeviceKeys      = "UNIFI_PER_DEVICE_KEYS"
 	envHighTemperature    = "UNIFI_TEMPERATURE_HIGH_CELSIUS"
+	envMaxPoEUtilization  = "UNIFI_POE_MAX_UTILIZATION_PERCENT"
 
 	envWebhookEnabled     = "UNIFI_WEBHOOK_ENABLED"
 	envWebhookBindAddress = "UNIFI_WEBHOOK_BIND_ADDRESS"
@@ -75,18 +76,19 @@ type Config struct {
 	URL string
 	// APIKey is resolved per request, not held from startup, so rotating a
 	// mounted credential takes effect on the next poll.
-	APIKey                 APIKey
-	Site                   string
-	InsecureSkipVerify     bool
-	PollInterval           time.Duration
-	LowBatteryPercent      int
-	CriticalBatteryPercent int
-	ShortRuntimeSeconds    int
-	CriticalRuntimeSeconds int
-	HighLoadPercent        float64
-	MinAvailabilityPercent float64
-	MaxLatencyMs           float64
-	HighTemperatureCelsius float64
+	APIKey                   APIKey
+	Site                     string
+	InsecureSkipVerify       bool
+	PollInterval             time.Duration
+	LowBatteryPercent        int
+	CriticalBatteryPercent   int
+	ShortRuntimeSeconds      int
+	CriticalRuntimeSeconds   int
+	HighLoadPercent          float64
+	MinAvailabilityPercent   float64
+	MaxLatencyMs             float64
+	HighTemperatureCelsius   float64
+	MaxPoEUtilizationPercent float64
 	// PerDeviceKeys opts into a device.<name> key per adopted device. Off by
 	// default: it is the only setting that changes how many series an install
 	// publishes rather than what any of them mean.
@@ -147,19 +149,20 @@ type WebhookConfig struct {
 // mapping can be tested without mutating process state.
 func ConfigFromEnv(lookup func(string) string) (Config, bool, error) {
 	cfg := Config{
-		URL:                    lookup(envURL),
-		Site:                   lookup(envSite),
-		InsecureSkipVerify:     lookup(envInsecureSkipVerify) == envTrue,
-		PollInterval:           DefaultPollInterval,
-		LowBatteryPercent:      DefaultLowBatteryPercent,
-		CriticalBatteryPercent: DefaultCriticalBatteryPercent,
-		ShortRuntimeSeconds:    DefaultShortRuntimeSeconds,
-		CriticalRuntimeSeconds: DefaultCriticalRuntimeSeconds,
-		HighLoadPercent:        DefaultHighLoadPercent,
-		MinAvailabilityPercent: DefaultMinAvailabilityPercent,
-		MaxLatencyMs:           DefaultMaxLatencyMs,
-		HighTemperatureCelsius: DefaultHighTemperatureCelsius,
-		PerDeviceKeys:          lookup(envPerDeviceKeys) == envTrue,
+		URL:                      lookup(envURL),
+		Site:                     lookup(envSite),
+		InsecureSkipVerify:       lookup(envInsecureSkipVerify) == envTrue,
+		PollInterval:             DefaultPollInterval,
+		LowBatteryPercent:        DefaultLowBatteryPercent,
+		CriticalBatteryPercent:   DefaultCriticalBatteryPercent,
+		ShortRuntimeSeconds:      DefaultShortRuntimeSeconds,
+		CriticalRuntimeSeconds:   DefaultCriticalRuntimeSeconds,
+		HighLoadPercent:          DefaultHighLoadPercent,
+		MinAvailabilityPercent:   DefaultMinAvailabilityPercent,
+		MaxLatencyMs:             DefaultMaxLatencyMs,
+		HighTemperatureCelsius:   DefaultHighTemperatureCelsius,
+		MaxPoEUtilizationPercent: DefaultMaxPoEUtilizationPercent,
+		PerDeviceKeys:            lookup(envPerDeviceKeys) == envTrue,
 		Webhook: WebhookConfig{
 			Enabled:            lookup(envWebhookEnabled) == envTrue,
 			BindAddress:        DefaultWebhookBindAddress,
@@ -239,6 +242,7 @@ func ConfigFromEnv(lookup func(string) string) (Config, bool, error) {
 		{envMaxLatency, &cfg.MaxLatencyMs},
 		{envHighLoad, &cfg.HighLoadPercent},
 		{envHighTemperature, &cfg.HighTemperatureCelsius},
+		{envMaxPoEUtilization, &cfg.MaxPoEUtilizationPercent},
 	} {
 		raw := lookup(field.env)
 		if raw == "" {

--- a/internal/providers/unifi/config.go
+++ b/internal/providers/unifi/config.go
@@ -51,6 +51,7 @@ const (
 	envMinAvailability    = "UNIFI_WAN_QUALITY_MIN_AVAILABILITY_PERCENT"
 	envMaxLatency         = "UNIFI_WAN_QUALITY_MAX_LATENCY_MS"
 	envPerDeviceKeys      = "UNIFI_PER_DEVICE_KEYS"
+	envHighTemperature    = "UNIFI_TEMPERATURE_HIGH_CELSIUS"
 
 	envWebhookEnabled     = "UNIFI_WEBHOOK_ENABLED"
 	envWebhookBindAddress = "UNIFI_WEBHOOK_BIND_ADDRESS"
@@ -85,6 +86,7 @@ type Config struct {
 	HighLoadPercent        float64
 	MinAvailabilityPercent float64
 	MaxLatencyMs           float64
+	HighTemperatureCelsius float64
 	// PerDeviceKeys opts into a device.<name> key per adopted device. Off by
 	// default: it is the only setting that changes how many series an install
 	// publishes rather than what any of them mean.
@@ -156,6 +158,7 @@ func ConfigFromEnv(lookup func(string) string) (Config, bool, error) {
 		HighLoadPercent:        DefaultHighLoadPercent,
 		MinAvailabilityPercent: DefaultMinAvailabilityPercent,
 		MaxLatencyMs:           DefaultMaxLatencyMs,
+		HighTemperatureCelsius: DefaultHighTemperatureCelsius,
 		PerDeviceKeys:          lookup(envPerDeviceKeys) == envTrue,
 		Webhook: WebhookConfig{
 			Enabled:            lookup(envWebhookEnabled) == envTrue,
@@ -235,6 +238,7 @@ func ConfigFromEnv(lookup func(string) string) (Config, bool, error) {
 		{envMinAvailability, &cfg.MinAvailabilityPercent},
 		{envMaxLatency, &cfg.MaxLatencyMs},
 		{envHighLoad, &cfg.HighLoadPercent},
+		{envHighTemperature, &cfg.HighTemperatureCelsius},
 	} {
 		raw := lookup(field.env)
 		if raw == "" {

--- a/internal/providers/unifi/devices.go
+++ b/internal/providers/unifi/devices.go
@@ -86,10 +86,20 @@ type deviceTally struct {
 	counted, offline int
 	// offlineNames are the slugs behind that count, for the diagnostic line.
 	offlineNames []string
+	// perDeviceKeys is the opt-in from Client. With it off — the default — one
+	// key is published no matter how large the fleet is, which is the whole
+	// point: the per-device keys are the ones whose names, and therefore whose
+	// metric series count, are bounded by someone's rack rather than by this
+	// repository.
+	perDeviceKeys bool
 }
 
-func newDeviceTally() *deviceTally {
-	return &deviceTally{perDevice: map[string]string{}, shared: map[string]bool{}}
+func newDeviceTally(perDeviceKeys bool) *deviceTally {
+	return &deviceTally{
+		perDevice:     map[string]string{},
+		shared:        map[string]bool{},
+		perDeviceKeys: perDeviceKeys,
+	}
 }
 
 // observe folds one adopted device into the tally.
@@ -142,12 +152,7 @@ func (t *deviceTally) observe(ctx context.Context, d deviceRecord) {
 }
 
 // publish writes the fleet keys into the state map.
-//
-// perDeviceKeys is the opt-in from Client. With it off — the default — one key
-// is published no matter how large the fleet is, which is the whole point: the
-// per-device keys are the ones whose names, and therefore whose metric series
-// count, are bounded by someone's rack rather than by this repository.
-func (t *deviceTally) publish(ctx context.Context, state map[string]string, perDeviceKeys bool) {
+func (t *deviceTally) publish(ctx context.Context, state map[string]string) {
 	log := logf.FromContext(ctx).WithName("unifi-devices")
 	if t.counted == 0 {
 		log.V(1).Info("No adopted device reported a recognisable state; devices will not be published")
@@ -161,9 +166,9 @@ func (t *deviceTally) publish(ctx context.Context, state map[string]string, perD
 	slices.Sort(t.offlineNames)
 	log.V(1).Info("device fleet", "devices", state[stateKeyDevices], "adopted", t.counted,
 		"offline", t.offline, "offlineDevices", strings.Join(t.offlineNames, ","),
-		"perDeviceKeys", perDeviceKeys)
+		"perDeviceKeys", t.perDeviceKeys)
 
-	if !perDeviceKeys {
+	if !t.perDeviceKeys {
 		return
 	}
 	for key, value := range t.perDevice {
@@ -183,7 +188,7 @@ func (t *deviceTally) publish(ctx context.Context, state map[string]string, perD
 }
 
 // offlineDescription is one offline device as it appears in the diagnostic
-// line: what it is called, why the console lost it, and when it was last seen.
+// line: what it is called, and why the console says it lost it.
 func offlineDescription(slug string, d deviceRecord) string {
 	name := slug
 	if name == "" {

--- a/internal/providers/unifi/devices.go
+++ b/internal/providers/unifi/devices.go
@@ -1,0 +1,196 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
+)
+
+// The two values of the console's per-device state field this provider is
+// willing to read. UniFi documents others — provisioning, upgrading, heartbeat
+// missed, adoption pending — and none of them has been captured, so anything
+// else is treated as "this device says nothing" rather than being folded into
+// one of these. Reading an unfamiliar state as offline is how a firmware that
+// added a value would shed a cluster's load.
+const (
+	deviceStateOffline = 0
+	deviceStateOnline  = 1
+)
+
+// deviceHealthFields are the fields the devices and device.<name> keys are
+// derived from. They are embedded in deviceRecord, so they decode from the same
+// flat object; keeping them here means the fields and the parser that reads
+// them are in one file.
+type deviceHealthFields struct {
+	// State is 1 while the console is in contact with the device and 0 when it
+	// is not.
+	//
+	// It is a pointer, and that is the load-bearing decision in this file. An
+	// absent state is not state 0: a record truncated by a firmware change, or
+	// a device type that does not report the field, would otherwise be read as
+	// a dead device and take the whole fleet to degraded. Absent means absent.
+	State *int `json:"state"`
+	// Adopted gates every fleet-wide key: an unadopted device is one the
+	// console can see but does not manage, and #8 is about the fleet you own.
+	// A pointer for the same reason, and nil is read as "not known to be
+	// adopted" — the direction that publishes fewer keys rather than more.
+	Adopted *bool `json:"adopted"`
+	// DisconnectionReason is never derived from. It is the diagnostic that
+	// makes an offline device actionable — a V(1) line naming which device and
+	// why the console lost it — and a diagnostic is a log line rather than API.
+	DisconnectionReason string `json:"disconnection_reason"`
+}
+
+// adopted reports whether this record is a device the console manages.
+func (d deviceRecord) adopted() bool {
+	return d.Adopted != nil && *d.Adopted
+}
+
+// deviceTally accumulates one device list into the fleet keys.
+//
+// It is a tally rather than a first-match scan because both keys are about the
+// whole fleet: wan comes from the one gateway, but devices is only meaningful
+// once every record has been seen.
+type deviceTally struct {
+	// perDevice is the value each device's own key would publish, keyed by the
+	// full state key.
+	perDevice map[string]string
+	// shared holds the keys more than one device slugified onto, which is a
+	// name collision rather than an observation and is published as neither
+	// device's state.
+	shared map[string]bool
+	// counted is how many adopted devices reported a state this provider
+	// recognises, and offline how many of those were offline. A fleet where
+	// counted is zero publishes nothing at all: there is nothing observable,
+	// which is not the same as nothing being wrong.
+	counted, offline int
+	// offlineNames are the slugs behind that count, for the diagnostic line.
+	offlineNames []string
+}
+
+func newDeviceTally() *deviceTally {
+	return &deviceTally{perDevice: map[string]string{}, shared: map[string]bool{}}
+}
+
+// observe folds one adopted device into the tally.
+func (t *deviceTally) observe(ctx context.Context, d deviceRecord) {
+	log := logf.FromContext(ctx).WithName("unifi-devices")
+
+	if d.State == nil {
+		log.V(1).Info("An adopted device reports no state; it counts towards neither devices nor a key of its own",
+			"model", d.Model, "type", d.Type)
+		return
+	}
+
+	var value string
+	switch *d.State {
+	case deviceStateOnline:
+		value = deviceOnline
+	case deviceStateOffline:
+		value = deviceOffline
+	default:
+		// An unrecognised state is not translated into a value, for the same
+		// reason an unrecognised www status is not: provisioning and upgrading
+		// are states a healthy device passes through, and reading either as
+		// offline would report a firmware update as a fleet outage.
+		log.Info("A device reports a state this provider does not recognise; it counts towards neither "+
+			"devices nor a key of its own. Please report it — the set of states is what this key is derived from",
+			"state", *d.State, "model", d.Model, "type", d.Type)
+		return
+	}
+
+	slug := slugify(d.Name)
+	t.counted++
+	if value == deviceOffline {
+		t.offline++
+		t.offlineNames = append(t.offlineNames, offlineDescription(slug, d))
+	}
+
+	if slug == "" {
+		// Nameless devices still count towards the fleet — a dead AP is dead
+		// whether or not anyone named it — but there is no key to publish it
+		// under.
+		log.V(1).Info("A device has no name to derive a key from; it counts towards devices only",
+			"model", d.Model, "type", d.Type, "state", value)
+		return
+	}
+	key := stateKeyDevicePrefix + slug
+	if _, already := t.perDevice[key]; already {
+		t.shared[key] = true
+	}
+	t.perDevice[key] = value
+}
+
+// publish writes the fleet keys into the state map.
+//
+// perDeviceKeys is the opt-in from Client. With it off — the default — one key
+// is published no matter how large the fleet is, which is the whole point: the
+// per-device keys are the ones whose names, and therefore whose metric series
+// count, are bounded by someone's rack rather than by this repository.
+func (t *deviceTally) publish(ctx context.Context, state map[string]string, perDeviceKeys bool) {
+	log := logf.FromContext(ctx).WithName("unifi-devices")
+	if t.counted == 0 {
+		log.V(1).Info("No adopted device reported a recognisable state; devices will not be published")
+		return
+	}
+
+	state[stateKeyDevices] = devicesAllOnline
+	if t.offline > 0 {
+		state[stateKeyDevices] = devicesDegraded
+	}
+	slices.Sort(t.offlineNames)
+	log.V(1).Info("device fleet", "devices", state[stateKeyDevices], "adopted", t.counted,
+		"offline", t.offline, "offlineDevices", strings.Join(t.offlineNames, ","),
+		"perDeviceKeys", perDeviceKeys)
+
+	if !perDeviceKeys {
+		return
+	}
+	for key, value := range t.perDevice {
+		if t.shared[key] {
+			// Two devices named the same thing after slugification. Publishing
+			// either one's state under this key would be arbitrary, and the
+			// arbitrary choice could be the one that hides a dead device, so
+			// the key is published as neither. devices still counts both.
+			metrics.SignalsDisagreed(ProviderName, signalDeviceNameShared)
+			log.Info("Two or more devices share one key after slugifying their names, so that key "+
+				"reports neither of them; rename one on the console to tell them apart",
+				"key", key)
+			continue
+		}
+		state[key] = value
+	}
+}
+
+// offlineDescription is one offline device as it appears in the diagnostic
+// line: what it is called, why the console lost it, and when it was last seen.
+func offlineDescription(slug string, d deviceRecord) string {
+	name := slug
+	if name == "" {
+		name = "(unnamed " + d.Model + ")"
+	}
+	if d.DisconnectionReason != "" {
+		name += "=" + d.DisconnectionReason
+	}
+	return name
+}

--- a/internal/providers/unifi/devices_test.go
+++ b/internal/providers/unifi/devices_test.go
@@ -1,0 +1,277 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// adoptedDevice is a device record in the shape the captures have: adopted,
+// named, and reporting a state. Everything below starts from this so that what
+// a test changes is the one field it is about.
+func adoptedDevice(name string, state int) deviceRecord {
+	adopted := true
+	return deviceRecord{
+		Model: "USW48",
+		Type:  "usw",
+		Name:  name,
+		deviceHealthFields: deviceHealthFields{
+			State:   &state,
+			Adopted: &adopted,
+		},
+	}
+}
+
+// fleetState derives the fleet keys from a device list, with the per-device
+// keys opted into or not.
+func fleetState(t *testing.T, perDeviceKeys bool, devices ...deviceRecord) map[string]string {
+	t.Helper()
+	c := NewClient("", nil, "", false)
+	c.PerDeviceKeys = perDeviceKeys
+	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	return state
+}
+
+// The captured gateway and UPS are both adopted and both report state 1, so the
+// committed captures alone say the fleet is healthy.
+func TestFleetIsAllOnlineInTheCapture(t *testing.T) {
+	c := serve(t, merged(t, "stat-device-gateway.json", "stat-device-ups.json"))
+
+	state, err := c.Observe(context.Background())
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if state[stateKeyDevices] != devicesAllOnline {
+		t.Errorf("state[devices] = %q, want %q", state[stateKeyDevices], devicesAllOnline)
+	}
+}
+
+// The aggregate is the safe default and the one that ships on, so it is
+// published with no per-device key beside it however large the fleet is.
+func TestPerDeviceKeysAreOptIn(t *testing.T) {
+	devices := []deviceRecord{
+		adoptedDevice("Switch 48", deviceStateOnline),
+		adoptedDevice("AP Kitchen", deviceStateOffline),
+	}
+
+	off := fleetState(t, false, devices...)
+	if off[stateKeyDevices] != devicesDegraded {
+		t.Errorf("state[devices] = %q, want %q", off[stateKeyDevices], devicesDegraded)
+	}
+	for key := range off {
+		if strings.HasPrefix(key, stateKeyDevicePrefix) {
+			t.Errorf("per-device key %q must not be published unless it is opted into", key)
+		}
+	}
+
+	on := fleetState(t, true, devices...)
+	for key, want := range map[string]string{
+		stateKeyDevices:                     devicesDegraded,
+		stateKeyDevicePrefix + "switch-48":  deviceOnline,
+		stateKeyDevicePrefix + "ap-kitchen": deviceOffline,
+	} {
+		if on[key] != want {
+			t.Errorf("state[%q] = %q, want %q", key, on[key], want)
+		}
+	}
+}
+
+func TestFleetAggregate(t *testing.T) {
+	tests := []struct {
+		name    string
+		devices []deviceRecord
+		want    string
+	}{
+		{"every device online", []deviceRecord{
+			adoptedDevice("A", deviceStateOnline),
+			adoptedDevice("B", deviceStateOnline),
+		}, devicesAllOnline},
+		{"one device offline", []deviceRecord{
+			adoptedDevice("A", deviceStateOnline),
+			adoptedDevice("B", deviceStateOffline),
+		}, devicesDegraded},
+		{"every device offline", []deviceRecord{
+			adoptedDevice("A", deviceStateOffline),
+		}, devicesDegraded},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fleetState(t, false, tc.devices...)[stateKeyDevices]; got != tc.want {
+				t.Errorf("state[devices] = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The bug #5 nearly shipped, in this file's terms. The console omits fields
+// rather than zeroing them, and state 0 is offline: a record that carries no
+// state at all must not be read as a dead device, because one truncated record
+// would take the whole fleet to degraded and shed a cluster's load.
+func TestMissingStateIsNotAnOfflineDevice(t *testing.T) {
+	silent := adoptedDevice("Mystery", deviceStateOnline)
+	silent.State = nil
+
+	state := fleetState(t, true, adoptedDevice("Switch 48", deviceStateOnline), silent)
+
+	if got := state[stateKeyDevices]; got != devicesAllOnline {
+		t.Errorf("state[devices] = %q, want %q: a device reporting no state is not a device at zero", got, devicesAllOnline)
+	}
+	if got, present := state[stateKeyDevicePrefix+"mystery"]; present {
+		t.Errorf("a device reporting no state should publish no key of its own, got %q", got)
+	}
+}
+
+// Provisioning, upgrading and heartbeat-missed are states UniFi documents and
+// no capture has ever shown. None of them may be folded into offline: a fleet
+// mid-firmware-upgrade is not a fleet outage.
+func TestUnrecognisedDeviceStateIsNeitherOnlineNorOffline(t *testing.T) {
+	for _, state := range []int{2, 4, 5, 6, 11, -1} {
+		odd := adoptedDevice("Provisioning", state)
+		got := fleetState(t, true, adoptedDevice("Switch 48", deviceStateOnline), odd)
+
+		if got[stateKeyDevices] != devicesAllOnline {
+			t.Errorf("state %d: state[devices] = %q, want %q", state, got[stateKeyDevices], devicesAllOnline)
+		}
+		if value, present := got[stateKeyDevicePrefix+"provisioning"]; present {
+			t.Errorf("state %d should publish no key of its own, got %q", state, value)
+		}
+	}
+}
+
+// #8 asks for unadopted and pending devices to be excluded: they are devices
+// the console can see and does not manage, so an offline one is not an outage
+// of anything anyone owns.
+func TestUnadoptedDevicesAreNotPartOfTheFleet(t *testing.T) {
+	pending := adoptedDevice("Neighbour AP", deviceStateOffline)
+	pending.Adopted = nil
+	notAdopted := adoptedDevice("Other AP", deviceStateOffline)
+	notAdopted.Adopted = new(bool)
+
+	state := fleetState(t, true, adoptedDevice("Switch 48", deviceStateOnline), pending, notAdopted)
+
+	if got := state[stateKeyDevices]; got != devicesAllOnline {
+		t.Errorf("state[devices] = %q, want %q: unadopted devices are not part of the fleet", got, devicesAllOnline)
+	}
+	for _, slug := range []string{"neighbour-ap", "other-ap"} {
+		if value, present := state[stateKeyDevicePrefix+slug]; present {
+			t.Errorf("unadopted device %q should publish no key, got %q", slug, value)
+		}
+	}
+}
+
+// Omit what you cannot see, at the fleet level: a device list where nothing is
+// adopted publishes no devices key rather than all-online. "Nothing to report"
+// and "nothing is wrong" are different claims, and only one of them is true.
+func TestAListWithNothingAdoptedObservesNothing(t *testing.T) {
+	pending := adoptedDevice("Neighbour AP", deviceStateOnline)
+	pending.Adopted = nil
+
+	c := NewClient("", nil, "", false)
+	if _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{pending}}); err == nil {
+		t.Fatal("a list holding nothing observable should be an error, not an empty observation")
+	}
+}
+
+// Renaming a device on the console makes its old key vanish and a new one
+// appear. The vanishing half is what must not look like a transition to
+// "recovered": the engine reports a disappeared key as unavailable and the
+// reconciler holds the last known state, which is only correct if the provider
+// genuinely stops publishing the old name rather than publishing it as offline.
+func TestRenamingADeviceMovesItsKeyRatherThanFailingIt(t *testing.T) {
+	before := fleetState(t, true, adoptedDevice("Switch 48", deviceStateOnline))
+	after := fleetState(t, true, adoptedDevice("Core Switch", deviceStateOnline))
+
+	if before[stateKeyDevicePrefix+"switch-48"] != deviceOnline {
+		t.Fatalf("state[device.switch-48] = %q, want %q", before[stateKeyDevicePrefix+"switch-48"], deviceOnline)
+	}
+	if value, present := after[stateKeyDevicePrefix+"switch-48"]; present {
+		t.Errorf("the old key should vanish on a rename, not report %q", value)
+	}
+	if after[stateKeyDevicePrefix+"core-switch"] != deviceOnline {
+		t.Errorf("state[device.core-switch] = %q, want %q", after[stateKeyDevicePrefix+"core-switch"], deviceOnline)
+	}
+	// Removing a device is the same shape as renaming one, and the aggregate
+	// must not move for either: what is left is still all online.
+	if after[stateKeyDevices] != devicesAllOnline {
+		t.Errorf("state[devices] = %q, want %q", after[stateKeyDevices], devicesAllOnline)
+	}
+}
+
+// Two devices whose names slugify to the same key. Publishing either one's
+// state would be arbitrary, and the arbitrary choice could be the one that
+// hides the dead device, so the key reports neither — while the aggregate,
+// which counts both, still goes degraded.
+func TestTwoDevicesSharingAKeyPublishNeither(t *testing.T) {
+	before := disagreements(t, signalDeviceNameShared)
+
+	state := fleetState(t, true,
+		adoptedDevice("AP 1", deviceStateOnline),
+		adoptedDevice("ap-1", deviceStateOffline))
+
+	if value, present := state[stateKeyDevicePrefix+"ap-1"]; present {
+		t.Errorf("a shared key should publish nothing, got %q", value)
+	}
+	if state[stateKeyDevices] != devicesDegraded {
+		t.Errorf("state[devices] = %q, want %q: both devices still count", state[stateKeyDevices], devicesDegraded)
+	}
+	if after := disagreements(t, signalDeviceNameShared); after <= before {
+		t.Errorf("a shared key should be counted as a disagreement, %v -> %v", before, after)
+	}
+}
+
+// A device with no name at all counts towards the fleet — a dead AP is dead
+// whether or not anyone named it — but there is no key to publish it under.
+func TestANamelessDeviceStillCountsTowardsTheFleet(t *testing.T) {
+	nameless := adoptedDevice("", deviceStateOffline)
+
+	state := fleetState(t, true, adoptedDevice("Switch 48", deviceStateOnline), nameless)
+
+	if state[stateKeyDevices] != devicesDegraded {
+		t.Errorf("state[devices] = %q, want %q", state[stateKeyDevices], devicesDegraded)
+	}
+	if len(state) != 2 { // devices plus the one named device
+		t.Errorf("expected only the aggregate and the named device's key, got %v", state)
+	}
+}
+
+// Per-key degradation: the fleet keys and the gateway keys come from the same
+// response and are still independent observations. A device list with no
+// gateway in it reports the fleet, and a gateway with nothing adopted reports
+// wan.
+func TestFleetAndGatewayKeysDegradeIndependently(t *testing.T) {
+	withoutGateway := fleetState(t, false, adoptedDevice("Switch 48", deviceStateOffline))
+	if withoutGateway[stateKeyDevices] != devicesDegraded {
+		t.Errorf("state[devices] = %q, want %q", withoutGateway[stateKeyDevices], devicesDegraded)
+	}
+	if _, present := withoutGateway[stateKeyWAN]; present {
+		t.Error("wan should be absent when no gateway is in the list")
+	}
+
+	gateway := deviceRecord{Model: "UDMPRO", WAN1: &wanPort{IsUplink: true, Up: true}}
+	withoutFleet := fleetState(t, false, gateway)
+	if withoutFleet[stateKeyWAN] != wanPrimary {
+		t.Errorf("state[wan] = %q, want %q", withoutFleet[stateKeyWAN], wanPrimary)
+	}
+	if value, present := withoutFleet[stateKeyDevices]; present {
+		t.Errorf("devices should be absent when the gateway does not report adoption, got %q", value)
+	}
+}

--- a/internal/providers/unifi/firmware.go
+++ b/internal/providers/unifi/firmware.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// firmwareFields are the fields the firmware key is derived from, embedded in
+// deviceRecord so they decode from the same flat object.
+//
+// NONE of these has been captured. The committed records carry version and
+// displayable_version and nothing else about upgrades, so every field here is
+// written to the shape UniFi's own API documents and named in issue #12, and
+// added to the allowlist in hack/capture-unifi.sh so the next real capture
+// settles them. See the live-verification list in testdata/unifi/README.md.
+type firmwareFields struct {
+	// Version is the firmware the device is running now, and the one field here
+	// that IS in both committed captures. Diagnostics only: it gives the log
+	// line a "from" to go with the "to" below.
+	Version string `json:"version"`
+	// Upgradable is the console's own answer to "is there a newer firmware for
+	// this device", and the only field this key is derived from.
+	//
+	// A pointer, because absent is not false. A firmware that renamed the field,
+	// or a device type that does not report it, would otherwise be read as "up
+	// to date" — which is the wrong direction to be wrong in for a key whose
+	// whole job is to say that an update exists.
+	Upgradable *bool `json:"upgradable"`
+	// UpgradeToFirmware and RequiredVersion are diagnostics: which version the
+	// console would move a device to, and the minimum the controller wants.
+	// Never derived from — a version string is not something spec.when could
+	// match, and one series per version is not something Prometheus should keep.
+	UpgradeToFirmware string `json:"upgrade_to_firmware"`
+	RequiredVersion   string `json:"required_version"`
+	// SafeForAutoupgrade, ModelInEOL and ModelInLTS are diagnostics too, and
+	// the reason they are read at all is that they are what makes an upgrade
+	// decision: a model past end of life is not going to get the fix you are
+	// waiting for. See the note on why none of them is a key of its own.
+	SafeForAutoupgrade *bool `json:"safe_for_autoupgrade"`
+	ModelInEOL         *bool `json:"model_in_eol"`
+	ModelInLTS         *bool `json:"model_in_lts"`
+}
+
+// firmwareTally accumulates the fleet's upgrade state.
+//
+// One key for the whole fleet rather than one per device, for the reason
+// device.<name> is opt-in: a per-device firmware key would multiply series by
+// fleet size, and "is there anything to upgrade" is the question. Which devices
+// answers it — issue #12's acceptance criterion — is a log line.
+type firmwareTally struct {
+	// reporting is how many adopted devices answered the question at all. Zero
+	// publishes no key: a console that says nothing about upgrades is not a
+	// console saying everything is current.
+	reporting int
+	// upgradable names the devices with an update waiting, and silent the ones
+	// that did not report the field, both for the diagnostic line.
+	upgradable []string
+	silent     []string
+	// eol and lts are counted rather than named: they are properties of a model
+	// rather than of an install, and they do not change between polls.
+	eol, lts int
+}
+
+// observe folds one adopted device into the tally.
+func (t *firmwareTally) observe(d deviceRecord) {
+	name := slugify(d.Name)
+	if name == "" {
+		name = strings.ToLower(d.Model)
+	}
+	if d.ModelInEOL != nil && *d.ModelInEOL {
+		t.eol++
+	}
+	if d.ModelInLTS != nil && *d.ModelInLTS {
+		t.lts++
+	}
+
+	if d.Upgradable == nil {
+		t.silent = append(t.silent, name)
+		return
+	}
+	t.reporting++
+	if !*d.Upgradable {
+		return
+	}
+	if d.UpgradeToFirmware != "" {
+		name += "=" + d.Version + "->" + d.UpgradeToFirmware
+	}
+	t.upgradable = append(t.upgradable, name)
+}
+
+// publish writes the firmware key, or withholds it when nothing answered.
+func (t *firmwareTally) publish(ctx context.Context, state map[string]string) {
+	log := logf.FromContext(ctx).WithName("unifi-firmware")
+	slices.Sort(t.silent)
+	if t.reporting == 0 {
+		log.V(1).Info("No adopted device reports whether it is upgradable; firmware will not be published",
+			"devicesSilent", strings.Join(t.silent, ","))
+		return
+	}
+
+	state[stateKeyFirmware] = firmwareCurrent
+	if len(t.upgradable) > 0 {
+		state[stateKeyFirmware] = firmwareUpdatesAvailable
+	}
+	// Which devices, and what would move where: #12 asks for that to be visible
+	// somewhere, and a log line is where a version string belongs. It is not a
+	// state value (spec.when compares strings, and one series per version is
+	// the cardinality failure isp would have been) and it is not one per key.
+	slices.Sort(t.upgradable)
+	log.V(1).Info("firmware", "firmware", state[stateKeyFirmware],
+		"devicesReporting", t.reporting, "devicesUpgradable", strings.Join(t.upgradable, ","),
+		"devicesSilent", strings.Join(t.silent, ","), "modelsPastEOL", t.eol, "modelsOnLTS", t.lts)
+}

--- a/internal/providers/unifi/firmware_test.go
+++ b/internal/providers/unifi/firmware_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// upgradableDevice is an adopted device that answers the upgrade question.
+func upgradableDevice(name string, upgradable bool) deviceRecord {
+	d := adoptedDevice(name, deviceStateOnline)
+	d.firmwareFields = firmwareFields{
+		Version:    "1.2.3",
+		Upgradable: &upgradable,
+	}
+	if upgradable {
+		d.UpgradeToFirmware = "1.3.0"
+	}
+	return d
+}
+
+func TestFirmwareAcrossTheFleet(t *testing.T) {
+	tests := []struct {
+		name    string
+		devices []deviceRecord
+		want    string
+	}{
+		{"nothing to upgrade", []deviceRecord{
+			upgradableDevice("Switch 48", false),
+			upgradableDevice("AP Kitchen", false),
+		}, firmwareCurrent},
+		{"one device behind", []deviceRecord{
+			upgradableDevice("Switch 48", false),
+			upgradableDevice("AP Kitchen", true),
+		}, firmwareUpdatesAvailable},
+		{"everything behind", []deviceRecord{
+			upgradableDevice("Switch 48", true),
+		}, firmwareUpdatesAvailable},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fleetState(t, false, tc.devices...)[stateKeyFirmware]; got != tc.want {
+				t.Errorf("state[firmware] = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// Absent is not false, and here that matters in the direction of a missed
+// update rather than a false alarm: the committed captures carry no upgradable
+// field at all, so a console that reports none must publish no key rather than
+// "everything is current".
+func TestMissingUpgradableIsNotUpToDate(t *testing.T) {
+	c := serve(t, merged(t, "stat-device-gateway.json", "stat-device-ups.json"))
+
+	state, err := c.Observe(context.Background())
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if got, present := state[stateKeyFirmware]; present {
+		t.Errorf("the captures report no upgradable field, so firmware must be absent, got %q", got)
+	}
+}
+
+// A fleet where only some devices answer is the realistic case — the field is
+// per device type — and the ones that do answer are enough to publish the key.
+// The silent ones are named in the diagnostic line rather than assumed current.
+func TestFirmwareIsDerivedFromTheDevicesThatAnswer(t *testing.T) {
+	silent := adoptedDevice("Old Switch", deviceStateOnline)
+
+	state := fleetState(t, false, silent, upgradableDevice("AP Kitchen", true))
+	if got := state[stateKeyFirmware]; got != firmwareUpdatesAvailable {
+		t.Errorf("state[firmware] = %q, want %q", got, firmwareUpdatesAvailable)
+	}
+
+	onlySilent := fleetState(t, false, silent)
+	if got, present := onlySilent[stateKeyFirmware]; present {
+		t.Errorf("a fleet where nothing answers should publish no firmware key, got %q", got)
+	}
+}
+
+// Unadopted devices are excluded from every fleet key, and firmware is no
+// exception: a neighbour's out-of-date AP is not an update you can apply.
+func TestFirmwareIgnoresUnadoptedDevices(t *testing.T) {
+	neighbour := upgradableDevice("Neighbour AP", true)
+	neighbour.Adopted = nil
+
+	state := fleetState(t, false, upgradableDevice("Switch 48", false), neighbour)
+
+	if got := state[stateKeyFirmware]; got != firmwareCurrent {
+		t.Errorf("state[firmware] = %q, want %q", got, firmwareCurrent)
+	}
+}
+
+// The firmware fields have never been captured, so the shape they are parsed
+// from is the shape UniFi documents. This asserts the decode of that documented
+// shape end to end, and it is a HYPOTHESIS rather than ground truth: it lives
+// here in code, deliberately, because a file under testdata/ claims to have
+// come off a console. See the live-verification list in testdata/unifi/README.md.
+func TestFirmwareDecodesTheDocumentedShape(t *testing.T) {
+	const documented = `{"data":[{
+		"model": "USW48", "type": "usw", "name": "Switch 48",
+		"state": 1, "adopted": true,
+		"version": "6.6.65.14856", "displayable_version": "6.6.65",
+		"upgradable": true, "upgrade_to_firmware": "7.0.50.15613",
+		"required_version": "6.0.0", "safe_for_autoupgrade": true,
+		"model_in_eol": false, "model_in_lts": false
+	}]}`
+
+	var parsed deviceStatResponse
+	if err := json.Unmarshal([]byte(documented), &parsed); err != nil {
+		t.Fatalf("parsing the documented shape: %v", err)
+	}
+	d := parsed.Data[0]
+	if d.Upgradable == nil || !*d.Upgradable {
+		t.Fatalf("upgradable did not decode: %+v", d.Upgradable)
+	}
+	if d.UpgradeToFirmware != "7.0.50.15613" || d.Version != "6.6.65.14856" {
+		t.Errorf("version fields did not decode: %q -> %q", d.Version, d.UpgradeToFirmware)
+	}
+	if d.ModelInEOL == nil || *d.ModelInEOL {
+		t.Errorf("model_in_eol did not decode: %+v", d.ModelInEOL)
+	}
+
+	c := NewClient("", nil, "", false)
+	state, err := c.stateFromDevices(context.Background(), parsed)
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	if state[stateKeyFirmware] != firmwareUpdatesAvailable {
+		t.Errorf("state[firmware] = %q, want %q", state[stateKeyFirmware], firmwareUpdatesAvailable)
+	}
+}
+
+// model_in_eol is read and deliberately not published as a key. It is an
+// inventory fact rather than a state — it does not transition, so an Automation
+// matching it would hold a permanent condition — and this asserts the decision
+// rather than the derivation, so nobody quietly turns it into a sixth key
+// without arguing for it.
+func TestEndOfLifeIsADiagnosticRatherThanAKey(t *testing.T) {
+	eol, no := true, false
+	device := upgradableDevice("Old Switch", false)
+	device.ModelInEOL, device.ModelInLTS = &eol, &no
+
+	state := fleetState(t, false, device)
+
+	if state[stateKeyFirmware] != firmwareCurrent {
+		t.Errorf("state[firmware] = %q, want %q: end of life is not an available update",
+			state[stateKeyFirmware], firmwareCurrent)
+	}
+	for key := range state {
+		if key == "firmware.eol" || key == "eol" {
+			t.Errorf("%q is not a published key; end of life is a diagnostic", key)
+		}
+	}
+}

--- a/internal/providers/unifi/health.go
+++ b/internal/providers/unifi/health.go
@@ -57,6 +57,18 @@ type healthSubsystem struct {
 	// UptimeStats appears on the wan subsystem, keyed by uplink (WAN, WAN2,
 	// WAN3) exactly as last_wan_status is.
 	UptimeStats map[string]uplinkHealth `json:"uptime_stats"`
+
+	// The AP counts on the wlan subsystem, which the wifi key is derived from.
+	// Pointers, like every other number in this file: a subsystem that reports
+	// no counts is not a subsystem with zero APs, and zero adopted APs is a
+	// site with no WiFi rather than a site whose WiFi is fine.
+	//
+	// The capture carries all three — 2, 3 and 1 — and they are internally
+	// consistent: 2 connected plus 1 disconnected is the 3 that are adopted,
+	// which is what says NumAdopted is the denominator wifi should use.
+	NumAP           *int `json:"num_ap"`
+	NumAdopted      *int `json:"num_adopted"`
+	NumDisconnected *int `json:"num_disconnected"`
 }
 
 // uplinkHealth is one uplink's entry in the wan subsystem's uptime_stats.
@@ -121,6 +133,10 @@ func (c *Client) mergeHealth(ctx context.Context, state map[string]string, healt
 				"internet will not be published. Please report it — the set of statuses is "+
 				"what this key is derived from",
 				"status", subsystem.Status)
+		case healthSubsystemWLAN:
+			if wifi := wifiFrom(ctx, subsystem); wifi != "" {
+				state[stateKeyWiFi] = wifi
+			}
 		case healthSubsystemWAN:
 			c.crossCheckUplinkHealth(ctx, wan, subsystem.UptimeStats)
 			if wan == "" {

--- a/internal/providers/unifi/poe.go
+++ b/internal/providers/unifi/poe.go
@@ -161,10 +161,17 @@ type poeDraw struct {
 // exact situation #14 exists to catch.
 func (d deviceRecord) poe() poeDraw {
 	draw := poeDraw{}
-	if d.TotalMaxPower == nil || *d.TotalMaxPower <= 0 || len(d.PortTable) == 0 {
+	if d.TotalMaxPower == nil || *d.TotalMaxPower <= 0 {
 		return draw
 	}
 	draw.budget = *d.TotalMaxPower
+	if len(d.PortTable) == 0 {
+		// A budget with no port table at all is a truncated record rather than
+		// a switch delivering nothing, so it is reported as unreadable and
+		// named in the diagnostic line instead of counting as free headroom.
+		draw.silent = append(draw.silent, "no port table")
+		return draw
+	}
 	for _, port := range d.PortTable {
 		if port.PoEEnable == nil || !*port.PoEEnable {
 			// Not powering anything. A port that is off draws nothing, and that
@@ -191,6 +198,9 @@ func (p poeDraw) utilization() float64 {
 // worst switch decides: one switch out of headroom drops the cameras on that
 // switch, whatever the others have spare.
 type poeTally struct {
+	// maximum is the utilization at or above which the fleet reports
+	// insufficient, taken from Client at construction.
+	maximum float64
 	// switches is how many reported a budget and a readable port table.
 	switches int
 	// worst is the highest utilization anywhere, and worstSwitch the slug
@@ -202,6 +212,13 @@ type poeTally struct {
 	// budget and would not say what they were delivering.
 	draws      []string
 	unreadable []string
+}
+
+func newPoETally(maximum float64) poeTally {
+	if maximum <= 0 {
+		maximum = DefaultMaxPoEUtilizationPercent
+	}
+	return poeTally{maximum: maximum}
 }
 
 // observe folds one adopted device into the tally. Devices with no PoE at all —
@@ -230,8 +247,8 @@ func (t *poeTally) observe(d deviceRecord) {
 	}
 }
 
-// publishPoE buckets the worst switch's utilization against the threshold.
-func (c *Client) publishPoE(ctx context.Context, state map[string]string, t poeTally) {
+// publish buckets the worst switch's utilization against the threshold.
+func (t poeTally) publish(ctx context.Context, state map[string]string) {
 	log := logf.FromContext(ctx).WithName("unifi-poe")
 	if t.switches == 0 {
 		log.V(1).Info("No adopted switch reports a readable PoE budget; poe will not be published",
@@ -239,18 +256,13 @@ func (c *Client) publishPoE(ctx context.Context, state map[string]string, t poeT
 		return
 	}
 
-	maximum := c.MaxPoEUtilizationPercent
-	if maximum <= 0 {
-		maximum = DefaultMaxPoEUtilizationPercent
-	}
-
 	value := poeOK
-	if t.worst >= maximum {
+	if t.worst >= t.maximum {
 		value = poeInsufficient
 	}
 	state[stateKeyPoE] = value
 
 	log.V(1).Info("poe", "poe", value, "worstUtilizationPercent", t.worst,
-		"worstSwitch", t.worstSwitch, "thresholdPercent", maximum, "switchesMeasured", t.switches,
+		"worstSwitch", t.worstSwitch, "thresholdPercent", t.maximum, "switchesMeasured", t.switches,
 		"draws", strings.Join(t.draws, ","), "switchesUnreadable", strings.Join(t.unreadable, ","))
 }

--- a/internal/providers/unifi/poe.go
+++ b/internal/providers/unifi/poe.go
@@ -1,0 +1,256 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// DefaultMaxPoEUtilizationPercent is the share of a switch's PoE budget at or
+// above which poe reports insufficient.
+//
+// Set against the debounce this key ships with, per #7's rule. PoE draw is an
+// instantaneous measurement like ups.load — a camera's heater or an AP's radios
+// coming up move it by tens of watts within one poll — so it settles over 3
+// samples, and 90% leaves roughly one powered device's worth of headroom on a
+// typical switch for those 90 seconds. Raise it towards 100 and there is no
+// headroom left to react in; lower it and a switch that simply has a full
+// complement of APs reports insufficient forever.
+const DefaultMaxPoEUtilizationPercent = 90.0
+
+// jsonNull is the literal a JSON null arrives as, which flexibleNumber has to
+// recognise before it can distinguish "no reading" from a number.
+const jsonNull = "null"
+
+// poeFields are the fields the poe key is derived from, embedded in
+// deviceRecord so they decode from the same flat object.
+//
+// NONE of these has been captured. No switch record exists in testdata at all —
+// the UPS 2U is reported as a switch-type device but carries no port_table —
+// so both are written to the shape UniFi's API documents and to the names issue
+// #14 lists, and added to hack/capture-unifi.sh. See the live-verification list
+// in testdata/unifi/README.md.
+type poeFields struct {
+	// TotalMaxPower is the switch's whole PoE budget in watts: the denominator.
+	// A pointer, because a switch reporting no budget is not a switch with no
+	// budget — and dividing by an absent field read as zero is the other way
+	// this key could have gone wrong.
+	TotalMaxPower *float64 `json:"total_max_power"`
+	// PortTable is projected down hard in the capture script: a real one carries
+	// per-port names, MACs and client counts, none of which this key needs.
+	PortTable []devicePort `json:"port_table"`
+}
+
+// devicePort is one switch port's PoE state.
+type devicePort struct {
+	PortIdx *int `json:"port_idx"`
+	// PoEEnable says the port is delivering power. A pointer: absent is not
+	// "disabled", and a port whose state is unknown is not a port drawing
+	// nothing.
+	PoEEnable *bool `json:"poe_enable"`
+	// PoEPower is the watts this port is delivering, and it is a flexible
+	// number because UniFi is documented to report it as a STRING ("3.90") on
+	// several firmwares while other endpoints use a number. Decoding it as one
+	// or the other would make an entire switch's draw unreadable on the half of
+	// the world that reports it the other way.
+	PoEPower flexibleNumber `json:"poe_power"`
+	// PoEClass is a diagnostic: which powering class the port negotiated. Never
+	// derived from — it names a port that is powering something and will not
+	// say how much, which is the case that makes a switch unreadable.
+	PoEClass string `json:"poe_class"`
+}
+
+// describe names one port for a diagnostic line.
+func (p devicePort) describe() string {
+	name := "port"
+	if p.PortIdx != nil {
+		name += strconv.Itoa(*p.PortIdx)
+	} else {
+		name += "?"
+	}
+	if p.PoEClass != "" {
+		name += "(class " + p.PoEClass + ")"
+	}
+	return name
+}
+
+// flexibleNumber decodes a JSON number, a numeric string, or null into an
+// optional float.
+//
+// It exists for one field and it is deliberately narrow: nothing here coerces
+// a value it does not understand into zero. Absent, null, empty and
+// unparseable all mean "no reading", which the caller treats as missing rather
+// than as no power.
+type flexibleNumber struct {
+	Value float64
+	Known bool
+}
+
+func (f *flexibleNumber) UnmarshalJSON(data []byte) error {
+	data = bytes.TrimSpace(data)
+	if len(data) == 0 || string(data) == jsonNull {
+		return nil
+	}
+	if data[0] == '"' {
+		var raw string
+		if err := json.Unmarshal(data, &raw); err != nil {
+			return err
+		}
+		raw = strings.TrimSpace(raw)
+		if raw == "" {
+			return nil
+		}
+		value, err := strconv.ParseFloat(raw, 64)
+		if err != nil {
+			// A string this provider cannot read as a number is a reading it
+			// does not have, not a reading of zero. Failing the decode here
+			// would take the whole observation — every other key included —
+			// down with one unfamiliar port.
+			return nil
+		}
+		f.Value, f.Known = value, true
+		return nil
+	}
+	var value float64
+	if err := json.Unmarshal(data, &value); err != nil {
+		return nil
+	}
+	f.Value, f.Known = value, true
+	return nil
+}
+
+// poeDraw is one switch's PoE picture: what it is delivering against what it
+// can deliver.
+type poeDraw struct {
+	watts, budget float64
+	// measurable is false when the switch cannot be read honestly — no budget,
+	// or a port that is powering something and will not say how much.
+	measurable bool
+	// enabled is how many ports are powering something, and silent names the
+	// ones among them that would not say how much.
+	enabled int
+	silent  []string
+}
+
+// poe reads one device's PoE draw.
+//
+// A port that is powering something and reports no wattage makes the whole
+// switch unmeasurable rather than contributing zero. That is the "absent is not
+// zero" rule at the only place on this key where it can hide a failure:
+// under-counting the draw reports headroom that is not there, which is the
+// exact situation #14 exists to catch.
+func (d deviceRecord) poe() poeDraw {
+	draw := poeDraw{}
+	if d.TotalMaxPower == nil || *d.TotalMaxPower <= 0 || len(d.PortTable) == 0 {
+		return draw
+	}
+	draw.budget = *d.TotalMaxPower
+	for _, port := range d.PortTable {
+		if port.PoEEnable == nil || !*port.PoEEnable {
+			// Not powering anything. A port that is off draws nothing, and that
+			// is a reading rather than an absence.
+			continue
+		}
+		draw.enabled++
+		if !port.PoEPower.Known {
+			draw.silent = append(draw.silent, port.describe())
+			continue
+		}
+		draw.watts += port.PoEPower.Value
+	}
+	draw.measurable = len(draw.silent) == 0
+	return draw
+}
+
+// utilization is the draw as a percentage of the budget.
+func (p poeDraw) utilization() float64 {
+	return p.watts / p.budget * 100
+}
+
+// poeTally accumulates the fleet's PoE headroom into one bucketed key. The
+// worst switch decides: one switch out of headroom drops the cameras on that
+// switch, whatever the others have spare.
+type poeTally struct {
+	// switches is how many reported a budget and a readable port table.
+	switches int
+	// worst is the highest utilization anywhere, and worstSwitch the slug
+	// behind it.
+	worst       float64
+	worstKnown  bool
+	worstSwitch string
+	// draws is every switch's numbers, and unreadable the ones that reported a
+	// budget and would not say what they were delivering.
+	draws      []string
+	unreadable []string
+}
+
+// observe folds one adopted device into the tally. Devices with no PoE at all —
+// a gateway, an AP, the UPS — simply contribute nothing.
+func (t *poeTally) observe(d deviceRecord) {
+	draw := d.poe()
+	if draw.budget <= 0 {
+		return
+	}
+	name := slugify(d.Name)
+	if name == "" {
+		name = strings.ToLower(d.Model)
+	}
+	if !draw.measurable {
+		t.unreadable = append(t.unreadable, name+"="+strings.Join(draw.silent, "/")+
+			" of "+strconv.Itoa(draw.enabled)+" powered ports report no wattage")
+		return
+	}
+
+	t.switches++
+	used := draw.utilization()
+	t.draws = append(t.draws, name+"="+strconv.FormatFloat(draw.watts, 'f', 1, 64)+"/"+
+		strconv.FormatFloat(draw.budget, 'f', 0, 64)+"W")
+	if !t.worstKnown || used > t.worst {
+		t.worst, t.worstKnown, t.worstSwitch = used, true, name
+	}
+}
+
+// publishPoE buckets the worst switch's utilization against the threshold.
+func (c *Client) publishPoE(ctx context.Context, state map[string]string, t poeTally) {
+	log := logf.FromContext(ctx).WithName("unifi-poe")
+	if t.switches == 0 {
+		log.V(1).Info("No adopted switch reports a readable PoE budget; poe will not be published",
+			"switchesUnreadable", strings.Join(t.unreadable, ","))
+		return
+	}
+
+	maximum := c.MaxPoEUtilizationPercent
+	if maximum <= 0 {
+		maximum = DefaultMaxPoEUtilizationPercent
+	}
+
+	value := poeOK
+	if t.worst >= maximum {
+		value = poeInsufficient
+	}
+	state[stateKeyPoE] = value
+
+	log.V(1).Info("poe", "poe", value, "worstUtilizationPercent", t.worst,
+		"worstSwitch", t.worstSwitch, "thresholdPercent", maximum, "switchesMeasured", t.switches,
+		"draws", strings.Join(t.draws, ","), "switchesUnreadable", strings.Join(t.unreadable, ","))
+}

--- a/internal/providers/unifi/poe.go
+++ b/internal/providers/unifi/poe.go
@@ -50,6 +50,12 @@ const jsonNull = "null"
 // so both are written to the shape UniFi's API documents and to the names issue
 // #14 lists, and added to hack/capture-unifi.sh. See the live-verification list
 // in testdata/unifi/README.md.
+//
+// write.go reads this same port_table, untyped, to guard a power-cycle. The two
+// are deliberately separate — that one must refuse on any field it cannot read,
+// this one must tell absent from zero on every number, and neither could be the
+// other — but they share field names that Go cannot share through a struct tag.
+// TestBothPoEReadersAgreeOnOnePortTable is what fails if they drift apart.
 type poeFields struct {
 	// TotalMaxPower is the switch's whole PoE budget in watts: the denominator.
 	// A pointer, because a switch reporting no budget is not a switch with no

--- a/internal/providers/unifi/poe_shared_test.go
+++ b/internal/providers/unifi/poe_shared_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"encoding/json"
+	"testing"
+
+	reactorv1alpha1 "github.com/robbeverhelst/unifi-reactor/api/v1alpha1"
+)
+
+// Two things in this package read a switch's port_table, and they are
+// deliberately not the same reader.
+//
+// The write path (write.go) navigates map[string]any fetched through the UniFi
+// OS session, because it must not lose fields it does not know about, and it
+// refuses on any field it cannot read: a guard that silently stops applying is
+// worse than one that declines. The poe state key (poe.go) decodes a typed
+// struct from the API-key poll, because absent must be distinguishable from
+// zero on every number, and it omits its key rather than refusing anything.
+// Neither could be the other without giving up the property that makes it
+// correct.
+//
+// What they DO share is the field names, and Go cannot put a constant in a
+// struct tag — so `poe_enable` and `port_idx` are spelled in two files, and a
+// firmware that renamed one would be fixed in one place by whoever noticed.
+// This test is the thing that notices: one port table, both readers, and an
+// assertion that they agree about the same port.
+func TestBothPoEReadersAgreeOnOnePortTable(t *testing.T) {
+	// The documented shape, with poe_power as the string UniFi is documented to
+	// use. It carries every field either reader looks at, which is the point:
+	// this document is the contract between them.
+	const document = `{"data":[{
+		"mac": "aa:bb:cc:00:11:33", "model": "USW48P", "type": "usw",
+		"name": "Switch", "state": 1, "adopted": true,
+		"total_max_power": 195,
+		"port_table": [
+			{"port_idx": 1, "name": "uplink", "is_uplink": true,  "port_poe": true, "poe_enable": true,  "poe_power": "0.00"},
+			{"port_idx": 7, "name": "ap",     "is_uplink": false, "port_poe": true, "poe_enable": true,  "poe_power": "13.20"},
+			{"port_idx": 9, "name": "spare",  "is_uplink": false, "port_poe": true, "poe_enable": false, "poe_power": "0.00"}
+		]
+	}]}`
+
+	t.Run("the state key measures it", func(t *testing.T) {
+		var parsed deviceStatResponse
+		if err := json.Unmarshal([]byte(document), &parsed); err != nil {
+			t.Fatalf("typed decode: %v", err)
+		}
+		draw := parsed.Data[0].poe()
+		if !draw.measurable {
+			t.Fatalf("the switch should be measurable, got %+v", draw)
+		}
+		if draw.budget != 195 {
+			t.Errorf("budget = %v, want 195: total_max_power is the denominator", draw.budget)
+		}
+		// The uplink port reports 0.00 and the spare is not powered, so the
+		// whole draw is the one port delivering anything.
+		if draw.watts != 13.2 {
+			t.Errorf("watts = %v, want 13.2", draw.watts)
+		}
+		if draw.enabled != 2 {
+			t.Errorf("enabled = %d, want 2: poe_enable is what powering means to both readers", draw.enabled)
+		}
+	})
+
+	t.Run("the write path guards it", func(t *testing.T) {
+		var raw struct {
+			Data []map[string]any `json:"data"`
+		}
+		if err := json.Unmarshal([]byte(document), &raw); err != nil {
+			t.Fatalf("untyped decode: %v", err)
+		}
+		table := raw.Data[0][fieldPortTable]
+
+		port, found := portByIndex(table, testAPPort)
+		if !found {
+			t.Fatal("the write path did not find port 7; the two readers disagree about port_idx")
+		}
+		spec := reactorv1alpha1.PoEPort{Device: testSwitchMAC, Port: testAPPort, PortName: "ap"}
+		if err := checkPort(spec.Device, spec, port); err != nil {
+			t.Errorf("the write path refused a port the state key measures: %v", err)
+		}
+
+		// And the two floors still hold on the same document, which is what
+		// says the state key's decorations did not weaken the guard.
+		uplink, found := portByIndex(table, 1)
+		if !found {
+			t.Fatal("the write path did not find port 1")
+		}
+		uplinkSpec := reactorv1alpha1.PoEPort{Device: spec.Device, Port: 1, PortName: "uplink"}
+		if err := checkPort(uplinkSpec.Device, uplinkSpec, uplink); err == nil {
+			t.Error("cycling the uplink should be refused whatever else the record says")
+		}
+		off, found := portByIndex(table, 9)
+		if !found {
+			t.Fatal("the write path did not find port 9")
+		}
+		offSpec := reactorv1alpha1.PoEPort{Device: spec.Device, Port: 9, PortName: "spare"}
+		if err := checkPort(offSpec.Device, offSpec, off); err == nil {
+			t.Error("a port whose power is switched off should be refused")
+		}
+	})
+}
+
+// poe_enable means the same thing to both readers, and this is the assertion
+// that keeps it that way: the write path treats an explicit false as "nothing
+// to cycle", and the state key treats it as "this port draws nothing". A change
+// to either reading that did not change the other would show up here.
+func TestPoweredMeansTheSameToBothReaders(t *testing.T) {
+	const document = `{"data":[{
+		"mac": "aa:bb:cc:00:11:33", "type": "usw", "name": "Switch", "state": 1, "adopted": true,
+		"total_max_power": 60,
+		"port_table": [
+			{"port_idx": 3, "name": "camera", "is_uplink": false, "port_poe": true, "poe_enable": false, "poe_power": "0.00"}
+		]
+	}]}`
+
+	var parsed deviceStatResponse
+	if err := json.Unmarshal([]byte(document), &parsed); err != nil {
+		t.Fatalf("typed decode: %v", err)
+	}
+	if draw := parsed.Data[0].poe(); draw.enabled != 0 || draw.watts != 0 {
+		t.Errorf("an unpowered port should contribute nothing, got %+v", draw)
+	}
+
+	var raw struct {
+		Data []map[string]any `json:"data"`
+	}
+	if err := json.Unmarshal([]byte(document), &raw); err != nil {
+		t.Fatalf("untyped decode: %v", err)
+	}
+	port, found := portByIndex(raw.Data[0][fieldPortTable], 3)
+	if !found {
+		t.Fatal("the write path did not find port 3")
+	}
+	spec := reactorv1alpha1.PoEPort{Device: testSwitchMAC, Port: 3, PortName: "camera"}
+	if err := checkPort(spec.Device, spec, port); err == nil {
+		t.Error("the write path should refuse a port whose power is already off")
+	}
+}

--- a/internal/providers/unifi/poe_test.go
+++ b/internal/providers/unifi/poe_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// poweredSwitch is an adopted switch with a PoE budget and one port per wattage
+// given, each powering something.
+func poweredSwitch(name string, budget float64, watts ...float64) deviceRecord {
+	d := adoptedDevice(name, deviceStateOnline)
+	d.TotalMaxPower = &budget
+	enabled := true
+	for i, w := range watts {
+		index := i + 1
+		d.PortTable = append(d.PortTable, devicePort{
+			PortIdx:   &index,
+			PoEEnable: &enabled,
+			PoEPower:  flexibleNumber{Value: w, Known: true},
+			PoEClass:  "4",
+		})
+	}
+	return d
+}
+
+// switchWithPortsOff is an adopted switch whose ports are all PoE-disabled:
+// nothing plugged in, which is a draw of zero rather than a missing reading.
+func switchWithPortsOff(name string, budget float64, ports int) deviceRecord {
+	d := adoptedDevice(name, deviceStateOnline)
+	d.TotalMaxPower = &budget
+	off := false
+	for i := range ports {
+		index := i + 1
+		d.PortTable = append(d.PortTable, devicePort{PortIdx: &index, PoEEnable: &off})
+	}
+	return d
+}
+
+// poeState derives the poe key with a given threshold.
+func poeState(t *testing.T, threshold float64, devices ...deviceRecord) map[string]string {
+	t.Helper()
+	c := NewClient("", nil, "", false)
+	c.MaxPoEUtilizationPercent = threshold
+	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	return state
+}
+
+func TestPoEBuckets(t *testing.T) {
+	tests := []struct {
+		name    string
+		devices []deviceRecord
+		want    string
+	}{
+		{"plenty of headroom", []deviceRecord{
+			poweredSwitch("Switch 48", 60, 6.5, 7.2, 4.1),
+		}, poeOK},
+		{"exactly at the threshold", []deviceRecord{
+			poweredSwitch("Switch 48", 60, 54),
+		}, poeInsufficient},
+		{"over the threshold", []deviceRecord{
+			poweredSwitch("Switch 8", 60, 30, 28),
+		}, poeInsufficient},
+		// A switch with a budget and nothing plugged into it draws nothing, and
+		// that is a measurement rather than an absence.
+		{"nothing powered at all", []deviceRecord{
+			switchWithPortsOff("Switch 48", 60, 4),
+		}, poeOK},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := poeState(t, DefaultMaxPoEUtilizationPercent, tc.devices...)[stateKeyPoE]; got != tc.want {
+				t.Errorf("state[poe] = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The worst switch decides. One switch out of headroom drops the cameras on
+// that switch, whatever the rest of the rack has spare.
+func TestTheWorstSwitchDecides(t *testing.T) {
+	state := poeState(t, DefaultMaxPoEUtilizationPercent,
+		poweredSwitch("Switch 48", 400, 20, 15),
+		poweredSwitch("Switch 8", 60, 57))
+
+	if got := state[stateKeyPoE]; got != poeInsufficient {
+		t.Errorf("state[poe] = %q, want %q", got, poeInsufficient)
+	}
+}
+
+func TestCustomPoEThreshold(t *testing.T) {
+	device := poweredSwitch("Switch 48", 100, 70)
+
+	if got := poeState(t, 60, device)[stateKeyPoE]; got != poeInsufficient {
+		t.Errorf("state[poe] = %q at 70%% with a 60%% threshold, want %q", got, poeInsufficient)
+	}
+	if got := poeState(t, 95, device)[stateKeyPoE]; got != poeOK {
+		t.Errorf("state[poe] = %q at 70%% with a 95%% threshold, want %q", got, poeOK)
+	}
+}
+
+// Absent is not zero, in the direction that hides the failure: a port that is
+// powering something and will not say how much makes the whole switch
+// unreadable, because counting it as 0W would report headroom that is not there
+// — the exact situation this key exists to catch.
+func TestAPoweredPortWithNoWattageMakesTheSwitchUnreadable(t *testing.T) {
+	device := poweredSwitch("Switch 8", 60, 55)
+	enabled := true
+	index := 2
+	device.PortTable = append(device.PortTable, devicePort{
+		PortIdx: &index, PoEEnable: &enabled, PoEClass: "4",
+	})
+
+	state := poeState(t, DefaultMaxPoEUtilizationPercent, device)
+	if got, present := state[stateKeyPoE]; present {
+		t.Errorf("an unreadable switch should publish no poe key, got %q", got)
+	}
+
+	// And it must not drag a readable switch down with it: the other switch is
+	// still measured, so the key is published from what can be read.
+	both := poeState(t, DefaultMaxPoEUtilizationPercent, device, poweredSwitch("Switch 48", 400, 20))
+	if got := both[stateKeyPoE]; got != poeOK {
+		t.Errorf("state[poe] = %q, want %q from the switch that can be read", got, poeOK)
+	}
+}
+
+// A port that is off draws nothing, and that is a reading rather than an
+// absence — so a switch with disabled ports is measurable.
+func TestDisabledPortsAreNotUnreadable(t *testing.T) {
+	device := poweredSwitch("Switch 8", 60, 12)
+	off, index := false, 2
+	device.PortTable = append(device.PortTable, devicePort{PortIdx: &index, PoEEnable: &off})
+
+	if got := poeState(t, DefaultMaxPoEUtilizationPercent, device)[stateKeyPoE]; got != poeOK {
+		t.Errorf("state[poe] = %q, want %q", got, poeOK)
+	}
+}
+
+// A switch reporting no budget is not a switch with no budget, and it is
+// certainly not a division by zero. It contributes nothing.
+func TestMissingBudgetIsNotAZeroBudget(t *testing.T) {
+	device := poweredSwitch("Switch 8", 60, 12)
+	device.TotalMaxPower = nil
+
+	if got, present := poeState(t, DefaultMaxPoEUtilizationPercent, device)[stateKeyPoE]; present {
+		t.Errorf("a switch reporting no budget should publish no poe key, got %q", got)
+	}
+
+	zero := 0.0
+	device.TotalMaxPower = &zero
+	if got, present := poeState(t, DefaultMaxPoEUtilizationPercent, device)[stateKeyPoE]; present {
+		t.Errorf("a zero budget is not a denominator, got %q", got)
+	}
+}
+
+// Neither committed capture carries a port_table at all — the UPS 2U is a
+// switch-type device with no ports — so the key must be absent rather than ok.
+func TestNoSwitchPublishesNoPoEKey(t *testing.T) {
+	c := serve(t, merged(t, "stat-device-gateway.json", "stat-device-ups.json"))
+
+	state, err := c.Observe(context.Background())
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if got, present := state[stateKeyPoE]; present {
+		t.Errorf("no capture reports a PoE budget, so poe must be absent, got %q", got)
+	}
+}
+
+// UniFi is documented to report poe_power as a STRING on several firmwares and
+// as a number on others. Both have to decode, because getting it wrong makes an
+// entire switch's draw unreadable on half the world's consoles — and neither
+// null nor an unparseable value may become 0W.
+func TestPoEPowerDecodesAsBothAStringAndANumber(t *testing.T) {
+	tests := []struct {
+		json  string
+		value float64
+		known bool
+	}{
+		{`"3.90"`, 3.9, true},
+		{`3.9`, 3.9, true},
+		{`0`, 0, true},
+		{`"0.00"`, 0, true},
+		{jsonNull, 0, false},
+		{`""`, 0, false},
+		{`"n/a"`, 0, false},
+		{`{}`, 0, false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.json, func(t *testing.T) {
+			var got flexibleNumber
+			if err := json.Unmarshal([]byte(tc.json), &got); err != nil {
+				t.Fatalf("decoding %s: %v", tc.json, err)
+			}
+			if got.Known != tc.known || got.Value != tc.value {
+				t.Errorf("%s decoded to %+v, want {%v %v}", tc.json, got, tc.value, tc.known)
+			}
+		})
+	}
+}
+
+// The PoE fields have never been captured, so this asserts the decode of the
+// shape UniFi documents, with poe_power in its string form. It is a HYPOTHESIS
+// in code rather than a fixture, for the reason the failover variants are.
+func TestPoEDecodesTheDocumentedShape(t *testing.T) {
+	const documented = `{"data":[{
+		"model": "USW48P", "type": "usw", "name": "Switch 48", "state": 1, "adopted": true,
+		"total_max_power": 195,
+		"port_table": [
+			{"port_idx": 1, "poe_enable": true, "poe_power": "6.52", "poe_class": "Class 3", "poe_mode": "auto"},
+			{"port_idx": 2, "poe_enable": true, "poe_power": "13.20", "poe_class": "Class 4", "poe_mode": "auto"},
+			{"port_idx": 3, "poe_enable": false, "poe_power": "0.00", "poe_class": "Unknown", "poe_mode": "off"},
+			{"port_idx": 4}
+		]
+	}]}`
+
+	var parsed deviceStatResponse
+	if err := json.Unmarshal([]byte(documented), &parsed); err != nil {
+		t.Fatalf("parsing the documented shape: %v", err)
+	}
+	draw := parsed.Data[0].poe()
+	if !draw.measurable || draw.budget != 195 {
+		t.Fatalf("the documented shape did not decode: %+v", draw)
+	}
+	if draw.watts != 19.72 {
+		t.Errorf("watts = %v, want 19.72: only the powered ports count", draw.watts)
+	}
+	if draw.enabled != 2 {
+		t.Errorf("enabled = %d, want 2: a port with no poe_enable is not powering anything", draw.enabled)
+	}
+
+	c := NewClient("", nil, "", false)
+	state, err := c.stateFromDevices(context.Background(), parsed)
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	if state[stateKeyPoE] != poeOK {
+		t.Errorf("state[poe] = %q, want %q at 19.72W of 195W", state[stateKeyPoE], poeOK)
+	}
+}

--- a/internal/providers/unifi/poe_test.go
+++ b/internal/providers/unifi/poe_test.go
@@ -143,6 +143,18 @@ func TestAPoweredPortWithNoWattageMakesTheSwitchUnreadable(t *testing.T) {
 	}
 }
 
+// A budget with no port table beside it is a truncated record, not a switch
+// delivering nothing. Same rule as a silent port, one level up.
+func TestABudgetWithNoPortTableIsUnreadable(t *testing.T) {
+	device := adoptedDevice("Switch 8", deviceStateOnline)
+	budget := 60.0
+	device.TotalMaxPower = &budget
+
+	if got, present := poeState(t, DefaultMaxPoEUtilizationPercent, device)[stateKeyPoE]; present {
+		t.Errorf("a switch reporting no ports should publish no poe key, got %q", got)
+	}
+}
+
 // A port that is off draws nothing, and that is a reading rather than an
 // absence — so a switch with disabled ports is measurable.
 func TestDisabledPortsAreNotUnreadable(t *testing.T) {

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -33,6 +33,7 @@ const (
 	stateKeyDevices     = "devices"
 	stateKeyFirmware    = "firmware"
 	stateKeyTemperature = "temperature"
+	stateKeyWiFi        = "wifi"
 
 	// stateKeyDevicePrefix is what a per-device key is published under:
 	// device.<slugified name>. It is the first key on this list whose NAME is
@@ -83,8 +84,9 @@ const (
 
 	// The stat/health subsystems this provider reads. www is the console's own
 	// internet-reachability subsystem; wan carries the per-uplink uptime_stats.
-	healthSubsystemWWW = "www"
-	healthSubsystemWAN = "wan"
+	healthSubsystemWWW  = "www"
+	healthSubsystemWAN  = "wan"
+	healthSubsystemWLAN = "wlan"
 
 	// The per-subsystem status values. ok, warning and unknown are all present
 	// in the committed capture — on wan, wlan and vpn respectively — so the
@@ -146,20 +148,29 @@ const (
 	// V(1) log line.
 	temperatureNormal = "normal"
 	temperatureHigh   = "high"
+
+	// wifi is the WiFi subsystem as a whole, which is a different question from
+	// any single AP being down: error is every adopted AP gone, warning is some
+	// of them. It is derived from the console's AP counts rather than from its
+	// own status wording — see wifi.go for why, which #9 asks to be documented.
+	wifiOK      = "ok"
+	wifiWarning = "warning"
+	wifiError   = "error"
 )
 
 // The comparisons this provider makes between two independent signals for the
 // same fact, named so a disagreement can be counted without the values that
 // disagreed — which come from the outside world — becoming a metric label.
 const (
-	signalWANUplinkDisagrees = "wan-uplink-disagrees"
-	signalWANUplinkUnclaimed = "wan-uplink-unclaimed"
-	signalWANUplinkAmbiguous = "wan-uplink-ambiguous"
-	signalWANNotOnline       = "wan-not-online"
-	signalWANMovedWithoutISP = "wan-moved-without-isp"
-	signalISPMovedWithoutWAN = "isp-moved-without-wan"
-	signalWANHealthDisagrees = "wan-health-disagrees"
-	signalDeviceNameShared   = "device-name-shared"
+	signalWANUplinkDisagrees  = "wan-uplink-disagrees"
+	signalWANUplinkUnclaimed  = "wan-uplink-unclaimed"
+	signalWANUplinkAmbiguous  = "wan-uplink-ambiguous"
+	signalWANNotOnline        = "wan-not-online"
+	signalWANMovedWithoutISP  = "wan-moved-without-isp"
+	signalISPMovedWithoutWAN  = "isp-moved-without-wan"
+	signalWANHealthDisagrees  = "wan-health-disagrees"
+	signalDeviceNameShared    = "device-name-shared"
+	signalWiFiStatusDisagrees = "wifi-status-disagrees"
 )
 
 // StateVocabulary is the closed value set of every key this provider publishes
@@ -208,5 +219,6 @@ func StateVocabulary() map[string][]string {
 		stateKeyDevices:     {devicesAllOnline, devicesDegraded},
 		stateKeyFirmware:    {firmwareCurrent, firmwareUpdatesAvailable},
 		stateKeyTemperature: {temperatureNormal, temperatureHigh},
+		stateKeyWiFi:        {wifiOK, wifiWarning, wifiError},
 	}
 }

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -22,16 +22,17 @@ const (
 	// ProviderName is how Automations refer to this provider.
 	ProviderName = "unifi"
 
-	stateKeyWAN        = "wan"
-	stateKeyWANQuality = "wan.quality"
-	stateKeyISP        = "isp"
-	stateKeyInternet   = "internet"
-	stateKeyUPS        = "ups"
-	stateKeyUPSBattery = "ups.battery"
-	stateKeyUPSRuntime = "ups.runtime"
-	stateKeyUPSLoad    = "ups.load"
-	stateKeyDevices    = "devices"
-	stateKeyFirmware   = "firmware"
+	stateKeyWAN         = "wan"
+	stateKeyWANQuality  = "wan.quality"
+	stateKeyISP         = "isp"
+	stateKeyInternet    = "internet"
+	stateKeyUPS         = "ups"
+	stateKeyUPSBattery  = "ups.battery"
+	stateKeyUPSRuntime  = "ups.runtime"
+	stateKeyUPSLoad     = "ups.load"
+	stateKeyDevices     = "devices"
+	stateKeyFirmware    = "firmware"
+	stateKeyTemperature = "temperature"
 
 	// stateKeyDevicePrefix is what a per-device key is published under:
 	// device.<slugified name>. It is the first key on this list whose NAME is
@@ -137,6 +138,14 @@ const (
 	// into something that can page, notify or open a ticket, and stops there.
 	firmwareCurrent          = "current"
 	firmwareUpdatesAvailable = "updates-available"
+
+	// temperature buckets a measurement, exactly as wan.quality and ups.load
+	// do, and for the same two reasons: a number cannot be matched by spec.when,
+	// and it could never be a metric label. The hottest device in the fleet
+	// decides, against a configurable threshold; the readings behind it are a
+	// V(1) log line.
+	temperatureNormal = "normal"
+	temperatureHigh   = "high"
 )
 
 // The comparisons this provider makes between two independent signals for the
@@ -189,14 +198,15 @@ const (
 // and in a Kubernetes Event, exactly as isp's value does.
 func StateVocabulary() map[string][]string {
 	return map[string][]string{
-		stateKeyWAN:        {wanPrimary, wanBackup},
-		stateKeyWANQuality: {wanQualityGood, wanQualityDegraded},
-		stateKeyInternet:   {internetOK, internetDegraded, internetDown},
-		stateKeyUPS:        {upsOnline, upsOnBattery},
-		stateKeyUPSBattery: {batteryNormal, batteryLow, batteryCritical},
-		stateKeyUPSRuntime: {upsRuntimeAmple, upsRuntimeShort, upsRuntimeCritical},
-		stateKeyUPSLoad:    {upsLoadNormal, upsLoadHigh},
-		stateKeyDevices:    {devicesAllOnline, devicesDegraded},
-		stateKeyFirmware:   {firmwareCurrent, firmwareUpdatesAvailable},
+		stateKeyWAN:         {wanPrimary, wanBackup},
+		stateKeyWANQuality:  {wanQualityGood, wanQualityDegraded},
+		stateKeyInternet:    {internetOK, internetDegraded, internetDown},
+		stateKeyUPS:         {upsOnline, upsOnBattery},
+		stateKeyUPSBattery:  {batteryNormal, batteryLow, batteryCritical},
+		stateKeyUPSRuntime:  {upsRuntimeAmple, upsRuntimeShort, upsRuntimeCritical},
+		stateKeyUPSLoad:     {upsLoadNormal, upsLoadHigh},
+		stateKeyDevices:     {devicesAllOnline, devicesDegraded},
+		stateKeyFirmware:    {firmwareCurrent, firmwareUpdatesAvailable},
+		stateKeyTemperature: {temperatureNormal, temperatureHigh},
 	}
 }

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -34,6 +34,7 @@ const (
 	stateKeyFirmware    = "firmware"
 	stateKeyTemperature = "temperature"
 	stateKeyWiFi        = "wifi"
+	stateKeyPoE         = "poe"
 
 	// stateKeyDevicePrefix is what a per-device key is published under:
 	// device.<slugified name>. It is the first key on this list whose NAME is
@@ -156,6 +157,14 @@ const (
 	wifiOK      = "ok"
 	wifiWarning = "warning"
 	wifiError   = "error"
+
+	// poe buckets a budget, which is a measurement like temperature and
+	// ups.load. insufficient means the headroom is gone — the worst switch is
+	// delivering at or above the configured share of its budget — rather than
+	// that a port has already been denied power. By the time the console
+	// refuses a port, the camera is already off.
+	poeOK           = "ok"
+	poeInsufficient = "insufficient"
 )
 
 // The comparisons this provider makes between two independent signals for the
@@ -220,5 +229,6 @@ func StateVocabulary() map[string][]string {
 		stateKeyFirmware:    {firmwareCurrent, firmwareUpdatesAvailable},
 		stateKeyTemperature: {temperatureNormal, temperatureHigh},
 		stateKeyWiFi:        {wifiOK, wifiWarning, wifiError},
+		stateKeyPoE:         {poeOK, poeInsufficient},
 	}
 }

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -30,6 +30,13 @@ const (
 	stateKeyUPSBattery = "ups.battery"
 	stateKeyUPSRuntime = "ups.runtime"
 	stateKeyUPSLoad    = "ups.load"
+	stateKeyDevices    = "devices"
+
+	// stateKeyDevicePrefix is what a per-device key is published under:
+	// device.<slugified name>. It is the first key on this list whose NAME is
+	// open rather than whose values are, and that is why publishing them is
+	// opt-in — see the note on StateVocabulary below.
+	stateKeyDevicePrefix = "device."
 
 	wanPrimary = "primary"
 	wanBackup  = "backup"
@@ -110,6 +117,18 @@ const (
 	// could never be a metric label.
 	upsLoadNormal = "normal"
 	upsLoadHigh   = "high"
+
+	// device.<name> is whether the console is in contact with one adopted
+	// device. It is a switch position, not a measurement — the console either
+	// has a heartbeat from a device or it does not.
+	deviceOnline  = "online"
+	deviceOffline = "offline"
+
+	// devices is the fleet in one value, and it is the key most installs should
+	// match on: it says nothing about which device is missing, and it costs one
+	// series regardless of how many devices are adopted.
+	devicesAllOnline = "all-online"
+	devicesDegraded  = "degraded"
 )
 
 // The comparisons this provider makes between two independent signals for the
@@ -123,6 +142,7 @@ const (
 	signalWANMovedWithoutISP = "wan-moved-without-isp"
 	signalISPMovedWithoutWAN = "isp-moved-without-wan"
 	signalWANHealthDisagrees = "wan-health-disagrees"
+	signalDeviceNameShared   = "device-name-shared"
 )
 
 // StateVocabulary is the closed value set of every key this provider publishes
@@ -147,6 +167,18 @@ const (
 // distinct latency reading is the same cardinality failure isp would have
 // been. Bucketing into two named levels is what makes it a state key at all —
 // a number is not something spec.when can match either.
+//
+// device.<name> is absent for a third reason, and it is the reason this map is
+// keyed at all rather than being a list of values. Its VALUES are closed —
+// online and offline, two of them — but its key NAME is derived from a device
+// name, so the set of keys is open and only known at runtime. This map is
+// returned once at startup and cannot enumerate them, and enumerating them
+// would be the wrong thing to want: an install with forty adopted devices would
+// silently multiply its series count. So the per-device keys are opt-in
+// (Client.PerDeviceKeys), they are never labelled by value, and the aggregate
+// devices key — one series, whatever the fleet size — is what ships on by
+// default. What any single device currently is stays in the Automation's status
+// and in a Kubernetes Event, exactly as isp's value does.
 func StateVocabulary() map[string][]string {
 	return map[string][]string{
 		stateKeyWAN:        {wanPrimary, wanBackup},
@@ -156,5 +188,6 @@ func StateVocabulary() map[string][]string {
 		stateKeyUPSBattery: {batteryNormal, batteryLow, batteryCritical},
 		stateKeyUPSRuntime: {upsRuntimeAmple, upsRuntimeShort, upsRuntimeCritical},
 		stateKeyUPSLoad:    {upsLoadNormal, upsLoadHigh},
+		stateKeyDevices:    {devicesAllOnline, devicesDegraded},
 	}
 }

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -31,6 +31,7 @@ const (
 	stateKeyUPSRuntime = "ups.runtime"
 	stateKeyUPSLoad    = "ups.load"
 	stateKeyDevices    = "devices"
+	stateKeyFirmware   = "firmware"
 
 	// stateKeyDevicePrefix is what a per-device key is published under:
 	// device.<slugified name>. It is the first key on this list whose NAME is
@@ -129,6 +130,13 @@ const (
 	// series regardless of how many devices are adopted.
 	devicesAllOnline = "all-online"
 	devicesDegraded  = "degraded"
+
+	// firmware is whether the console has an update waiting for anything in the
+	// fleet. Observing is in scope and applying is not: Reactor never triggers
+	// an upgrade, so this key turns "I should check for UniFi updates sometime"
+	// into something that can page, notify or open a ticket, and stops there.
+	firmwareCurrent          = "current"
+	firmwareUpdatesAvailable = "updates-available"
 )
 
 // The comparisons this provider makes between two independent signals for the
@@ -189,5 +197,6 @@ func StateVocabulary() map[string][]string {
 		stateKeyUPSRuntime: {upsRuntimeAmple, upsRuntimeShort, upsRuntimeCritical},
 		stateKeyUPSLoad:    {upsLoadNormal, upsLoadHigh},
 		stateKeyDevices:    {devicesAllOnline, devicesDegraded},
+		stateKeyFirmware:   {firmwareCurrent, firmwareUpdatesAvailable},
 	}
 }

--- a/internal/providers/unifi/temperature.go
+++ b/internal/providers/unifi/temperature.go
@@ -122,6 +122,9 @@ func (d deviceRecord) instrumented() bool {
 // behind it are a V(1) log line — a temperature cannot be a state value at all,
 // since spec.when compares strings and one series per reading is unbounded.
 type temperatureTally struct {
+	// high is the reading at or above which the fleet reports high, taken from
+	// Client at construction so that publishing needs nothing but the tally.
+	high float64
 	// instrumented is how many adopted devices said anything about their
 	// thermals. Zero publishes no key.
 	instrumented int
@@ -138,6 +141,13 @@ type temperatureTally struct {
 	// fanless counts instrumented devices with no fan, which is why a warm one
 	// may be normal.
 	fanless int
+}
+
+func newTemperatureTally(high float64) temperatureTally {
+	if high <= 0 {
+		high = DefaultHighTemperatureCelsius
+	}
+	return temperatureTally{high: high}
 }
 
 // observe folds one adopted device into the tally.
@@ -172,16 +182,11 @@ func (t *temperatureTally) observe(ctx context.Context, d deviceRecord) {
 }
 
 // publish buckets the fleet's hottest reading against the threshold.
-func (c *Client) publishTemperature(ctx context.Context, state map[string]string, t temperatureTally) {
+func (t temperatureTally) publish(ctx context.Context, state map[string]string) {
 	log := logf.FromContext(ctx).WithName("unifi-temperature")
 	if t.instrumented == 0 {
 		log.V(1).Info("No adopted device reports its thermals; temperature will not be published")
 		return
-	}
-
-	high := c.HighTemperatureCelsius
-	if high <= 0 {
-		high = DefaultHighTemperatureCelsius
 	}
 
 	value := temperatureNormal
@@ -190,7 +195,7 @@ func (c *Client) publishTemperature(ctx context.Context, state map[string]string
 		// The console's own verdict wins over the threshold in this repository:
 		// the firmware knows this model's tolerances and a default does not.
 		value = temperatureHigh
-	case t.hottestKnown && t.hottest >= high:
+	case t.hottestKnown && t.hottest >= t.high:
 		value = temperatureHigh
 	}
 	state[stateKeyTemperature] = value
@@ -199,7 +204,7 @@ func (c *Client) publishTemperature(ctx context.Context, state map[string]string
 	// operator where to put their own threshold.
 	log.V(1).Info("temperature", "temperature", value, "hottestCelsius", t.hottest,
 		"hottestDevice", t.hottestDevice, "readingKnown", t.hottestKnown,
-		"thresholdCelsius", high, "devicesInstrumented", t.instrumented,
+		"thresholdCelsius", t.high, "devicesInstrumented", t.instrumented,
 		"devicesOverheating", strings.Join(t.overheating, ","), "devicesFanless", t.fanless,
 		"readings", strings.Join(t.readings, ","))
 }

--- a/internal/providers/unifi/temperature.go
+++ b/internal/providers/unifi/temperature.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// DefaultHighTemperatureCelsius is the reading at or above which the hottest
+// device in the fleet reports temperature: high.
+//
+// It is set against the debounce this key ships with, not in isolation, and the
+// #7 rule applies: move one and you have moved the other. 75 °C is well above
+// where UniFi switches and APs normally sit (40–60 °C in a ventilated rack) and
+// below where the console's own overheating flag is understood to trip, so 3
+// samples — 90 seconds at the default poll — is a reading that has genuinely
+// held rather than a fan spinning up late. Lower this towards the normal
+// operating range and 90 seconds of hysteresis stops being enough to mean
+// anything, because the reading will cross the line and stay there.
+const DefaultHighTemperatureCelsius = 75.0
+
+// temperatureFields are the fields the temperature key is derived from,
+// embedded in deviceRecord so they decode from the same flat object.
+//
+// NONE of these has been captured. The UPS 2U record has no thermal fields at
+// all — issue #11 notes it reports has_fan: false and no temperatures — and the
+// gateway record was allowlisted before any of this was parsed. So every field
+// here is written to the shape UniFi's API documents and to the names #11 lists,
+// and added to hack/capture-unifi.sh so a capture from a switch or an AP settles
+// them. See the live-verification list in testdata/unifi/README.md.
+type temperatureFields struct {
+	// HasTemperature is the console's statement that this device does thermal
+	// reporting at all, which is what makes a device with no readings distinct
+	// from a device that is not instrumented.
+	HasTemperature *bool `json:"has_temperature"`
+	// Overheating is the console's own verdict, and it is trusted directly:
+	// whatever threshold the firmware applies knows more about this model's
+	// tolerances than a number in this repository does.
+	Overheating *bool `json:"overheating"`
+	// HasFan is never derived from. It is a diagnostic: a hot fanless device and
+	// a hot device with a failed fan are different problems.
+	HasFan *bool `json:"has_fan"`
+	// Temperatures is the per-sensor table newer devices carry. Every value is a
+	// pointer for the reason this whole provider decodes numbers as pointers: a
+	// missing reading is not 0 °C, and reading it as one would report a cooking
+	// switch as the coldest thing in the rack — the direction that hides the
+	// failure this key exists to catch.
+	Temperatures []deviceTemperature `json:"temperatures"`
+	// GeneralTemperature is the single-value form older devices report instead.
+	GeneralTemperature *float64 `json:"general_temperature"`
+}
+
+// deviceTemperature is one sensor's reading. name and type are diagnostics —
+// "CPU" and "PHY" are different places on the same board — and neither is
+// derived from, because a sensor name could not be a state value.
+type deviceTemperature struct {
+	Name  string   `json:"name"`
+	Type  string   `json:"type"`
+	Value *float64 `json:"value"`
+}
+
+// hottest is the highest reading this device reports, and whether it reported
+// any. The per-sensor table wins over the single-value field where both are
+// present; the hottest sensor is the one that matters, since a board is as hot
+// as its hottest part.
+func (d deviceRecord) hottest() (float64, bool) {
+	hottest, known := 0.0, false
+	for _, sensor := range d.Temperatures {
+		if sensor.Value == nil {
+			continue
+		}
+		if !known || *sensor.Value > hottest {
+			hottest, known = *sensor.Value, true
+		}
+	}
+	if known {
+		return hottest, true
+	}
+	if d.GeneralTemperature != nil {
+		return *d.GeneralTemperature, true
+	}
+	return 0, false
+}
+
+// instrumented reports whether this device says anything about its own
+// thermals: it claims temperature reporting, it produced a reading, or it is
+// telling us it is overheating. A device that says none of those things is not a
+// device at 0 °C, and it contributes nothing.
+func (d deviceRecord) instrumented() bool {
+	if d.HasTemperature != nil && *d.HasTemperature {
+		return true
+	}
+	if _, known := d.hottest(); known {
+		return true
+	}
+	return d.Overheating != nil && *d.Overheating
+}
+
+// temperatureTally accumulates the fleet's thermals into one bucketed key.
+//
+// One key rather than one per device, for the same reason firmware is one key:
+// "is anything cooking" is the question, and a per-device thermal key would
+// multiply series by fleet size. The hottest device decides, and the numbers
+// behind it are a V(1) log line — a temperature cannot be a state value at all,
+// since spec.when compares strings and one series per reading is unbounded.
+type temperatureTally struct {
+	// instrumented is how many adopted devices said anything about their
+	// thermals. Zero publishes no key.
+	instrumented int
+	// hottest is the highest reading anywhere in the fleet, and hottestDevice
+	// the slug behind it.
+	hottest       float64
+	hottestKnown  bool
+	hottestDevice string
+	// overheating names the devices the console itself calls overheating, which
+	// is escalated regardless of what any reading says.
+	overheating []string
+	// readings is every device's hottest reading, for the diagnostic line.
+	readings []string
+	// fanless counts instrumented devices with no fan, which is why a warm one
+	// may be normal.
+	fanless int
+}
+
+// observe folds one adopted device into the tally.
+func (t *temperatureTally) observe(ctx context.Context, d deviceRecord) {
+	if !d.instrumented() {
+		return
+	}
+	t.instrumented++
+	name := slugify(d.Name)
+	if name == "" {
+		name = strings.ToLower(d.Model)
+	}
+	if d.HasFan != nil && !*d.HasFan {
+		t.fanless++
+	}
+	if d.Overheating != nil && *d.Overheating {
+		t.overheating = append(t.overheating, name)
+	}
+
+	reading, known := d.hottest()
+	if !known {
+		// Instrumented and silent: it claims thermal reporting and produced no
+		// number. That is a real thing to be — and it is not 0 °C.
+		logf.FromContext(ctx).WithName("unifi-temperature").V(1).Info(
+			"A device claims temperature reporting but published no reading", "device", name, "model", d.Model)
+		return
+	}
+	t.readings = append(t.readings, name+"="+strconv.FormatFloat(reading, 'f', 1, 64))
+	if !t.hottestKnown || reading > t.hottest {
+		t.hottest, t.hottestKnown, t.hottestDevice = reading, true, name
+	}
+}
+
+// publish buckets the fleet's hottest reading against the threshold.
+func (c *Client) publishTemperature(ctx context.Context, state map[string]string, t temperatureTally) {
+	log := logf.FromContext(ctx).WithName("unifi-temperature")
+	if t.instrumented == 0 {
+		log.V(1).Info("No adopted device reports its thermals; temperature will not be published")
+		return
+	}
+
+	high := c.HighTemperatureCelsius
+	if high <= 0 {
+		high = DefaultHighTemperatureCelsius
+	}
+
+	value := temperatureNormal
+	switch {
+	case len(t.overheating) > 0:
+		// The console's own verdict wins over the threshold in this repository:
+		// the firmware knows this model's tolerances and a default does not.
+		value = temperatureHigh
+	case t.hottestKnown && t.hottest >= high:
+		value = temperatureHigh
+	}
+	state[stateKeyTemperature] = value
+
+	// The raw numbers are diagnostics, not API. This is the line that tells an
+	// operator where to put their own threshold.
+	log.V(1).Info("temperature", "temperature", value, "hottestCelsius", t.hottest,
+		"hottestDevice", t.hottestDevice, "readingKnown", t.hottestKnown,
+		"thresholdCelsius", high, "devicesInstrumented", t.instrumented,
+		"devicesOverheating", strings.Join(t.overheating, ","), "devicesFanless", t.fanless,
+		"readings", strings.Join(t.readings, ","))
+}

--- a/internal/providers/unifi/temperature_test.go
+++ b/internal/providers/unifi/temperature_test.go
@@ -1,0 +1,243 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// sensorCPU is one sensor name in the documented per-sensor table. The names
+// are diagnostics — nothing is derived from them — so any one will do.
+const sensorCPU = "CPU"
+
+// warmDevice is an adopted device with a thermal sensor reporting one reading.
+func warmDevice(name string, celsius float64) deviceRecord {
+	d := adoptedDevice(name, deviceStateOnline)
+	instrumented, fan := true, true
+	d.temperatureFields = temperatureFields{
+		HasTemperature: &instrumented,
+		HasFan:         &fan,
+		Overheating:    new(bool),
+		Temperatures:   []deviceTemperature{{Name: sensorCPU, Type: "cpu", Value: &celsius}},
+	}
+	return d
+}
+
+// heatState derives the temperature key with a given threshold, so the
+// bucketing and the configurability are tested through the same path.
+func heatState(t *testing.T, threshold float64, devices ...deviceRecord) map[string]string {
+	t.Helper()
+	c := NewClient("", nil, "", false)
+	c.HighTemperatureCelsius = threshold
+	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	return state
+}
+
+func TestTemperatureBuckets(t *testing.T) {
+	tests := []struct {
+		name    string
+		devices []deviceRecord
+		want    string
+	}{
+		{"a cool rack", []deviceRecord{
+			warmDevice("Switch 48", 42),
+			warmDevice("AP Kitchen", 51),
+		}, temperatureNormal},
+		{"one device at the threshold", []deviceRecord{
+			warmDevice("Switch 48", 42),
+			warmDevice("AP Attic", 75),
+		}, temperatureHigh},
+		{"one device over it", []deviceRecord{
+			warmDevice("Switch 48", 81.5),
+		}, temperatureHigh},
+		{"just under it", []deviceRecord{
+			warmDevice("Switch 48", 74.9),
+		}, temperatureNormal},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := heatState(t, DefaultHighTemperatureCelsius, tc.devices...)[stateKeyTemperature]; got != tc.want {
+				t.Errorf("state[temperature] = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// The threshold is what an operator tunes against their own rack, so the same
+// reading has to be able to fall on either side of it.
+func TestCustomTemperatureThreshold(t *testing.T) {
+	device := warmDevice("Switch 48", 60)
+
+	if got := heatState(t, 55, device)[stateKeyTemperature]; got != temperatureHigh {
+		t.Errorf("state[temperature] = %q at 60 °C with a 55 °C threshold, want %q", got, temperatureHigh)
+	}
+	if got := heatState(t, 90, device)[stateKeyTemperature]; got != temperatureNormal {
+		t.Errorf("state[temperature] = %q at 60 °C with a 90 °C threshold, want %q", got, temperatureNormal)
+	}
+}
+
+// The hottest sensor on the hottest device decides. A board is as hot as its
+// hottest part, and averaging would let one cool sensor hide a cooking one.
+func TestTheHottestSensorDecides(t *testing.T) {
+	cool, hot := 45.0, 88.0
+	device := warmDevice("Switch 48", cool)
+	device.Temperatures = []deviceTemperature{
+		{Name: sensorCPU, Type: "cpu", Value: &cool},
+		{Name: "PHY", Type: "phy", Value: &hot},
+		{Name: "Board", Type: "board", Value: nil},
+	}
+
+	if got := heatState(t, DefaultHighTemperatureCelsius, device)[stateKeyTemperature]; got != temperatureHigh {
+		t.Errorf("state[temperature] = %q, want %q: the hottest sensor decides", got, temperatureHigh)
+	}
+}
+
+// The console's own verdict outranks the threshold in this repository: the
+// firmware knows what this model tolerates and a default does not.
+func TestOverheatingIsBelievedRegardlessOfTheReading(t *testing.T) {
+	overheating := true
+	device := warmDevice("AP Attic", 48)
+	device.Overheating = &overheating
+
+	if got := heatState(t, DefaultHighTemperatureCelsius, device)[stateKeyTemperature]; got != temperatureHigh {
+		t.Errorf("state[temperature] = %q, want %q: the console said it is overheating", got, temperatureHigh)
+	}
+}
+
+// A device that says it is overheating and reports no number at all is the case
+// that must not be missed, so the flag alone is enough to publish the key.
+func TestOverheatingWithoutAReadingStillPublishes(t *testing.T) {
+	overheating := true
+	device := adoptedDevice("AP Attic", deviceStateOnline)
+	device.Overheating = &overheating
+
+	if got := heatState(t, DefaultHighTemperatureCelsius, device)[stateKeyTemperature]; got != temperatureHigh {
+		t.Errorf("state[temperature] = %q, want %q", got, temperatureHigh)
+	}
+}
+
+// Absent is not zero, in the direction that matters most for this key: a device
+// reporting no temperature is not a device at 0 °C, and reading it as one would
+// make the fleet look coldest exactly when a sensor stops answering. The UPS
+// capture is a real example — issue #11 notes it has no thermal fields at all.
+func TestMissingTemperatureIsNotZeroDegrees(t *testing.T) {
+	c := serve(t, merged(t, "stat-device-gateway.json", "stat-device-ups.json"))
+
+	state, err := c.Observe(context.Background())
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	if got, present := state[stateKeyTemperature]; present {
+		t.Errorf("neither capture reports thermals, so temperature must be absent, got %q", got)
+	}
+
+	// And the same at the level below: a sensor with a null value contributes
+	// nothing rather than dragging the maximum down to zero.
+	hot := 82.0
+	device := warmDevice("Switch 48", hot)
+	device.Temperatures = []deviceTemperature{{Name: sensorCPU, Value: nil}, {Name: "PHY", Value: &hot}}
+	if got := heatState(t, DefaultHighTemperatureCelsius, device)[stateKeyTemperature]; got != temperatureHigh {
+		t.Errorf("state[temperature] = %q, want %q: a null sensor is not 0 °C", got, temperatureHigh)
+	}
+}
+
+// A device that claims thermal reporting and then publishes nothing is
+// instrumented and silent. It keeps the key alive — something is reporting — and
+// contributes no reading, rather than being read as cold or dropping the key.
+func TestAnInstrumentedDeviceWithNoReadingKeepsTheKey(t *testing.T) {
+	instrumented := true
+	silent := adoptedDevice("Switch 48", deviceStateOnline)
+	silent.HasTemperature = &instrumented
+
+	state := heatState(t, DefaultHighTemperatureCelsius, silent)
+	if got := state[stateKeyTemperature]; got != temperatureNormal {
+		t.Errorf("state[temperature] = %q, want %q", got, temperatureNormal)
+	}
+}
+
+// The single-value form older devices report instead of a sensor table.
+func TestGeneralTemperatureIsReadWhenThereIsNoTable(t *testing.T) {
+	celsius := 79.0
+	device := adoptedDevice("Old Switch", deviceStateOnline)
+	instrumented := true
+	device.HasTemperature, device.GeneralTemperature = &instrumented, &celsius
+
+	if got := heatState(t, DefaultHighTemperatureCelsius, device)[stateKeyTemperature]; got != temperatureHigh {
+		t.Errorf("state[temperature] = %q, want %q", got, temperatureHigh)
+	}
+}
+
+// Unadopted devices are outside every fleet key, temperature included.
+func TestTemperatureIgnoresUnadoptedDevices(t *testing.T) {
+	neighbour := warmDevice("Neighbour AP", 95)
+	neighbour.Adopted = nil
+
+	state := heatState(t, DefaultHighTemperatureCelsius, warmDevice("Switch 48", 40), neighbour)
+	if got := state[stateKeyTemperature]; got != temperatureNormal {
+		t.Errorf("state[temperature] = %q, want %q", got, temperatureNormal)
+	}
+}
+
+// The thermal fields have never been captured, so this asserts the decode of
+// the shape UniFi documents. It is a HYPOTHESIS and it lives in code for the
+// same reason the failover variants do: a file under testdata/ claims to have
+// come off a console, and this has not. Both documented forms are covered —
+// the per-sensor table and the single general_temperature field.
+func TestTemperatureDecodesTheDocumentedShape(t *testing.T) {
+	const documented = `{"data":[
+		{
+			"model": "USW48", "type": "usw", "name": "Switch 48", "state": 1, "adopted": true,
+			"has_temperature": true, "has_fan": true, "overheating": false,
+			"temperatures": [
+				{"name": "CPU", "type": "cpu", "value": 62.5},
+				{"name": "PHY", "type": "phy", "value": 78.25},
+				{"name": "System", "type": "board", "value": null}
+			]
+		},
+		{
+			"model": "UAPFLEXHD", "type": "uap", "name": "AP Kitchen", "state": 1, "adopted": true,
+			"has_temperature": true, "has_fan": false, "overheating": false,
+			"general_temperature": 55
+		}
+	]}`
+
+	var parsed deviceStatResponse
+	if err := json.Unmarshal([]byte(documented), &parsed); err != nil {
+		t.Fatalf("parsing the documented shape: %v", err)
+	}
+	if got, known := parsed.Data[0].hottest(); !known || got != 78.25 {
+		t.Errorf("the sensor table decoded to (%v, %v), want (78.25, true)", got, known)
+	}
+	if got, known := parsed.Data[1].hottest(); !known || got != 55 {
+		t.Errorf("general_temperature decoded to (%v, %v), want (55, true)", got, known)
+	}
+
+	c := NewClient("", nil, "", false)
+	state, err := c.stateFromDevices(context.Background(), parsed)
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	if state[stateKeyTemperature] != temperatureHigh {
+		t.Errorf("state[temperature] = %q, want %q at 78.25 °C against a 75 °C default",
+			state[stateKeyTemperature], temperatureHigh)
+	}
+}

--- a/internal/providers/unifi/wifi.go
+++ b/internal/providers/unifi/wifi.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
+)
+
+// wifiFrom derives the wifi key from the wlan subsystem's own counts.
+//
+// It is derived from num_disconnected and num_adopted rather than from the
+// subsystem's status string, and #9 asks for that choice to be documented
+// rather than left mysterious. Three reasons:
+//
+//   - The counts are a fact this provider can explain. "warning" is a word
+//     whose rule lives in the console's firmware, and an operator asking why
+//     wifi is warning deserves an answer better than "UniFi said so".
+//   - error becomes derivable. No capture has ever shown any subsystem saying
+//     "error", so mapping it through would be inference; "every adopted AP is
+//     disconnected" is an observation, and it is what error means here.
+//   - The two agree in the only capture there is — status "warning" with 1 of 3
+//     adopted APs disconnected — so this is a sharpening of the console's
+//     verdict rather than a disagreement with it.
+//
+// The status string is still read, and a mismatch is counted and logged. That
+// is the same third-opinion pattern the wan mapping uses: two independent
+// signals for one fact, neither silently trusted.
+//
+// An empty result means the wlan subsystem said nothing this provider can act
+// on, and the key is omitted rather than guessed.
+func wifiFrom(ctx context.Context, subsystem healthSubsystem) string {
+	log := logf.FromContext(ctx).WithName("unifi-wifi")
+
+	adopted, disconnected := subsystem.NumAdopted, subsystem.NumDisconnected
+	if adopted == nil || disconnected == nil {
+		log.V(1).Info("The wlan subsystem reports no AP counts; wifi will not be published",
+			"status", subsystem.Status)
+		return ""
+	}
+	if *adopted == 0 {
+		// No access points adopted at all. There is no WiFi here to be healthy
+		// or unhealthy, which is "omit what you cannot see" rather than ok.
+		log.V(1).Info("No access point is adopted; wifi will not be published")
+		return ""
+	}
+
+	wifi := wifiOK
+	switch {
+	case *disconnected >= *adopted:
+		// Every adopted AP is out of contact. This is what error means here,
+		// and deriving it is why the vendor's own status is not the source:
+		// "error" has never been captured on any subsystem.
+		wifi = wifiError
+	case *disconnected > 0:
+		wifi = wifiWarning
+	}
+
+	// num_ap is the count of APs actually connected: in the capture it is 2
+	// alongside 3 adopted and 1 disconnected, which is the arithmetic that says
+	// num_adopted is the right denominator. It is logged rather than derived
+	// from, so that a firmware where it stops adding up is visible here first.
+	log.V(1).Info("wifi", "wifi", wifi, "adopted", *adopted, "disconnected", *disconnected,
+		"connected", derefInt(subsystem.NumAP), "consoleStatus", subsystem.Status)
+
+	crossCheckWiFiStatus(ctx, wifi, subsystem.Status)
+	return wifi
+}
+
+// crossCheckWiFiStatus reports when the console's own wlan status and the value
+// derived from its counts disagree.
+//
+// Nothing is resolved here: the counts stay the source, because they are the
+// half that can be explained. What this buys is that if UniFi's wording turns
+// out to mean something else — a "warning" that is about airtime or channel
+// interference rather than about an AP being gone — the count rises instead of
+// the derivation quietly being wrong.
+func crossCheckWiFiStatus(ctx context.Context, derived, status string) {
+	if status == "" {
+		return
+	}
+	fromStatus := ""
+	switch status {
+	case healthStatusOK:
+		fromStatus = wifiOK
+	case healthStatusWarning:
+		fromStatus = wifiWarning
+	case healthStatusError:
+		fromStatus = wifiError
+	default:
+		// A status this provider does not recognise is not a disagreement: it
+		// is a vocabulary it has never seen, and the counts stand on their own.
+		logf.FromContext(ctx).WithName("unifi-wifi").V(1).Info(
+			"The wlan subsystem reports an unfamiliar status; wifi is derived from the AP counts regardless",
+			"status", status, "wifi", derived)
+		return
+	}
+	if fromStatus == derived {
+		return
+	}
+	metrics.SignalsDisagreed(ProviderName, signalWiFiStatusDisagrees)
+	logf.FromContext(ctx).WithName("unifi-wifi").Info(
+		"The console's own wlan status and the value derived from its AP counts disagree; "+
+			"the counts are what wifi reports, because they are the half that can be explained",
+		"wifi", derived, "consoleStatus", status, "consoleStatusWouldBe", fromStatus)
+}

--- a/internal/providers/unifi/wifi_test.go
+++ b/internal/providers/unifi/wifi_test.go
@@ -1,0 +1,191 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"testing"
+)
+
+// counts sets the wlan subsystem's AP counts on a decoded capture.
+func counts(t *testing.T, health *healthResponse, adopted, disconnected, connected int) {
+	t.Helper()
+	wlan := subsystem(t, health, healthSubsystemWLAN)
+	wlan.NumAdopted, wlan.NumDisconnected, wlan.NumAP = &adopted, &disconnected, &connected
+}
+
+// The capture was taken with 3 APs adopted, 1 disconnected and 2 connected, and
+// the console calling the subsystem "warning". Both signals agree on that
+// reading, which is the whole reason the counts are trusted as the sharper of
+// the two rather than as a contradiction of it.
+func TestWiFiAgainstTheCapture(t *testing.T) {
+	health := capturedHealth(t)
+	wlan := subsystem(t, &health, healthSubsystemWLAN)
+	if wlan.Status != healthStatusWarning {
+		t.Fatalf("the capture's wlan status is %q, expected %q — this test is written against it",
+			wlan.Status, healthStatusWarning)
+	}
+	if wlan.NumAdopted == nil || *wlan.NumAdopted != 3 ||
+		wlan.NumDisconnected == nil || *wlan.NumDisconnected != 1 ||
+		wlan.NumAP == nil || *wlan.NumAP != 2 {
+		t.Fatalf("the capture's wlan counts are not the 3/1/2 this test is written against: %+v", wlan)
+	}
+
+	before := disagreements(t, signalWiFiStatusDisagrees)
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+
+	if state[stateKeyWiFi] != wifiWarning {
+		t.Errorf("state[wifi] = %q, want %q", state[stateKeyWiFi], wifiWarning)
+	}
+	if after := disagreements(t, signalWiFiStatusDisagrees); after != before {
+		t.Errorf("the capture's two signals agree, so nothing should be counted: %v -> %v", before, after)
+	}
+}
+
+func TestWiFiFromTheAPCounts(t *testing.T) {
+	tests := []struct {
+		name                  string
+		adopted, disconnected int
+		want                  string
+	}{
+		{"every AP connected", 3, 0, wifiOK},
+		{"one of three gone", 3, 1, wifiWarning},
+		{"two of three gone", 3, 2, wifiWarning},
+		{"every AP gone", 3, 3, wifiError},
+		{"the only AP gone", 1, 1, wifiError},
+		{"a single healthy AP", 1, 0, wifiOK},
+	}
+	c := NewClient("", nil, "", false)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			health := capturedHealth(t)
+			counts(t, &health, tc.adopted, tc.disconnected, tc.adopted-tc.disconnected)
+			// The console's own status is moved out of the way, so this test is
+			// about the derivation rather than about the cross-check.
+			subsystem(t, &health, healthSubsystemWLAN).Status = ""
+
+			if got := mergedHealth(t, c, health, wanPrimary)[stateKeyWiFi]; got != tc.want {
+				t.Errorf("state[wifi] = %q with %d adopted and %d disconnected, want %q",
+					got, tc.adopted, tc.disconnected, tc.want)
+			}
+		})
+	}
+}
+
+// A site with no access points has no WiFi to be healthy or unhealthy. Omit
+// what you cannot see: zero adopted is not ok.
+func TestNoAccessPointsPublishesNoWiFiKey(t *testing.T) {
+	health := capturedHealth(t)
+	counts(t, &health, 0, 0, 0)
+
+	if got, present := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)[stateKeyWiFi]; present {
+		t.Errorf("a site with no adopted AP should publish no wifi key, got %q", got)
+	}
+}
+
+// Absent is not zero, on the health half: a subsystem reporting no counts is
+// not a subsystem with no APs, and it must not be read as either "ok" or "every
+// AP is down".
+func TestMissingAPCountsPublishNoWiFiKey(t *testing.T) {
+	c := NewClient("", nil, "", false)
+	for _, drop := range []struct {
+		name                  string
+		adopted, disconnected bool
+	}{
+		{"no adopted count", true, false},
+		{"no disconnected count", false, true},
+		{"neither count", true, true},
+	} {
+		t.Run(drop.name, func(t *testing.T) {
+			health := capturedHealth(t)
+			wlan := subsystem(t, &health, healthSubsystemWLAN)
+			if drop.adopted {
+				wlan.NumAdopted = nil
+			}
+			if drop.disconnected {
+				wlan.NumDisconnected = nil
+			}
+
+			if got, present := mergedHealth(t, c, health, wanPrimary)[stateKeyWiFi]; present {
+				t.Errorf("missing counts should publish no wifi key, got %q", got)
+			}
+		})
+	}
+}
+
+// A console whose wlan subsystem disappears entirely — the same per-key
+// degradation a UPS dropping off produces. internet and wan.quality are
+// unaffected, and an Automation matching wifi holds its last known state.
+func TestWiFiDegradesWithoutTakingTheOtherHealthKeys(t *testing.T) {
+	health := capturedHealth(t)
+	var kept []healthSubsystem
+	for _, s := range health.Data {
+		if s.Subsystem != healthSubsystemWLAN {
+			kept = append(kept, s)
+		}
+	}
+	health.Data = kept
+
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+	if got, present := state[stateKeyWiFi]; present {
+		t.Errorf("wifi should be absent when the wlan subsystem is, got %q", got)
+	}
+	for key, want := range map[string]string{
+		stateKeyInternet:   internetOK,
+		stateKeyWANQuality: wanQualityGood,
+	} {
+		if state[key] != want {
+			t.Errorf("state[%q] = %q, want %q: the other health keys are a separate observation", key, state[key], want)
+		}
+	}
+}
+
+// The console's own status is a second, independent opinion. When it and the
+// counts disagree the counts win — they are the half that can be explained —
+// and the disagreement is counted rather than swallowed, so a firmware whose
+// "warning" means something else announces itself.
+func TestTheConsolesOwnStatusIsCrossCheckedRatherThanTrusted(t *testing.T) {
+	before := disagreements(t, signalWiFiStatusDisagrees)
+
+	health := capturedHealth(t)
+	counts(t, &health, 3, 0, 3)
+	subsystem(t, &health, healthSubsystemWLAN).Status = healthStatusWarning
+
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+	if state[stateKeyWiFi] != wifiOK {
+		t.Errorf("state[wifi] = %q, want %q: every adopted AP is connected", state[stateKeyWiFi], wifiOK)
+	}
+	if after := disagreements(t, signalWiFiStatusDisagrees); after <= before {
+		t.Errorf("the disagreement should be counted, %v -> %v", before, after)
+	}
+}
+
+// An unfamiliar status is not a disagreement — it is a vocabulary this provider
+// has never seen — and the counts stand on their own regardless.
+func TestAnUnfamiliarWiFiStatusIsNotADisagreement(t *testing.T) {
+	before := disagreements(t, signalWiFiStatusDisagrees)
+
+	health := capturedHealth(t)
+	counts(t, &health, 2, 0, 2)
+	subsystem(t, &health, healthSubsystemWLAN).Status = "degraded-somehow"
+
+	if got := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)[stateKeyWiFi]; got != wifiOK {
+		t.Errorf("state[wifi] = %q, want %q", got, wifiOK)
+	}
+	if after := disagreements(t, signalWiFiStatusDisagrees); after != before {
+		t.Errorf("an unrecognised status is not a disagreement, %v -> %v", before, after)
+	}
+}

--- a/internal/providers/unifi/write.go
+++ b/internal/providers/unifi/write.go
@@ -68,6 +68,11 @@ const (
 	// The device and port_table fields the PoE check reads. Every one of them
 	// is a refusal if it is absent: a guard that silently does not apply is
 	// worse than one that declines.
+	//
+	// poe.go reads the same port_table through a typed struct to measure the
+	// PoE budget for the poe state key. That reader omits its key where this
+	// one refuses, which is why they are not one decoder;
+	// TestBothPoEReadersAgreeOnOnePortTable holds them to the same field names.
 	fieldMAC       = "mac"
 	fieldPortTable = "port_table"
 	fieldPortIndex = "port_idx"

--- a/test/e2e/harness/mock.go
+++ b/test/e2e/harness/mock.go
@@ -175,6 +175,37 @@ func (m *Mock) Internet(query string) error { return m.post("/internet?" + query
 // to go back to the capture.
 func (m *Mock) Quality(query string) error { return m.post("/quality?" + query) }
 
+// Device drives one adopted device's fleet fields, which the devices and
+// device.<name> keys are derived from: name=<slug> plus state=online|offline,
+// adopted=<bool>, rename=<new name>, or present=false to take it off the
+// console entirely. reset=true puts every device back to the capture.
+//
+// A device is addressed by the slug of the name it was CAPTURED under, even
+// after a rename, which is what makes the rename rehearsal reversible.
+func (m *Mock) Device(query string) error { return m.post("/device?" + query) }
+
+// Firmware drives the upgrade fields: upgradable=<bool>, eol=<bool>,
+// name=<slug> to move one device rather than all of them, present=false to stop
+// reporting the field at all — which is the state every committed capture is
+// in, and therefore the mock's own default.
+func (m *Mock) Firmware(query string) error { return m.post("/firmware?" + query) }
+
+// Temperature drives the thermal fields: celsius=<reading>, overheating=<bool>,
+// general=true for the single-value form, present=false for a device reporting
+// no thermals. Nothing is served until this is called, because no capture
+// carries a thermal field.
+func (m *Mock) Temperature(query string) error { return m.post("/temperature?" + query) }
+
+// WiFi drives the wlan subsystem's AP counts, which the wifi key is derived
+// from: adopted=<n>, disconnected=<n>, present=false to remove the subsystem.
+// status=<word> moves the console's own wording without moving the counts,
+// which is how the disagreement path is rehearsed.
+func (m *Mock) WiFi(query string) error { return m.post("/wifi?" + query) }
+
+// PoE drives the PoE budget and draw: watts=<n>, budget=<n>, silent=true for a
+// powered port that reports no wattage, present=false for no PoE fields at all.
+func (m *Mock) PoE(query string) error { return m.post("/poe?" + query) }
+
 // Reachable reports whether the mock is answering yet.
 func (m *Mock) Reachable() error {
 	return m.request(http.MethodGet, "/proxy/network/api/s/default/stat/device")

--- a/test/e2e/reaction/fleet_test.go
+++ b/test/e2e/reaction/fleet_test.go
@@ -1,0 +1,327 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaction
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Each key in this batch is observed through an Automation that matches on it,
+// because a key that nothing can react to is not a feature. The provider's own
+// tests cover the derivations; these cover the round trip — rehearsed console,
+// poll, debounce, condition, action — for keys whose failure modes are all
+// about what happens when something stops being reported.
+//
+// The console starts from the captures, where firmware, temperature and PoE are
+// not reported at all. That is deliberate: the first assertion of each block is
+// that the key is absent, which is the state a real install of this version
+// against a real console is in until those fields are confirmed to exist.
+var _ = Describe("Reacting to the fleet, firmware, thermals, WiFi and PoE", Ordered, func() {
+	const (
+		fleetJob     = "fleet-batch"
+		deviceJob    = "device-batch"
+		firmwareJob  = "firmware-batch"
+		thermalJob   = "thermal-batch"
+		wifiJob      = "wifi-batch"
+		poeJob       = "poe-batch"
+		fleetPolicy  = "hold-on-degraded-fleet"
+		devicePolicy = "hold-on-ups-offline"
+		firmwarePol  = "hold-on-updates"
+		thermalPol   = "shed-when-hot"
+		wifiPolicy   = "hold-on-wifi-warning"
+		poePolicy    = "shed-when-poe-tight"
+		baseline     = 2
+	)
+
+	degradedFleet := map[string]string{keyDevices: devicesDegraded}
+	upsOffline := map[string]string{keyUPSDevice: deviceOffline}
+	updatesWaiting := map[string]string{keyFirmware: firmwareUpdates}
+	tooHot := map[string]string{keyTemperature: temperatureHigh}
+	wifiDegraded := map[string]string{keyWiFi: wifiWarning}
+	noHeadroom := map[string]string{keyPoE: poeInsufficient}
+
+	policies := []struct {
+		name   string
+		when   map[string]string
+		target string
+	}{
+		{fleetPolicy, degradedFleet, fleetJob},
+		{devicePolicy, upsOffline, deviceJob},
+		{firmwarePol, updatesWaiting, firmwareJob},
+		{thermalPol, tooHot, thermalJob},
+		{wifiPolicy, wifiDegraded, wifiJob},
+		{poePolicy, noHeadroom, poeJob},
+	}
+
+	BeforeAll(func() {
+		resetConsole()
+		// The capture itself has one of three access points disconnected, so
+		// the console's own baseline is wifi: warning. This block starts from a
+		// healthy one and breaks it deliberately, rather than beginning
+		// half-broken.
+		Expect(mock.WiFi("adopted=3&disconnected=0")).To(Succeed())
+		for _, policy := range policies {
+			Expect(cluster.Apply(workload(policy.target, baseline))).To(Succeed())
+			Expect(cluster.Apply(scaleAutomation(policy.name, policy.when, policy.target, 0))).To(Succeed())
+		}
+		Eventually(func(g Gomega) {
+			for _, policy := range policies {
+				g.Expect(conditionOf(automationOf(g, policy.name), conditionReady)).NotTo(BeNil())
+			}
+		}).Should(Succeed())
+	})
+
+	// Every claim is released through a HEALTHY observation rather than through
+	// resetConsole, and the difference matters: reset makes these keys vanish,
+	// and a key that vanishes while its Automation is matching holds the claim
+	// instead of releasing it. That is the behaviour half this file exists to
+	// prove, and it would hang the teardown of the other half.
+	AfterAll(func() {
+		Expect(mock.WiFi("adopted=3&disconnected=0")).To(Succeed())
+		Expect(mock.Temperature("celsius=45")).To(Succeed())
+		Expect(mock.PoE("watts=12&budget=60&silent=false")).To(Succeed())
+		Expect(mock.Firmware("upgradable=false")).To(Succeed())
+		Expect(mock.Device("reset=true")).To(Succeed())
+		Eventually(func(g Gomega) {
+			for _, policy := range policies {
+				g.Expect(replicasOf(g, policy.target)).To(BeEquivalentTo(baseline))
+			}
+		}).Should(Succeed())
+		for _, policy := range policies {
+			Expect(cluster.Delete(scaleAutomation(policy.name, policy.when, policy.target, 0))).To(Succeed())
+		}
+		resetConsole()
+	})
+
+	// The capture has two adopted devices, both online, and no upgrade, thermal
+	// or PoE field anywhere. A console in that state must publish the two keys
+	// it can and none of the three it cannot.
+	It("reports the captured console as a healthy fleet, and says nothing about what it cannot see", func() {
+		Eventually(func(g Gomega) {
+			state := automationOf(g, fleetPolicy).Status.ObservedState
+			g.Expect(state).To(HaveKeyWithValue(keyDevices, devicesAllOnline))
+			g.Expect(automationOf(g, devicePolicy).Status.ObservedState).
+				To(HaveKeyWithValue(keyUPSDevice, deviceOnline))
+			g.Expect(automationOf(g, wifiPolicy).Status.ObservedState).
+				To(HaveKeyWithValue(keyWiFi, wifiOK))
+		}).Should(Succeed())
+
+		By("withholding the keys whose fields no capture contains")
+		for _, policy := range []struct {
+			name string
+			key  string
+		}{{firmwarePol, keyFirmware}, {thermalPol, keyTemperature}, {poePolicy, keyPoE}} {
+			ready := conditionOf(automationOf(Default, policy.name), conditionReady)
+			Expect(ready).NotTo(BeNil())
+			Expect(ready.Reason).To(Equal("StateKeyUnavailable"),
+				"%s should report the key it needs as unavailable, not react to a value nobody observed", policy.key)
+		}
+
+		Consistently(func(g Gomega) {
+			for _, policy := range policies {
+				g.Expect(replicasOf(g, policy.target)).To(BeEquivalentTo(baseline))
+			}
+		}).Should(Succeed())
+	})
+
+	// The capture's own wlan subsystem is the first half of this: 1 of 3 adopted
+	// access points disconnected, which is what a real console was reporting
+	// when it was captured.
+	//
+	// The second half is the caveat every three-value key carries, and it is the
+	// same one `internet: ok | degraded | down` has: an Automation matching
+	// `warning` stops matching at `error`, because those are different values of
+	// one key rather than steps of a ladder. Match the value you mean.
+	It("sheds while access points are missing, and reports all of them gone as a different value", func() {
+		By("restoring the capture: 1 of 3 access points disconnected")
+		Expect(mock.WiFi("reset=true")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(automationOf(g, wifiPolicy).Status.ObservedState).To(HaveKeyWithValue(keyWiFi, wifiWarning))
+			g.Expect(replicasOf(g, wifiJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		By("losing all of them, which is error rather than a worse warning")
+		Expect(mock.WiFi("adopted=3&disconnected=3")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(automationOf(g, wifiPolicy).Status.ObservedState).To(HaveKeyWithValue(keyWiFi, wifiError))
+			// An Automation matching `warning` no longer matches, so its claim
+			// is released. Anyone wanting to react to the whole WLAN being gone
+			// writes `wifi: error` — the values are alternatives, not degrees.
+			g.Expect(replicasOf(g, wifiJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+
+		By("bringing every access point back")
+		Expect(mock.WiFi("disconnected=0")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(automationOf(g, wifiPolicy).Status.ObservedState).To(HaveKeyWithValue(keyWiFi, wifiOK))
+			g.Expect(replicasOf(g, wifiJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+	})
+
+	It("reacts to a device going offline, on both the fleet key and the device's own", func() {
+		Expect(mock.Device("name=ups-2u&state=offline")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, fleetJob)).To(BeEquivalentTo(0))
+			g.Expect(replicasOf(g, deviceJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		state := automationOf(Default, fleetPolicy).Status.ObservedState
+		Expect(state).To(HaveKeyWithValue(keyDevices, devicesDegraded))
+		Expect(automationOf(Default, devicePolicy).Status.ObservedState).
+			To(HaveKeyWithValue(keyUPSDevice, deviceOffline))
+	})
+
+	// #8's acceptance criterion, and the reason the reconciler's hold-state
+	// behaviour matters here more than anywhere else: a device name is a key
+	// name, so renaming a switch on the console deletes a key. That must read as
+	// lost visibility, not as recovery.
+	It("holds its claim when a device is renamed out from under the key", func() {
+		Expect(mock.Device("name=ups-2u&rename=Rack+Power")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			ready := conditionOf(automationOf(g, devicePolicy), conditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+			g.Expect(ready.Reason).To(Equal("StateKeyUnavailable"))
+			g.Expect(ready.Message).To(ContainSubstring(keyUPSDevice))
+		}).Should(Succeed())
+
+		Consistently(func(g Gomega) {
+			g.Expect(replicasOf(g, deviceJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed(), "renaming a device is not the device coming back")
+
+		By("leaving the aggregate alone, which counts the device under either name")
+		Expect(automationOf(Default, fleetPolicy).Status.ObservedState).
+			To(HaveKeyWithValue(keyDevices, devicesDegraded))
+
+		By("restoring both once the device is back under its captured name")
+		Expect(mock.Device("reset=true")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, fleetJob)).To(BeEquivalentTo(baseline))
+			g.Expect(replicasOf(g, deviceJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+	})
+
+	It("reacts to firmware becoming available, and to it being applied", func() {
+		Expect(mock.Firmware("upgradable=false")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(automationOf(g, firmwarePol).Status.ObservedState).
+				To(HaveKeyWithValue(keyFirmware, firmwareCurrent))
+		}).Should(Succeed())
+
+		Expect(mock.Firmware("upgradable=true&name=ups-2u")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, firmwareJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		By("one upgradable device being enough, whatever the rest of the fleet says")
+		Expect(automationOf(Default, firmwarePol).Status.ObservedState).
+			To(HaveKeyWithValue(keyFirmware, firmwareUpdates))
+
+		Expect(mock.Firmware("upgradable=false")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, firmwareJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+	})
+
+	// temperature and poe are the two bucketed measurements in this batch, and
+	// they fail the same way twice over: a threshold crossed sheds the
+	// workload, and a reading that stops arriving holds the claim rather than
+	// reading as zero. One spec for both, because stating it once is the point
+	// — the second measurement key must not quietly grow its own rules.
+	DescribeTable("a bucketed measurement sheds on its threshold and holds when the reading stops",
+		func(m measurement) {
+			Expect(m.drive(m.healthy)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(automationOf(g, m.policy).Status.ObservedState).To(HaveKeyWithValue(m.key, m.healthyValue))
+			}).Should(Succeed())
+
+			By("crossing the configured threshold")
+			Expect(m.drive(m.tight)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(replicasOf(g, m.target)).To(BeEquivalentTo(0))
+			}).Should(Succeed())
+
+			By("losing the reading, which is not the measurement going back to zero")
+			Expect(m.drive(m.unreadable)).To(Succeed())
+			Eventually(func(g Gomega) {
+				ready := conditionOf(automationOf(g, m.policy), conditionReady)
+				g.Expect(ready).NotTo(BeNil())
+				g.Expect(ready.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(ready.Reason).To(Equal("StateKeyUnavailable"))
+			}).Should(Succeed())
+			Consistently(func(g Gomega) {
+				g.Expect(replicasOf(g, m.target)).To(BeEquivalentTo(0))
+			}).Should(Succeed(), m.holdReason)
+
+			Expect(m.drive(m.healthy)).To(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(replicasOf(g, m.target)).To(BeEquivalentTo(baseline))
+			}).Should(Succeed())
+		},
+		Entry("temperature", measurement{
+			policy: thermalPol, target: thermalJob, key: keyTemperature,
+			healthy: "celsius=45", healthyValue: temperatureNormal,
+			tight: "celsius=82", unreadable: "present=false",
+			holdReason: "a device that stopped reporting its temperature is not a device at 0 °C",
+			drive:      func(query string) error { return mock.Temperature(query) },
+		}),
+		Entry("poe", measurement{
+			policy: poePolicy, target: poeJob, key: keyPoE,
+			// silent=false is part of "healthy" because the mock holds that
+			// override until it is told otherwise, and the restore at the end
+			// of this spec has to undo it.
+			healthy: "watts=12&budget=60&silent=false", healthyValue: poeOK,
+			tight: "watts=57", unreadable: "silent=true",
+			holdReason: "an unreadable switch is not a switch with headroom",
+			drive:      func(query string) error { return mock.PoE(query) },
+		}),
+	)
+
+	// The keys in this batch come from two different endpoints and four
+	// different derivations, and they are independent observations: one going
+	// away must not move any of the others.
+	It("keeps every key independent of the others", func() {
+		Expect(mock.Temperature("celsius=82")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, thermalJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		Consistently(func(g Gomega) {
+			g.Expect(replicasOf(g, fleetJob)).To(BeEquivalentTo(baseline))
+			g.Expect(replicasOf(g, deviceJob)).To(BeEquivalentTo(baseline))
+			g.Expect(replicasOf(g, firmwareJob)).To(BeEquivalentTo(baseline))
+			g.Expect(replicasOf(g, poeJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed(), "a hot device is not a firmware update, a missing AP or a full PoE budget")
+	})
+})
+
+// measurement is one bucketed key's rehearsal: the console queries that put it
+// on either side of its threshold, and the one that stops the reading arriving
+// at all.
+type measurement struct {
+	policy, target, key   string
+	healthy, healthyValue string
+	tight, unreadable     string
+	holdReason            string
+	drive                 func(query string) error
+}

--- a/test/e2e/reaction/suite_test.go
+++ b/test/e2e/reaction/suite_test.go
@@ -72,13 +72,23 @@ const (
 
 	// The state values the rehearsed console publishes, written the way an
 	// Automation's spec.when.state writes them.
-	keyWAN             = "wan"
-	keyWANQuality      = "wan.quality"
-	keyUPS             = "ups"
-	keyUPSBattery      = "ups.battery"
-	keyUPSRuntime      = "ups.runtime"
-	keyUPSLoad         = "ups.load"
-	keyInternet        = "internet"
+	keyWAN         = "wan"
+	keyWANQuality  = "wan.quality"
+	keyUPS         = "ups"
+	keyUPSBattery  = "ups.battery"
+	keyUPSRuntime  = "ups.runtime"
+	keyUPSLoad     = "ups.load"
+	keyInternet    = "internet"
+	keyDevices     = "devices"
+	keyFirmware    = "firmware"
+	keyTemperature = "temperature"
+	keyWiFi        = "wifi"
+	keyPoE         = "poe"
+	// keyUPSDevice is the per-device key the captured UPS publishes under, and
+	// the reason the suite installs with per-device keys on: they are opt-in,
+	// so an install that does not ask for them is the default rather than the
+	// case under test.
+	keyUPSDevice       = "device.ups-2u"
 	wanPrimary         = "primary"
 	wanBackup          = "backup"
 	wanQualityDegraded = "degraded"
@@ -90,6 +100,19 @@ const (
 	upsLoadHigh        = "high"
 	internetOK         = "ok"
 	internetDown       = "down"
+	devicesAllOnline   = "all-online"
+	devicesDegraded    = "degraded"
+	deviceOnline       = "online"
+	deviceOffline      = "offline"
+	firmwareCurrent    = "current"
+	firmwareUpdates    = "updates-available"
+	temperatureNormal  = "normal"
+	temperatureHigh    = "high"
+	wifiOK             = "ok"
+	wifiWarning        = "warning"
+	wifiError          = "error"
+	poeOK              = "ok"
+	poeInsufficient    = "insufficient"
 
 	// settleWindow is how long a workload must hold a value for the suite to
 	// accept that nothing is going to move it. It spans several polls and at
@@ -163,6 +186,10 @@ var _ = BeforeSuite(func() {
 		// Reactor declines a workload a HorizontalPodAutoscaler already drives,
 		// which is exactly the behaviour this value turns on.
 		"--set", "safety.detectHPA=true",
+		// The per-device keys are opt-in, so the suite has to ask for them to
+		// rehearse one. The aggregate is published either way, and both are
+		// asserted — the point of the opt-in is that only one of them is free.
+		"--set", "unifi.devices.perDeviceKeys=true",
 		// Structured logs, so the suite can assert on what the operator did
 		// and did not observe rather than on a rendered sentence.
 		"--set", "log.format=json",
@@ -195,6 +222,15 @@ func resetConsole() {
 	Expect(mock.UPS("mode=mains&level=100&present=true&runtime=1043&output=310&budget=1000")).To(Succeed())
 	Expect(mock.Internet("present=true&status=ok")).To(Succeed())
 	Expect(mock.Quality("reset=true")).To(Succeed())
+	// The fleet keys hold their overrides the same way the UPS numbers do, so
+	// each is put back explicitly rather than left wherever the last spec left
+	// it. firmware, temperature and poe are reset to "not reported at all",
+	// which is what the captures actually show.
+	Expect(mock.Device("reset=true")).To(Succeed())
+	Expect(mock.WiFi("reset=true")).To(Succeed())
+	Expect(mock.Firmware("present=false")).To(Succeed())
+	Expect(mock.Temperature("present=false")).To(Succeed())
+	Expect(mock.PoE("present=false")).To(Succeed())
 }
 
 // workload renders a target Deployment. The pods run the mock's image because

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -18,8 +18,8 @@ The allowlist matters more than it looks. `stat/device` returns entire device re
 
 | File | Endpoint | What it documents |
 | --- | --- | --- |
-| `api/stat-device-gateway.json` | `GET /proxy/network/api/s/<site>/stat/device` (gateway) | `wan1`/`wan2` (`is_uplink`, `up`, `ifname`, `speed`), `uplink`, `last_wan_status`, `isp` (allowlisted from `active_geo_info.WAN.isp_name`) |
-| `api/stat-device-ups.json` | same call, UPS record | `vbms_table` battery state, `outlet_table` |
+| `api/stat-device-gateway.json` | `GET /proxy/network/api/s/<site>/stat/device` (gateway) | `wan1`/`wan2` (`is_uplink`, `up`, `ifname`, `speed`), `uplink`, `last_wan_status`, `isp` (allowlisted from `active_geo_info.WAN.isp_name`), `state`/`adopted`/`name` (the `devices` key) |
+| `api/stat-device-ups.json` | same call, UPS record | `vbms_table` battery state, `outlet_table`, `state`/`adopted`/`name` |
 | `api/stat-health.json` | `GET /proxy/network/api/s/<site>/stat/health` | per-subsystem `status` (the `internet` key), WAN `uptime_stats` monitors (the `wan.quality` key), ISP |
 | `api/integration-info.json` | `GET /proxy/network/integration/v1/info` | controller version, for the compatibility guard |
 | `api/integration-sites.json` | `GET /proxy/network/integration/v1/sites` | site listing |
@@ -216,6 +216,38 @@ UNIFI_URL=$UNIFI_URL UNIFI_API_KEY=$UNIFI_API_KEY ./hack/capture-unifi.sh
 That script writes `testdata/unifi/api/` through the allowlist. **Do not hand-edit `/tmp/failover/*.json` into a fixture** — those files are whole device records containing `x_authkey`, syslog keys and adoption identifiers. That exact shortcut put a live credential in this repository's history once. Capturing the backup-live stage means running the script *while the failover is in progress* and saving its output under a new name, e.g. `stat-device-gateway-on-backup.json`, then adding a row to the file table above.
 
 Post the comparison output on [#34](https://github.com/robbeverhelst/unifi-reactor/issues/34) even if you cannot commit fixtures. The five numbers per stage are the finding; the fixture is only how it gets tested.
+
+## Fleet health (`state`, `adopted`)
+
+Both committed device records carry `"state": 1` and `"adopted": true`, so the
+`devices` key is derived entirely from fields that are already here — the only
+key in this batch that needed nothing new.
+
+| Field | In the captures | What the provider does with it |
+| --- | --- | --- |
+| `state` | `1` on both records | `1` → `online`, `0` → `offline`, **anything else → no value at all** |
+| `adopted` | `true` on both records | gates the fleet keys: an unadopted device is not your fleet |
+| `name` | `Dream Machine Pro`, `UPS 2U` | slugified into the `device.<name>` key |
+| `disconnection_reason` | **absent** — both devices were connected | never derived from; a `V(1)` diagnostic naming why the console lost a device |
+
+`state` is decoded as a **pointer**, for the reason the whole of this file keeps
+repeating: `0` is a real value here and means offline, so an absent `state` read
+as `0` would report one truncated record as a dead device and take the fleet to
+`degraded`. `adopted` is a pointer too, and `nil` is read as "not known to be
+adopted" — the direction that publishes fewer keys rather than more.
+
+> ⚠️ **Only states 0 and 1 have been observed**, both of them `1`. UniFi
+> documents others — pending adoption, provisioning, upgrading, heartbeat missed,
+> isolated — and none has been captured, so none is mapped. A device in one of
+> them counts towards neither key and logs a line asking for a report, because
+> reading "upgrading" as `offline` would turn a firmware update into a fleet
+> outage. `disconnection_reason`'s field name comes from UniFi's own API rather
+> than from a capture; it is diagnostics only, so a wrong name costs a log field
+> and nothing else.
+
+The two captured names are the console's defaults for that hardware, which is
+what makes them safe to use as documentation examples. Anything derived from a
+device name in a fixture or a doc example must be a placeholder of that kind.
 
 ## UPS state (`vbms_table`)
 

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -275,6 +275,60 @@ here claims to have come off a console.
 > `current`. That is the direction a pointer buys you, and it is why absent is
 > never read as "up to date".
 
+## Temperature — parsed, not captured
+
+**No committed capture carries a single thermal field.** The UPS 2U reports
+`has_fan: false` and no temperatures, and the gateway record was allowlisted
+before any of this was parsed, so the `temperature` key is written entirely to
+the shape UniFi's API documents and the field names issue
+[#11](https://github.com/robbeverhelst/unifi-reactor/issues/11) lists.
+
+| Field | In the captures | What the provider does with it |
+| --- | --- | --- |
+| `has_temperature` | **absent** | the device says it does thermal reporting; keeps the key alive when it publishes no number |
+| `overheating` | **absent** | the console's own verdict, trusted over the configured threshold |
+| `temperatures[]` (`name`, `type`, `value`) | **absent** | the hottest sensor's `value` is the device's reading |
+| `general_temperature` | **absent** | the single-value form, used when there is no table |
+| `has_fan` | **absent** | never derived from; a hot fanless device and a hot device with a dead fan are different problems |
+
+Every `value` is a pointer. A sensor reporting nothing is not a sensor at 0 °C,
+and reading it as one would make the rack look *coldest* exactly when a sensor
+stops answering — the wrong direction for the only key whose job is to notice
+heat.
+
+All of them are now in the allowlist in `hack/capture-unifi.sh`, and the script
+now also writes `stat-device-switch.json` and `stat-device-ap.json` — see
+[what is not captured yet](#what-is-not-captured-yet) — because a switch or an
+AP is the hardware that would settle this. `internal/providers/unifi/temperature_test.go`
+asserts the decode of both documented forms **in code**, as a hypothesis rather
+than as a fixture.
+
+> ⚠️ **Unverified, including the unit.** Nothing confirms these readings are
+> Celsius. If a firmware reported Fahrenheit, the 75 default would trip on a
+> perfectly cool switch — which is the one failure mode here that is loud rather
+> than silent, and the reason the debug line prints the raw number. Compare it
+> against what the UniFi UI shows for the same device before trusting the key.
+
+## What is not captured yet
+
+`hack/capture-unifi.sh` writes two files that **do not exist in this
+repository**, because no capture has been taken since they were added:
+
+| File it would write | Why it matters |
+| --- | --- |
+| `api/stat-device-switch.json` | the ground truth for `poe` and for `temperature` on a switch, and the only device type carrying a `port_table` |
+| `api/stat-device-ap.json` | `temperature` on a fanless device, and the firmware flags on a second device type |
+
+Both are written with the device's `name` replaced by a placeholder, unlike the
+gateway and UPS records: those two kept the console's own default names for that
+hardware, while a switch or an AP is usually named after a room or a person. A
+device name is API-shaped — it *is* the `device.<name>` state key — so its shape
+belongs in a fixture; whose room it is does not.
+
+If the site has no such device adopted, the script says so and writes nothing.
+Run it and commit whatever it produces; every ⚠️ above and below is waiting on
+one of those two files.
+
 ## UPS state (`vbms_table`)
 
 A UniFi UPS is reported as a switch-type device (`USWDA26`) carrying:

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -98,6 +98,30 @@ something about how a dead uplink is summarized is not settled by one capture,
 and the parser does not need it to be: a missing field is treated as missing
 either way.
 
+### WiFi health (`wlan` subsystem)
+
+The third key from this capture, and the only one in the `device.<name>`/
+`firmware`/`temperature`/`wifi`/`poe` batch that needed no new field at all:
+
+| Field | In the capture | What the provider does with it |
+| --- | --- | --- |
+| `num_adopted` | `3` | the denominator: how many APs this site owns |
+| `num_disconnected` | `1` | some → `warning`, all → `error`, none → `ok` |
+| `num_ap` | `2` | never derived from — logged, because `2 + 1 = 3` is the arithmetic that says `num_adopted` is the right denominator |
+| `status` | `warning` | never derived from either. Cross-checked against the counts, and a mismatch is counted as `wifi-status-disagrees` |
+
+`wifi` comes from the counts rather than from `status`, and issue
+[#9](https://github.com/robbeverhelst/unifi-reactor/issues/9) asked for that to be
+documented rather than left mysterious. The counts can be explained — "1 of 3
+access points is disconnected" — and they make `error` *derivable*, where mapping
+the vendor string through would have been inference: no capture has ever shown
+any subsystem saying `error`, on any subsystem. Here the two agree exactly, which
+is what makes the counts a sharpening of the console's verdict rather than a
+disagreement with it.
+
+Both counts decode into pointers. Zero adopted APs is a site with no WiFi and
+publishes no key; a subsystem that reports no counts is not a site with no APs.
+
 ### A third opinion on the `wan` mapping
 
 `uptime` is the only field the capture shows exclusively on the live uplink,

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -369,7 +369,13 @@ shape **in code**, as a hypothesis rather than as a fixture.
 
 > ⚠️ **Unverified.** A `stat-device-switch.json` from a US-8-60W or a US-48 is
 > the single capture that would settle this key, the PoE half of `temperature`,
-> and the firmware flags at once.
+> and the firmware flags at once — **and the write path's PoE guard with them**,
+> which reads the same `port_table` for `is_uplink`, `port_poe` and a port name.
+> The allowlist projection carries both readers' fields for exactly that reason:
+> keeping only one set would make the first switch capture useless to the other
+> half, and look like evidence that its fields do not exist. Port names are
+> replaced with their index, because a port is usually named after the room or
+> the person on the end of it.
 
 ## What is not captured yet
 
@@ -423,7 +429,13 @@ UniFi also has a `network:ups_overload_detected` alarm trigger, which corroborat
 
 `unifi.wlan.*` and `unifi.poe.cycle` write to the console, and **no capture backs any of it**. There
 is no `rest/wlanconf` response here and no switch record — every device capture above is a gateway
-or a UPS — so the fields those actions read are inferred rather than observed. See
+or a UPS — so the fields those actions read are inferred rather than observed.
+
+> Since the state batch, `hack/capture-unifi.sh` writes a `stat-device-switch.json` when a switch is
+> adopted, and its `port_table` projection carries the write path's three fields (`is_uplink`,
+> `port_poe`, and a port name replaced by its index) alongside the `poe` state key's. One capture
+> would therefore give the PoE half of both paths its first ground truth at once. The WLAN half
+> still has none, and `wlanconf` is the record that carries pre-shared keys. See
 [docs/unifi-write-api.md](../../docs/unifi-write-api.md), which splits the two, and note that
 `hack/mock-unifi` builds its WLAN table and its PoE switch **in code**, clearly labelled, precisely
 so nothing in `testdata/` claims to have come off a console when it did not.

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -333,6 +333,44 @@ than as a fixture.
 > than silent, and the reason the debug line prints the raw number. Compare it
 > against what the UniFi UI shows for the same device before trusting the key.
 
+## PoE — parsed, not captured
+
+**No switch record exists in this repository at all.** The UPS 2U is reported as
+a switch-type device (`USWDA26`) and carries neither a `port_table` nor a PoE
+budget, so the `poe` key is written entirely to the shape UniFi's API documents
+and the field names issue [#14](https://github.com/robbeverhelst/unifi-reactor/issues/14)
+lists.
+
+| Field | In the captures | What the provider does with it |
+| --- | --- | --- |
+| `total_max_power` | **absent** | the switch's whole PoE budget in watts: the denominator |
+| `port_table[].poe_enable` | **absent** | whether the port is delivering power at all |
+| `port_table[].poe_power` | **absent** | the watts it is delivering, summed across powered ports |
+| `port_table[].poe_class` | **absent** | never derived from; names a port in the diagnostic line |
+| `port_table[].port_idx` | **absent** | never derived from; the same |
+
+Two decisions in the parser exist because of what is *not* known:
+
+`poe_power` is decoded by a type that accepts **a JSON number or a numeric
+string**. UniFi is documented to report it as `"3.90"` on several firmwares
+while other endpoints use a number, and committing to either would make an
+entire switch's draw unreadable on the half of the world that reports it the
+other way. Null, empty and unparseable all mean "no reading" — never 0 W.
+
+A port that is **powering something and reports no wattage makes the whole
+switch unreadable**, rather than contributing zero. This is "absent is not zero"
+at the one place on this key where it hides a failure: under-counting the draw
+reports headroom that is not there, which is exactly what #14 exists to catch.
+
+The whole `port_table` is projected down to those four fields in the capture
+script — a real one carries per-port names, MACs and client counts — and
+`internal/providers/unifi/poe_test.go` asserts the decode of the documented
+shape **in code**, as a hypothesis rather than as a fixture.
+
+> ⚠️ **Unverified.** A `stat-device-switch.json` from a US-8-60W or a US-48 is
+> the single capture that would settle this key, the PoE half of `temperature`,
+> and the firmware flags at once.
+
 ## What is not captured yet
 
 `hack/capture-unifi.sh` writes two files that **do not exist in this

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -249,6 +249,32 @@ The two captured names are the console's defaults for that hardware, which is
 what makes them safe to use as documentation examples. Anything derived from a
 device name in a fixture or a doc example must be a placeholder of that kind.
 
+## Firmware (`upgradable`) — parsed, not captured
+
+The `firmware` key is derived from `upgradable`, and **no capture contains that
+field**. `version` and `displayable_version` are here; nothing about upgrades is.
+
+| Field | In the captures | What the provider does with it |
+| --- | --- | --- |
+| `version` | `5.1.26.33914`, `1.6.1.413` | diagnostics: the "from" in the log line |
+| `upgradable` | **absent** | the only field the key is derived from; a pointer, so absent publishes no key |
+| `upgrade_to_firmware` | **absent** | diagnostics: the "to" |
+| `required_version`, `safe_for_autoupgrade` | **absent** | diagnostics |
+| `model_in_eol`, `model_in_lts` | **absent** | counted in the log line; deliberately not keys — an inventory fact does not transition |
+
+All six are now in the allowlist in `hack/capture-unifi.sh`, so the next real
+capture settles them. Until then the parser is written to the shape UniFi's own
+API documents and to the field names issue [#12](https://github.com/robbeverhelst/unifi-reactor/issues/12)
+lists, and `internal/providers/unifi/firmware_test.go` asserts the decode of
+that documented shape **in code**. It is a hypothesis, and it lives in a test
+rather than in this directory for the reason the failover hypotheses do: a file
+here claims to have come off a console.
+
+> ⚠️ **Unverified.** If the field is named something else on your firmware, the
+> failure mode is that `firmware` never appears — not that it wrongly reports
+> `current`. That is the direction a pointer buys you, and it is why absent is
+> never read as "up to date".
+
 ## UPS state (`vbms_table`)
 
 A UniFi UPS is reported as a switch-type device (`USWDA26`) carrying:


### PR DESCRIPTION
Five state keys, in #27's order of value: `device.<name>` and `devices` (#8), `firmware` (#12), `temperature` (#11), `wifi` (#9), `poe` (#14). One commit each, plus a refactor and the e2e suite.

Closes #8, closes #12, closes #11, closes #9, closes #14.

## The most important thing in this PR is not a state key

CI went red on the **arbitration** spec — #29's flagship scenario, and not one of this batch's specs. It is a real, pre-existing bug, and this PR now fixes it.

`status.targets[].desired` for a non-matching Automation is its reversal, which with `onExit` omitted is the **recorded baseline**. The spec saw `desired: 1` where it expected `3`, which means the baseline annotation itself said `1` — the level Reactor had applied, not the level the operator set. That is precisely the failure the baseline exists to prevent: the outage ends and the workload comes back at Reactor's number.

`claimTarget` decides "is a baseline already recorded?" from the caller's **snapshot** of the target, while the level it records comes from a **live** read of the scale subresource. `maxConcurrentReconciles` is 4 and the arbitration spec is two Automations on one workload, so the second reconcile can still see no baseline in its snapshot while the live level is already the one the first just applied — and record that. The annotation patch carried no precondition, so the wrong value was written straight over the right one.

The fix puts an optimistic lock on the write that records a baseline: a patch built from a stale snapshot is refused rather than believed, and on that conflict the target is re-read once and the claim written again, by which point the other reconcile's baseline is visible and this one leaves it alone. Releasing keeps the unguarded patch — clearing a claim is idempotent; it is recording a value that must not be got wrong.

**Evidence, not a guess.** `internal/controller/baseline_race_test.go` reproduces it deterministically in 11 ms — one target, one claim, then a second claim holding the snapshot it took beforehand — and fails without the fix with `baseline-replicas: "1"` against an expected `"3"`, which is the CI failure exactly. At the e2e level it is a race: the same commit went red once and green twice, and a full local `make test-reaction` on the unfixed code passed 50/50. That is why the proof is a unit test rather than a longer timeout.

**The e2e assertion is untouched.** It was right, and it was the only thing that noticed. Nothing here widens a window and hopes.

## The decision this batch is really about

`internal/metrics` bounds its `key` label at compile time, and its own comment set the rule before the case existed: per-entity keys "have to become opt-in rather than the point at which this is revisited". #8 is that case. `device.<name>` is the first key whose **name** comes from your network rather than from this repository, so an install with forty adopted devices would silently gain forty state keys and forty `reactor_state_transitions_total` series.

- **`devices`** — one key, two values, one series whatever the fleet size. On by default. It answers the question people actually ask, which is "is anything down".
- **`device.<name>`** — behind `unifi.devices.perDeviceKeys`, default `false`, announced in a startup log line, and left out of `StateVocabulary()` entirely so it is never a `reactor_state_info` label. Which device is down lives in `status.observedState`, in an Event, and in a `V(1)` line carrying the console's own `disconnection_reason`.

The metrics package comment now records that as settled rather than predicted. `docs/adding-a-provider.md` carries it as a general rule beside the bucketing one, because `client.<name>` (#10) hits it next.

## Debounce, and the one engine change

| Key | Samples | Why |
| --- | --- | --- |
| `devices`, `device.*` | 2 | A device's `state` is a switch position, but it is the console's judgement about a *heartbeat* rather than a wire it can see. One missed beat must not page anyone; 60s is nothing against a device that has been dead for days. |
| `wifi` | 2 | The same underlying fact — an AP count is heartbeats. |
| `temperature` | 3 | A measurement that hovers: thermals move with the room, the fan and the load. |
| `poe` | 3 | Instantaneous, like `ups.load`: an AP's radios coming up move the draw by tens of watts in one poll. |
| `firmware` | 3 | Derived from the console's lookup against Ubiquiti's release catalogue, which can blip — and nothing about an update is urgent, so extra samples are free. |

Per-device key names only exist at runtime, so no chart could enumerate them. `engine.DebounceConfig.PerKey` now accepts a trailing `*` (`device.*: 2`); exact entries win over patterns, longest prefix wins between patterns. The engine still learns nothing — it matches a string against a pattern handed to it as data — and `docs/adding-a-provider.md` records it under "when you need the engine to change".

**Thresholds are set against those samples**, per #7's precedent, and both directions are documented in `values.yaml`:

- `temperature.highCelsius: 75` — UniFi switches and APs normally sit at 40–60 °C, so 75 plus 3 samples is a reading that genuinely held for 90 seconds. Move the threshold into the normal operating range and that hysteresis stops meaning anything, because the reading crosses the line and stays there.
- `poe.maxUtilizationPercent: 90` — leaves roughly one powered device's worth of headroom during those 90 seconds. Raise it towards 100 and there is nothing left to react in.

## Bucketing, and what is deliberately not a key

`temperature` and `poe` publish named levels against configurable thresholds; the raw numbers are `V(1)` diagnostics, never API. So are the firmware version strings — one series per version is the cardinality failure `isp` would have been.

`model_in_eol` is read and **not** published as a key, though #12 is right that it is the more valuable fact: it is an inventory property, not a state. It never transitions, so an Automation matching it would sit permanently matched — a report rather than a reaction. It is counted in the firmware log line, and a test asserts the decision so nobody adds a sixth key by accident.

## `wifi` is derived from the counts, and #9 asked why

From `num_disconnected` against `num_adopted`, not from the `wlan` subsystem's `status` wording:

- The counts can be explained. "1 of 3 access points is disconnected" answers "why is wifi warning"; "UniFi said warning" does not.
- `error` becomes **derivable** rather than inferred — no capture has ever shown any subsystem saying `error`, so mapping the vendor string through would have been a guess about an unobserved value. "Every adopted AP is disconnected" is an observation.
- The two agree in the capture (`warning`, 1 of 3 disconnected), so this sharpens the console's verdict rather than contradicting it.

The status is still read and cross-checked: a mismatch counts `reactor_provider_signal_disagreements_total{signal="wifi-status-disagrees"}` and logs both values, so a firmware whose `warning` means airtime rather than a missing AP announces itself instead of the derivation quietly being wrong.

The e2e run surfaced the caveat every three-value key carries, so it is now asserted and documented: an Automation matching `wifi: warning` **stops** matching at `error` and reverses. That is the shape `internet` already has and it is the right one here — all three values answer a single question, unlike `ups`/`ups.battery` where two separate facts had to be split — but "match the value you mean" now says so in both READMEs.

## Absent is not zero — #5's bug, five more times

Every number is a pointer and every key fails by publishing **nothing** rather than something reassuring:

| Key | The absence that must not be zero |
| --- | --- |
| `devices` | `state: 0` means offline, so an absent `state` read as 0 would take the whole fleet to `degraded` on one truncated record |
| `firmware` | An absent `upgradable` is not "up to date". No device reporting it → no key, not `current` |
| `temperature` | A device reporting no temperature is not a device at 0 °C — that would make the rack look *coldest* when a sensor stops answering |
| `poe` | A port powering something that will not say how much makes the whole switch **unreadable**, because counting it as 0 W reports headroom that is not there |
| `wifi` | A subsystem reporting no counts is not a site with no APs; zero adopted APs is a site with no WiFi, not WiFi that is fine |

`TestMissingStateIsNotAnOfflineDevice`, `TestMissingTemperatureIsNotZeroDegrees`, `TestMissingBudgetIsNotAZeroBudget` and `TestMissingAPCountsPublishNoWiFiKey` imitate `TestMissingAvailabilityIsNotZeroAvailability`.

A device state this provider does not recognise — UniFi documents provisioning, upgrading, heartbeat-missed, none of them captured — counts towards neither key and logs asking for a report, because reading "upgrading" as `offline` would report a firmware upgrade as a fleet outage.

## Omit what you cannot see, per key

Renaming a device makes its old key **vanish** rather than report `offline`, which the engine already treats as lost visibility: last known state held, `Ready=False` with `StateKeyUnavailable`, no `onExit`. That is #8's acceptance criterion, covered in the provider tests and end to end. Two devices whose names slugify alike (`AP 1`, `ap-1`) publish **neither** key and count a disagreement — picking one is arbitrary, and the arbitrary pick can be the one hiding the dead device — while `devices` still counts both.

## Fixtures

| Key | Ground truth |
| --- | --- |
| `devices`, `device.<name>` | **Verified.** `state`, `adopted` and `name` are in both committed captures |
| `wifi` | **Verified.** `num_adopted`, `num_disconnected` and `num_ap` are in `stat-health.json`, and the counts are self-consistent (2 + 1 = 3) |
| `firmware` | **Unverified.** No capture contains `upgradable` |
| `temperature` | **Unverified.** No capture contains a single thermal field |
| `poe` | **Unverified.** No switch record exists in this repository at all |

Nothing was written into `testdata/`. The three unverified parsers are written to the shape UniFi's API documents and to the field names the issues list; every field is now in the allowlist in `hack/capture-unifi.sh`, which additionally learned to write `stat-device-switch.json` and `stat-device-ap.json` — with the device name replaced by a placeholder, because a switch or an AP is usually named after a room or a person, unlike the gateway and UPS which kept the console's own defaults. Each documented shape is asserted **in code**, in the provider's tests, as a hypothesis rather than as a fixture — the rule the failover variants already follow.

`poe_power` decodes through a type accepting a JSON number *or* a numeric string, because UniFi is documented to use `"3.90"` on several firmwares; null, empty and unparseable all mean "no reading", never 0 W, and an unfamiliar value never fails the decode and takes every other key down with it.

## Everything else

- `hack/mock-unifi` gained `GET /device` plus `POST /device`, `/firmware`, `/temperature`, `/wifi` and `/poe`, so every key can be driven by hand and rehearsed in CI. The three unverified ones serve nothing until asked — that is what the captures show — and every invented value is labelled as invented.
- The e2e reaction suite installs with `perDeviceKeys=true` (which also exercises `device.*=2` rendering through the chart into the operator) and drives each key through an Automation, including the rename holding its claim and both measurements holding when their reading stops.
- Running it found a real bug in the mock, which is the sort of thing this suite is for: `/device?reset=true` wiped a device's whole override record — one device has one record, shared with `/firmware` and `/temperature` — so resetting devices silently deleted two other endpoints' fields. That is not cosmetic, because making a field disappear is precisely the case Reactor holds a claim through: the teardown set a healthy temperature and reset devices in the same breath, the operator never observed the healthy value, and it correctly froze a workload the teardown was waiting on. Each endpoint now resets only what it drives.
- README, `charts/reactor/README.md`, `values.yaml`, `docs/adding-a-provider.md`, `docs/development.md`, `docs/troubleshooting.md` (§10b–10e) and `testdata/unifi/README.md` all learned about the five keys.
- Rebased onto #65. Nothing here touches `status.targets[]` or target handling, so the new `preview`/`managedBy` fields and the HPA decline path are untouched — no code in this branch assumes a claimed target has a baseline. The reaction suite now installs with `safety.detectHPA=true` **and** `unifi.devices.perDeviceKeys=true`; the fleet workloads have no HPA, so they are never declined.
- `make test`, `make lint` and `make manifests generate` are clean. All three e2e suites were run locally against throwaway kind clusters.

---

## LIVE VERIFICATION

Everything below is a field or an assumption **no capture in this repository contains**. Each row says what to run and what would change. The capture script already allowlists all of them, so the fastest path is:

```sh
UNIFI_URL=https://<console> UNIFI_API_KEY=<key> ./hack/capture-unifi.sh
```

That now writes `stat-device-switch.json` and `stat-device-ap.json` alongside the existing files, and **one switch record settles most of this list at once**. Run Reactor at `log.level=debug` against the same console while you do it; half the evidence is what it said.

### 1. `firmware` — the upgrade fields (#12)

**Do:**
```sh
curl -sk -H "X-API-KEY: $UNIFI_API_KEY" \
  "$UNIFI_URL/proxy/network/api/s/default/stat/device" \
  | jq '[.data[] | {name, version, upgradable, upgrade_to_firmware, required_version,
                    safe_for_autoupgrade, model_in_eol, model_in_lts}]'
```

**Look for:** whether `upgradable` exists at all, and on which device types. If it is absent everywhere, Reactor logs `No adopted device reports whether it is upgradable; firmware will not be published` — the key never appears, which is the intended failure. If it is present under another name, that name is the fix. Also check whether `upgrade_to_firmware` is a version string or an object; only the string form is parsed, and it is diagnostics either way.

**Changes if wrong:** the field name in `firmwareFields`. Nothing else — the derivation is a single boolean OR across adopted devices.

### 2. `temperature` — every thermal field, and the unit (#11)

**Do:** capture a switch or an AP (the UPS 2U has none), then:
```sh
jq '[.data[] | select(.has_temperature or .temperatures or .general_temperature)
     | {name, has_temperature, has_fan, overheating, general_temperature, temperatures}]' <capture>
```

**Look for, in order of how badly it matters:**

1. **The unit.** Compare the raw number against what the UniFi UI shows for that device. Nothing confirms these are Celsius, and if a firmware reports Fahrenheit the 75 default trips on a cool switch. The `V(1)` line prints `hottestCelsius` precisely so this can be compared.
2. **Which form.** A `temperatures[]` table (`{name, type, value}`) or a single `general_temperature`? Both are parsed; knowing which your hardware uses tells us whether the fallback is load-bearing.
3. **What a normal rack reads.** Watch `hottestCelsius` over a day. The 75 default assumes 40–60 °C is normal; if yours idles at 70, both the threshold **and** the 3-sample debounce need revisiting together — see the note in `values.yaml`.
4. **Whether `overheating` ever goes true, and at what reading.** It outranks the configured threshold, so its trip point is effectively a second threshold nobody here has seen.

**Changes if wrong:** field names in `temperatureFields`; possibly `DefaultHighTemperatureCelsius`, and the debounce with it.

### 3. `poe` — the budget, the port table, and `poe_power`'s type (#14)

**Do:** capture a PoE switch (US-8-60W, US-48, or any USW with PoE ports), then:
```sh
jq '[.data[] | select(.total_max_power) | {name, total_max_power,
      ports: [.port_table[] | select(.poe_enable) | {port_idx, poe_power, poe_class, poe_mode}]}]' <capture>
```

**Look for:**

1. **`poe_power`'s JSON type.** `"3.90"` (string) or `3.9` (number)? Both decode; this confirms which is real and whether the flexible decoder is needed or merely harmless.
2. **`total_max_power`'s meaning.** It is read as the whole PoE budget in watts. If it turns out to be something else — a per-port maximum, or the PSU rating rather than the PoE budget — the denominator is wrong and every reading is a fraction of the wrong number. Compare it against the switch's published PoE budget.
3. **Whether powered ports ever omit `poe_power`.** That makes the whole switch unreadable by design. If it happens routinely rather than exceptionally, the rule is too strict and should fall back to the ports that do report.
4. **What your rack actually draws.** Read `worstUtilizationPercent` over a day before trusting the 90% default.

**Changes if wrong:** field names in `poeFields`/`devicePort`, or `DefaultMaxPoEUtilizationPercent` and the debounce with it.

### 4. `devices` — the states nobody has seen (#8)

**Do:** watch `state` across a firmware upgrade and an adoption:
```sh
watch -n5 'curl -sk -H "X-API-KEY: $UNIFI_API_KEY" \
  "$UNIFI_URL/proxy/network/api/s/default/stat/device" \
  | jq -c "[.data[] | {name, state, adopted, disconnection_reason}]"'
```

**Look for:** any `state` other than `0` or `1`. UniFi documents pending-adoption, provisioning, upgrading, heartbeat-missed and isolated; none has been captured, and none is mapped. Reactor logs `A device reports a state this provider does not recognise` with the number — **that log line is the finding**. A device in an unmapped state counts towards neither key today, which is deliberate but conservative: if `6` turns out to mean "heartbeat missed", it probably belongs in `offline`.

Also confirm `disconnection_reason`'s field name by unplugging something. It is diagnostics only, so a wrong name costs a log field and nothing else.

**Changes if wrong:** the `switch` in `deviceTally.observe`, and possibly which states map to `offline`.

### 5. `wifi` — verified, with two open questions (#9)

The fields are all captured, so this key works. Two things a second capture would settle:

- **Does `num_ap` always equal `num_adopted - num_disconnected`?** It does in the capture, which is what makes `num_adopted` the right denominator. The `V(1)` line prints all three; if they stop adding up on your console, the denominator choice needs revisiting.
- **Does the console's `status` ever disagree with the counts?** Watch `reactor_provider_signal_disagreements_total{signal="wifi-status-disagrees"}`. A steady climb means UniFi's `warning` means something the counts do not — airtime or interference rather than a missing AP — which would be worth a second key rather than a different derivation.

### 6. The two new capture files

`hack/capture-unifi.sh` writes `stat-device-switch.json` and `stat-device-ap.json` when such a device is adopted, and says so when it is not. Neither exists yet. Committing them is what turns rows 2, 3 and most of 1 from "documented shape" into "captured", and `testdata/unifi/README.md` has a table of what each would document.

**Do not hand-edit a device record into a fixture.** Those files are whole 8 KB records with `x_authkey`, syslog keys and adoption identifiers in them; that exact shortcut put a live credential in this repository's history once. Run the script.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UniFi monitoring for fleet/device health, firmware availability, WiFi health, temperature, and PoE capacity.
  * Added optional per-device state reporting with configurable thresholds and debounce settings.
  * Added mock and end-to-end scenarios for testing device transitions, upgrades, overheating, WiFi issues, and PoE utilization.

* **Bug Fixes**
  * Improved reliability when concurrent reactions claim the same workload, preserving the correct baseline.

* **Documentation**
  * Expanded configuration, compatibility, troubleshooting, development, and test-data guidance for the new UniFi signals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->