### PR TITLE
state: observe UPS outlet state (`outlet.<n>`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -735,6 +735,7 @@ Each key is published only when the matching hardware is adopted by your control
 | `temperature` | `normal`, `high` | the hottest adopted device against the configured threshold |
 | `wifi` | `ok`, `warning`, `error` | the WiFi subsystem as a whole, from the console's AP counts |
 | `poe` | `ok`, `insufficient` | PoE headroom on the worst switch, against the configured threshold |
+| `outlet.<n>` | `on`, `off` | one switchable UPS outlet, by index or by name. **Read-only** — see below |
 
 `isp` is the one key whose values are not a closed set: it is the carrier name your console geolocated your public address to, lowercased with everything non-alphanumeric turned into a hyphen. Look it up before matching on it —
 
@@ -1035,6 +1036,85 @@ measured, so one unreadable switch does not take the key with it.
 A switch reporting no budget is likewise not a switch with no budget, and never a
 denominator. A fleet with no readable PoE switch publishes no `poe` key at all.
 
+### `outlet.<n>` is read-only, and the relay grouping is why
+
+A UniFi UPS reports one entry per switchable outlet, and Reactor publishes one
+key each — `on` while the relay is closed and delivering mains, `off` when it is
+not:
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      outlet.nas: off      # something cut power to the NAS
+```
+
+**Reactor will not switch an outlet.** Not behind a flag, not with an allowlist,
+not at all — and that is not caution about writes in general, since Reactor
+already power-cycles a PoE port. It is one specific unanswered question, visible
+in the capture:
+
+```json
+{"index": 1, "name": "Outlet 1", "relay_state": true, "relay_group": 1}
+```
+
+Outlets 1–4 report `relay_group: 1` and outlets 5–8 report `relay_group: 2`. If
+the relay **group** is what the hardware switches, then "turn off outlet 3" means
+"cut outlets 1 to 4", and one of those may be carrying your gateway, your switch
+or your storage. Nobody has confirmed which it is. The documented write path
+([`outlet_overrides`](https://github.com/Art-of-WiFi/UniFi-API-client/blob/main/examples/modify_smartpower_pdu_outlet.php))
+comes from the USP-PDU-Pro and USP-Strip, which expose per-outlet power and
+current and have **no relay groups at all**, so it is documented for a different
+device class and settles nothing here. Switching is tracked in
+[#23](https://github.com/robbeverhelst/unifi-reactor/issues/23) and stays there
+until it is answered.
+
+Observing is what answers it, safely. Reactor prints the grouping when it first
+sees it, and says what moved together whenever a relay does:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep unifi-outlets
+# A UPS is reporting switchable outlets. Reactor only READS them ...
+#   device=ups-2u relayGroups="1=[outlet.1 outlet.2 outlet.3 outlet.4] 2=[outlet.5 outlet.6 outlet.7 outlet.8]"
+# Outlet state changed. If you are running the relay-group experiment on issue #60, this line is its readout
+#   moved=outlet.5=on->off relayGroup=2 movedInGroup=1 outletsInGroup=4
+#   verdict="outlets in this group moved independently of each other"
+```
+
+Toggle **one** outlet by hand in the UniFi UI — pick one in the bank carrying
+nothing you care about — and that second line is the whole experiment:
+`movedInGroup=1` of `4` means outlets switch individually, and `4` of `4` means
+the relay group is the switching unit. Both are rehearsable without hardware; see
+[the mock](docs/development.md#running-without-a-udm).
+
+#### Name your outlets
+
+Out of the box every outlet is called `Outlet 1` … `Outlet 8`, which is the index
+spelled out rather than a name, so the key falls back to the index: `outlet.3`.
+Name them in the UniFi UI and the key becomes the name — `NAS` publishes
+`outlet.nas`.
+
+Do it before writing anything against them. `outlet.3` means something different
+the day somebody re-plugs the rack, and this is the same argument that made
+`portName` **required** rather than optional for
+[`unifi.poe.cycle`](#power-cycling-a-poe-port): hardware that carries mains power
+should be addressed by what it is, not by where it happens to be plugged.
+
+Renaming an outlet makes its old key *vanish* rather than report `off`, which
+Reactor treats as lost visibility — the last known state is held and `Ready=False`
+reports `StateKeyUnavailable`, so nothing sheds load because you labelled a socket.
+Two outlets addressed the same way publish **neither**, for the same reason two
+devices sharing a slug do.
+
+These keys appear only when an adopted device actually lists outlets. The captured
+gateway reports `"outlet_table": []`, so having the field is not the same as having
+outlets, and an outlet that reports no `relay_state` publishes nothing at all rather
+than being read as off.
+
+They are also **not** in `reactor_state_info`, and the reasoning is worth
+separating from [`device.<name>`'s](#cardinality-on-purpose), because only half of
+it carries over — see [Cardinality](#cardinality-on-purpose).
+
 If a provider stops reporting a key at all — the hardware dropped off the controller — Reactor holds the last known state and reports `Ready=False` with `StateKeyUnavailable` rather than treating lost visibility as a condition that ended ([what to do about it](docs/troubleshooting.md#2-statekeyunavailable-and-held-state)).
 
 ### Settling a noisy signal
@@ -1058,6 +1138,7 @@ unifi:
       temperature: 3    # ...and a measurement hovers on its threshold
       wifi: 2           # ...and an AP heartbeat can miss a beat
       poe: 3            # ...and a PoE draw moves when a radio comes up
+      outlet.*: 1       # a relay is a switch position; there is nothing to settle
 ```
 
 Each extra sample costs one `pollInterval` of reaction time, so the default is `1`: a WAN failover and a power cut both deserve an immediate reaction, and neither flaps. `ups.battery` ships at `2` because it is a threshold crossing — a charge hovering at 30% would otherwise report `low`, `normal`, `low` — and because a battery drains over minutes, so spending one more poll to be sure costs nothing. At the default 30s poll that makes a battery-level escalation react in 60s worst case instead of 30s.
@@ -1133,6 +1214,14 @@ Reconcile counts, queue depth and reconcile latency are controller-runtime's own
 Declaring the vocabulary is also what lets the gauge report `0` for the values a key does *not* hold. Without that, the series for a value it used to hold goes stale at `1` rather than dropping, and every graph built on it lies. All values `0` means the key is not currently observable — the metric side of [`StateKeyUnavailable`](docs/troubleshooting.md#2-statekeyunavailable-and-held-state).
 
 `device.<name>` is the other side of the same coin, and the reason [it is opt-in](#the-fleet-devices-and-why-devicename-is-opt-in). Its *values* are closed — two of them — but its **key name** comes from your network, so the set of keys is open. It is therefore never in `reactor_state_info` at all, and turning the keys on adds one `reactor_state_transitions_total` series per adopted device: a bounded number, chosen by you, rather than one this repository can promise. `devices` is one series regardless of fleet size, which is why it is the one that ships on.
+
+`outlet.<n>` is out of `reactor_state_info` too, and it is worth saying why it is **not** opt-in as well, because the two halves of `device.<name>`'s argument come apart here.
+
+The cardinality half does not carry over. Eight outlets are bounded by a chassis, not by a rack: nobody adds outlets to a UPS, and most installs have no outlet-bearing device at all. So these keys ship on, beside the other UPS keys, rather than being the one UPS key you have to ask for.
+
+The enumerability half does, and it is what keeps them out of the gauge. `StateVocabulary` is handed over once at startup, before any console has been polled, so it cannot contain a key whose name is an outlet somebody has not named yet — and hardcoding `outlet.1` … `outlet.8` would write one UPS's chassis into this repository and silently leave a larger PDU's ninth outlet outside the metric. Declaring `outlet.*` was considered and rejected for a sharper reason: the gauge reports `0` for the values a key does **not** hold, which requires enumerating the values of a key that is missing from the observation, and a prefix can only match keys that are present. An outlet key that vanished with its UPS would sit at `1` forever — the exact staleness declaring a vocabulary exists to prevent.
+
+They are still counted in `reactor_state_transitions_total` (one series each), they are in `status.observedState` and in Events, and the provider logs every change with its relay group in words. That last one is what the [relay-group experiment](#outletn-is-read-only-and-the-relay-grouping-is-why) actually reads.
 
 ### Alerts and the dashboard
 
@@ -1221,6 +1310,8 @@ Every parser here is written against a real captured response — except three, 
 They are written to the shape UniFi's own API documents, every field is in the [capture allowlist](testdata/unifi/README.md) so the next real capture settles them, and each fails by **publishing nothing** rather than by publishing a reassuring value: no `upgradable` anywhere means no `firmware` key, not `current`; no thermals means no `temperature` key, not `normal`; an unreadable switch is left out rather than counted as having headroom.
 
 If you run a UniFi switch or an access point, `./hack/capture-unifi.sh` now writes `stat-device-switch.json` and `stat-device-ap.json`, and one of each would settle all three at once.
+
+`outlet.<n>` is the opposite case and is listed here so the contrast is not lost: every field it reads — `index`, `name`, `relay_state`, `relay_group` — **is** in the committed capture, and the parser is written against real bytes. What is unverified about outlets is not the reading but the *writing*, which is why there is none.
 
 ## Configuration
 

--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -256,6 +256,7 @@ hardware is adopted by the controller.
 | `temperature` | `normal`, `high` | the hottest adopted device vs. the configured threshold |
 | `wifi` | `ok`, `warning`, `error` | the `wlan` subsystem's AP counts: some disconnected, or all of them |
 | `poe` | `ok`, `insufficient` | the worst switch's PoE draw vs. its budget and the configured threshold |
+| `outlet.<n>` | `on`, `off` | one switchable UPS outlet, by index or by name. **Read-only** |
 
 `isp` is the only key with an open value set — it is your carrier's name, lowercased with
 non-alphanumerics turned into hyphens. Read it off a state transition line before matching on it.
@@ -411,6 +412,29 @@ readable switch publishes no key.
 > ⚠️ The PoE fields are **not in any committed capture** — no switch record exists
 > at all — so this parser is written to the shape UniFi documents and is
 > unverified, including that `poe_power` arrives as a string.
+
+### `outlet.<n>`
+
+One key per switchable outlet on a UniFi UPS: `on` while the relay is closed and
+delivering mains. There is no configuration, because there is nothing to
+threshold — a relay is where it is.
+
+Addressed by index (`outlet.3`) while the outlet still carries the console's own
+`Outlet 3` placeholder, and by the slugified name (`outlet.nas`) once you name it.
+**Name them.** An automation matching `outlet.3` means something different the day
+somebody re-plugs the rack. Renaming makes the old key vanish, which is held as
+lost visibility rather than read as a recovery.
+
+Published only when an adopted device actually lists outlets; the captured gateway
+reports `"outlet_table": []`, which is not the same thing. An outlet reporting no
+`relay_state` publishes nothing rather than being read as off.
+
+> ⚠️ **Reactor never switches an outlet, and this is not a chart setting you can
+> turn on.** The captured UPS puts outlets 1–4 in `relay_group: 1` and 5–8 in
+> `relay_group: 2`, and nobody has confirmed whether the hardware switches an
+> outlet or a whole group — "turn off outlet 3" may mean "cut outlets 1 to 4".
+> Observing is how that gets settled safely; switching is
+> [#23](https://github.com/robbeverhelst/unifi-reactor/issues/23).
 
 ### `internet` and `wan.quality`
 
@@ -840,6 +864,16 @@ adds one `reactor_state_transitions_total` series per adopted device — a numbe
 bounded by your rack rather than by this chart, which is exactly why you have to
 ask for it.
 
+`outlet.<n>` is out of `reactor_state_info` for the key-name half of that
+argument and **not** for the cardinality half, which is why it needs no opt-in:
+eight outlets are bounded by a chassis rather than by your rack, and nobody adds
+outlets to a UPS. What keeps it out of the gauge is that the vocabulary is
+declared at startup, before any console is polled, so it cannot contain a key
+named after an outlet nobody has named yet. Declaring `outlet.*` would not work
+either: the gauge reports `0` for the values a key does **not** hold, and a
+prefix can only match keys that are present, so an outlet key that vanished with
+its UPS would sit at `1` forever.
+
 `wan.quality` and `ups.load` are in that list only because they were bucketed.
 The availability, latency and wattage behind them are continuous, and
 publishing those as values would have been the same cardinality failure — one
@@ -941,7 +975,7 @@ publishing — which fails as silence rather than as an error.
 | `unifi.temperature.highCelsius` | `75` | hottest adopted device at or above this reports `temperature: high` |
 | `unifi.poe.maxUtilizationPercent` | `90` | a switch delivering at or above this share of its PoE budget reports `poe: insufficient` |
 | `unifi.debounce.default` | `1` | consecutive observations a changed value needs before Reactor acts; each extra sample costs one `pollInterval` of reaction time |
-| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3, temperature: 3, wifi: 2, poe: 3}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
+| `unifi.debounce.keys` | `{ups.battery: 2, ups.runtime: 2, ups.load: 3, isp: 2, internet: 3, wan.quality: 3, devices: 2, device.*: 2, firmware: 3, temperature: 3, wifi: 2, poe: 3, outlet.*: 1}` | per-key overrides for signals that settle rather than switch; an entry may end in `*` to cover keys named after your hardware |
 | `unifi.webhook.enabled` | `false` | Run the webhook receiver; a delivery triggers a poll, never a state change |
 | `unifi.webhook.port` | `9090` | Port the receiver listens on inside the pod |
 | `unifi.webhook.path` | `/webhooks/unifi` | URL path deliveries are accepted on |

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -148,6 +148,15 @@ unifi:
     # your hardware, and no firmware update needs reacting to within 30
     # seconds. Extra samples are free when reaction time does not matter.
     #
+    # outlet.* is written down at 1 rather than left to the default, and it is
+    # the one entry here whose number is an argument rather than a setting. A
+    # relay is a switch position and not a measurement: it is where it is,
+    # nothing about it hovers on a threshold, and there is no reading to
+    # settle. It matches wan and ups, which are debounced at 1 for the same
+    # reason. Stating it means raising `default` cannot quietly delay an outlet
+    # by a poll, and it is a prefix because outlet keys are named outlet.<index>
+    # until somebody names the outlets, and outlet.<name> afterwards.
+    #
     # An entry may end in "*", which matches every key with that prefix. It is
     # how a group whose key names come from your hardware gets settled at all:
     # no list here could name them. Exact keys win over patterns, and the
@@ -166,6 +175,7 @@ unifi:
       temperature: 3
       wifi: 2
       poe: 3
+      outlet.*: 1
   # Name of an existing Secret containing the key UNIFI_API_KEY.
   # Create it with:
   #   kubectl -n <namespace> create secret generic unifi-reactor-credentials \

--- a/docs/adding-a-provider.md
+++ b/docs/adding-a-provider.md
@@ -267,6 +267,25 @@ provider reuses `isp`'s) so the key is always writable in YAML, and decide what 
 count a disagreement, because picking one is arbitrary and the arbitrary pick can
 be the one that hides the failure.
 
+**Separate the two halves of that argument before you copy it.** "Open key name"
+and "unbounded cardinality" travel together for `device.<name>` and come apart
+elsewhere, so decide each on its own. `outlet.<n>` is the case that shows the
+difference: its key name is open in exactly the same way — the index until
+somebody names the outlet, the name afterwards — so it is left out of
+`StateVocabulary()` for the same reason. But eight outlets are bounded by a
+chassis rather than by a rack, nobody adds outlets to a UPS, and most installs
+have no outlet-bearing device at all, so it needs **no opt-in**: it ships on
+beside the other keys its hardware publishes. Making it the one UPS key you have
+to ask for would have been consistency with the wrong half.
+
+If you are tempted to declare a prefix — `outlet.*` with two values — instead of
+leaving the key out, work through what `reactor_state_info` promises first. It
+reports `0` for the values a key does **not** currently hold, which is what stops
+a stale series sitting at `1`, and that requires enumerating the values of a key
+that is missing from the observation. A prefix can only match keys that are
+present, so the key would go stale at `1` the moment its hardware dropped off —
+the exact failure declaring a vocabulary exists to prevent.
+
 The other detail is debounce, and it needs the engine rather than the provider:
 a `PerKey` entry may end in `*`, so `device.*: 2` settles a group whose members
 are not known when the chart is written. The engine still learns nothing — it

--- a/docs/development.md
+++ b/docs/development.md
@@ -109,6 +109,12 @@ curl -X POST 'http://localhost:9443/temperature?celsius=82'    # a device runs h
 curl -X POST 'http://localhost:9443/poe?watts=55&budget=60'    # the PoE budget fills up
 curl -X POST 'http://localhost:9443/poe?silent=true'           # a powered port reports no wattage
 curl -X POST 'http://localhost:9443/poe?port=7&name=re-patched' # ...and the write path's identity check
+
+curl http://localhost:9443/outlets                             # every outlet, and which relay group it is in
+curl -X POST 'http://localhost:9443/outlets?outlet=5&state=off'          # one outlet opens
+curl -X POST 'http://localhost:9443/outlets?switching=group&outlet=5&state=off'   # ...and takes 5-8 with it
+curl -X POST 'http://localhost:9443/outlets?outlet=5&label=nas'          # key becomes outlet.nas
+curl -X POST 'http://localhost:9443/outlets?reset=true'        # back to the capture
 ```
 
 `/poe` drives both halves of the PoE story, because the mock has one synthetic switch and one `port_table` and they are the same one: `watts`/`budget`/`silent` move what the `poe` **state key** measures, while `port`/`name`/`uplink`/`poe` break the identity checks the `unifi.poe.cycle` **action** makes. That switch is adopted and online, so it is part of the fleet `devices` counts and is addressable as `mock-switch` through `/device`.
@@ -116,6 +122,10 @@ curl -X POST 'http://localhost:9443/poe?port=7&name=re-patched' # ...and the wri
 > **`/firmware`, `/temperature` and `/poe` serve fields no capture contains.** The committed records carry no upgrade flags, no thermals and no `port_table`, so those three endpoints render the shape UniFi's API *documents* — including `poe_power` as a string, which is the form most likely to break a parser. Driving them exercises the derivation; it does not confirm a console reports any of it. Until one does, the mock's honest default is what the captures show: those keys are simply absent, and `present=false` puts each back to that state. See [the capture notes](../testdata/unifi/README.md#what-is-not-captured-yet).
 
 Per-device keys are opt-in in Reactor (`unifi.devices.perDeviceKeys`), so `device.<name>` will not appear until you ask for it — `devices` is published either way. A device is addressed by the slug of the name it was *captured* under even after `rename=`, which is what makes the rename rehearsal reversible: renaming makes the old key **vanish**, and the reconciler holds the last known state rather than treating it as a recovery.
+
+`/outlets` is the one endpoint here that rehearses a question nobody has asked the hardware. Everything it serves **is** captured — `index`, `name`, `relay_state` and `relay_group` are all in `stat-device-ups.json` — but whether a UniFi UPS switches *an outlet* or *a relay group* is unknown, and `switching=` is the mock imitating each answer in turn. With `switching=individual`, asking for outlet 5 moves outlet 5; with `switching=group` the same request takes outlets 5–8, because they share `relay_group: 2`. Rehearse both, because a parser that only ever saw one of them is a parser tested against a guess.
+
+Reactor never writes an outlet — `/outlets` is the mock's own dev surface, not a UniFi endpoint Reactor calls. Switching is [#23](https://github.com/robbeverhelst/unifi-reactor/issues/23), and the experiment that decides it is H1 on [#60](https://github.com/robbeverhelst/unifi-reactor/issues/60): with the operator watching, toggle **one** outlet by hand in the UniFi UI and read whether one `relay_state` flips or four. `outlet=5&label=nas` rehearses the other half of that visit — naming the outlets, which moves the key off the index.
 
 `/wifi` drives the `wlan` subsystem's AP counts, because that is what `wifi` is derived from. `?status=` moves the console's own wording *without* moving the counts, which is how you rehearse the disagreement Reactor reports rather than silently resolving.
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -733,6 +733,54 @@ name removed — if it does not match what Reactor logged.
 
 ---
 
+## 10f. An `outlet.<n>` key is missing, or is not the one you expected
+
+Outlets are the one key in this batch whose fields are all in a real capture, so
+a missing one is usually about *addressing* rather than about parsing:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'unifi-outlets'
+# outlets device=ups-2u outlets=outlet.1=on,outlet.2=on,... needs log.level=debug
+# relayGroups="1=[outlet.1 outlet.2 outlet.3 outlet.4] 2=[outlet.5 outlet.6 outlet.7 outlet.8]"
+```
+
+The grouping line is at INFO and appears whenever the grouping is first seen or
+changes, so it is in the default log stream.
+
+| What you see | What it means |
+| --- | --- |
+| No `unifi-outlets` line at all | No adopted device lists any outlet. Note that the captured gateway reports `"outlet_table": []` — having the field is not having outlets |
+| The key is `outlet.5` and you expected `outlet.nas` | The outlet still carries the console's `Outlet 5` placeholder. Name it in the UniFi UI; any name of the form `Outlet <number>` is treated as the index spelled out, not as a name |
+| The key was `outlet.nas` and is now gone | You renamed the outlet. The old key vanishing is lost visibility, so the last known state is **held** and `Ready=False` reports `StateKeyUnavailable` — nothing fires `onExit` because you relabelled a socket. Point the automation at the new key |
+| `Two or more outlets are addressed by the same key` | Two outlets have the same name, or one is named after another's index. Neither is published, because picking one would be arbitrary and this key names something carrying mains power. Rename one |
+| `outletsUnreadable=outlet.4=no relay_state` | That outlet will not say what position it is in. Absent is not off, so it publishes nothing rather than reporting an outage |
+| `More than one adopted device reports an outlet table` | Outlet indexes restart on every chassis, so only the first device's outlets are published. Report it on [#23](https://github.com/robbeverhelst/unifi-reactor/issues/23), which has to decide how a second one is addressed before either can be switched |
+
+### Reactor will not switch an outlet, and that is deliberate
+
+There is no action, no flag and no allowlist for it. The captured UPS puts
+outlets 1–4 in `relay_group: 1` and 5–8 in `relay_group: 2`, and nobody has
+confirmed whether the hardware switches an outlet or a whole bank — if it is the
+bank, "turn off outlet 3" means "cut outlets 1 to 4". See
+[#23](https://github.com/robbeverhelst/unifi-reactor/issues/23).
+
+If you have the console in front of you, you can settle it in a minute. Pick an
+outlet in a bank carrying nothing you care about, toggle **one** outlet in the
+UniFi UI, and read the next line Reactor logs:
+
+```text
+Outlet state changed. If you are running the relay-group experiment on issue #60, this line is its readout
+  moved=outlet.5=on->off relayGroup=2 movedInGroup=1 outletsInGroup=4
+  verdict="outlets in this group moved independently of each other"
+```
+
+`movedInGroup=1` of `4` means outlets switch individually. `4` of `4` means the
+relay group is the switching unit. Either way, post it on
+[#60](https://github.com/robbeverhelst/unifi-reactor/issues/60) — that one line
+is what unblocks #23.
+
+---
+
 ## 11. Reactor warns about your UniFi Network version
 
 ```text

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -135,6 +135,25 @@ limitations under the License.
 //	curl -X POST 'http://localhost:9443/ups?present=false'
 //	curl -X POST 'http://localhost:9443/ups?present=true'
 //
+// The outlet table is the one place here that rehearses a question nobody has
+// answered. /outlets drives the outlet.<n> state keys, and `switching` chooses
+// which hypothesis the mock imitates — because asking for outlet 5 has to be
+// able to move outlet 5 alone OR take outlets 5-8 with it, and a parser that
+// only ever saw one of those is a parser tested against a guess:
+//
+//	curl http://localhost:9443/outlets                                  # states, and the relay grouping
+//	curl -X POST 'http://localhost:9443/outlets?switching=individual&outlet=5&state=off'
+//	curl -X POST 'http://localhost:9443/outlets?switching=group&outlet=5&state=off'   # takes 5-8
+//	curl -X POST 'http://localhost:9443/outlets?group=2&state=on'
+//	curl -X POST 'http://localhost:9443/outlets?outlet=5&label=nas'     # key becomes outlet.nas
+//	curl -X POST 'http://localhost:9443/outlets?groups=false'           # no relay_group reported
+//	curl -X POST 'http://localhost:9443/outlets?present=false'          # no outlet_table at all
+//	curl -X POST 'http://localhost:9443/outlets?reset=true'
+//
+// Reactor never writes an outlet, on the mock or anywhere else — this endpoint
+// is the mock's own dev surface, not a UniFi one. See issue #23, and hypothesis
+// H1 on #60 for the experiment that says which of the two switchings is real.
+//
 // It also serves — and enforces — the write endpoints the unifi.* edge actions
 // use. These are the first things Reactor changes on a console rather than
 // reads from it, and no write has ever been made against real hardware, so the
@@ -185,6 +204,7 @@ import (
 	"log"
 	"maps"
 	"net/http"
+	"net/url"
 	"os"
 	"slices"
 	"strconv"
@@ -452,6 +472,23 @@ type mock struct {
 	// outage ended".
 	noUPS bool
 
+	// The outlet_table rewrites, which is the only part of this mock that
+	// rehearses a question nobody has answered yet.
+	//
+	// outletOpen holds the outlets switched off, by their captured index, and
+	// outletLabels renames them — which moves their state key from outlet.<n>
+	// to outlet.<slug>, so the naming argument can be seen rather than only
+	// read about. outletGrouped is the hypothesis under test: with it set, one
+	// outlet cannot move alone and takes its whole relay group with it. See
+	// setOutlets. noOutlets drops the table entirely and noRelayGroups drops
+	// only the relay_group field, which is a readable outlet whose blast radius
+	// is unknown.
+	outletOpen    map[int]bool
+	outletLabels  map[int]string
+	outletGrouped bool
+	noOutlets     bool
+	noRelayGroups bool
+
 	// wlans is the wlanconf table the write actions read and change. Synthetic
 	// — see the package comment — and keyed by the id the mock made up.
 	wlans map[string]map[string]any
@@ -495,6 +532,8 @@ func main() {
 		wlans:           mockWLANs(),
 		switchDevice:    mockSwitch(),
 		deviceOverrides: map[string]*deviceOverride{},
+		outletOpen:      map[int]bool{},
+		outletLabels:    map[int]string{},
 	}
 	if raw, err := os.ReadFile(*deliveryFile); err == nil {
 		m.delivery = raw
@@ -557,6 +596,8 @@ func main() {
 	mux.HandleFunc("POST /firmware", m.setFirmware)
 	mux.HandleFunc("POST /temperature", m.setTemperature)
 	mux.HandleFunc("POST /wifi", m.setWiFi)
+	mux.HandleFunc("GET /outlets", m.describeOutlets)
+	mux.HandleFunc("POST /outlets", m.setOutlets)
 
 	// The write path: the Network application under /proxy/network, but
 	// authenticated the UniFi OS way — a session cookie plus the csrf header.
@@ -655,9 +696,10 @@ func (m *mock) rewriteFleet(device map[string]any) bool {
 	if override != nil && override.absent {
 		return false
 	}
-	// PoE is set for the whole mock rather than per device, so it applies
-	// whether or not this device has overrides of its own.
+	// PoE and the outlet table are set for the whole mock rather than per
+	// device, so they apply whether or not this device has overrides of its own.
 	m.rewritePoE(device)
+	m.rewriteOutlets(device)
 	if override == nil {
 		return true
 	}
@@ -829,8 +871,8 @@ func (m *mock) rewriteThermals(device map[string]any, override *deviceOverride) 
 	// The per-sensor form, with a null-valued sensor beside the real one: a
 	// sensor that reports nothing is a case the parser must not read as 0 °C.
 	device["temperatures"] = []any{
-		map[string]any{"name": "CPU", "type": "cpu", "value": *override.celsius},
-		map[string]any{"name": "System", "type": "board", "value": nil},
+		map[string]any{fieldName: "CPU", fieldType: "cpu", "value": *override.celsius},
+		map[string]any{fieldName: "System", fieldType: "board", "value": nil},
 	}
 }
 
@@ -1312,6 +1354,378 @@ func (m *mock) setUPS(w http.ResponseWriter, r *http.Request) {
 		"ups": state, "battery": m.battLvl,
 		"runtime": m.runtime, "output": m.output, paramBudget: m.budget,
 	})
+}
+
+// The outlet_table fields, named once so the mock and the parser agree on them
+// exactly. Unlike the PoE and thermal fields, every one of these IS in the
+// committed capture — this endpoint rewrites ground truth rather than inventing
+// a shape.
+const (
+	fieldOutletTable = "outlet_table"
+	fieldIndex       = "index"
+	fieldRelayState  = "relay_state"
+	fieldRelayGroup  = "relay_group"
+
+	paramOutlet = "outlet"
+	paramGroup  = "group"
+	paramState  = "state"
+)
+
+// capturedOutlets is the outlet table exactly as captured, for a handler that
+// needs to know which outlets exist and which relay group each is in. Callers
+// hold the lock.
+func (m *mock) capturedOutlets() []map[string]any {
+	var devices []any
+	if err := json.Unmarshal(m.pristine, &devices); err != nil {
+		return nil
+	}
+	for _, d := range devices {
+		device, ok := d.(map[string]any)
+		if !ok {
+			continue
+		}
+		table, ok := device[fieldOutletTable].([]any)
+		if !ok || len(table) == 0 {
+			// The captured gateway carries "outlet_table": [], so having the
+			// field is not the same as having outlets. Taking the first device
+			// with the field would hand back the gateway's empty one and hide
+			// the UPS behind it.
+			continue
+		}
+		outlets := make([]map[string]any, 0, len(table))
+		for _, entry := range table {
+			if outlet, ok := entry.(map[string]any); ok {
+				outlets = append(outlets, outlet)
+			}
+		}
+		return outlets
+	}
+	return nil
+}
+
+// outletIndex reads one captured outlet's index.
+func outletIndex(outlet map[string]any) (int, bool) {
+	index, ok := toFloat(outlet[fieldIndex])
+	return int(index), ok
+}
+
+// outletGroup reads one captured outlet's relay group.
+func outletGroup(outlet map[string]any) (int, bool) {
+	group, ok := toFloat(outlet[fieldRelayGroup])
+	return int(group), ok
+}
+
+// rewriteOutlets applies the outlet overrides to a device carrying an outlet
+// table. Callers hold the lock.
+func (m *mock) rewriteOutlets(device map[string]any) {
+	table, present := device[fieldOutletTable].([]any)
+	if !present {
+		return
+	}
+	if m.noOutlets {
+		delete(device, fieldOutletTable)
+		return
+	}
+	for _, entry := range table {
+		outlet, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		index, known := outletIndex(outlet)
+		if !known {
+			continue
+		}
+		if m.outletOpen[index] {
+			outlet[fieldRelayState] = false
+		}
+		if label := m.outletLabels[index]; label != "" {
+			outlet[fieldName] = label
+		}
+		if m.noRelayGroups {
+			delete(outlet, fieldRelayGroup)
+		}
+	}
+}
+
+// setOutlets drives the outlet table, and it is the only endpoint here that
+// rehearses a question the hardware has not answered.
+//
+//	?outlet=5&state=off     switch one outlet
+//	?group=2&state=off      switch a whole relay group
+//	?switching=group        make one outlet unable to move alone
+//	?outlet=5&label=nas     name an outlet, moving its key to outlet.nas
+//	?groups=false           an outlet reporting no relay_group at all
+//	?present=false          no outlet_table at all
+//	?reset=true             back to the capture
+//
+// switching is what makes both hypotheses reachable from the same request.
+// Nobody has confirmed whether a UniFi UPS switches an outlet or a bank, so
+// asking for outlet 5 has to be able to produce either reading: on its own with
+// switching=individual, and taking outlets 5-8 with it under switching=group.
+// A parser that only ever saw one of those would be a parser tested against a
+// guess. See issue #23, and hypothesis H1 on #60 for the experiment that
+// settles which of these two the mock is imitating.
+func (m *mock) setOutlets(w http.ResponseWriter, r *http.Request) {
+	query := r.URL.Query()
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if query.Get("reset") != "" {
+		m.outletOpen = map[int]bool{}
+		m.outletLabels = map[int]string{}
+		m.outletGrouped, m.noOutlets, m.noRelayGroups = false, false, false
+		log.Print("outlets are back to the capture: all eight closed, unnamed, in two relay groups")
+		m.writeOutlets(w)
+		return
+	}
+	if raw := query.Get(fieldPresent); raw != "" {
+		present, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "present must be a boolean", http.StatusBadRequest)
+			return
+		}
+		m.noOutlets = !present
+	}
+	if raw := query.Get("groups"); raw != "" {
+		grouped, err := strconv.ParseBool(raw)
+		if err != nil {
+			http.Error(w, "groups must be a boolean", http.StatusBadRequest)
+			return
+		}
+		m.noRelayGroups = !grouped
+	}
+	switch query.Get("switching") {
+	case "group":
+		m.outletGrouped = true
+	case "individual":
+		m.outletGrouped = false
+	case "":
+	default:
+		http.Error(w, `switching must be "individual" or "group"`, http.StatusBadRequest)
+		return
+	}
+
+	outlets := m.capturedOutlets()
+	if !m.applyOutletMove(w, query, outlets) {
+		return
+	}
+	if !m.applyOutletLabel(w, query, outlets) {
+		return
+	}
+
+	log.Printf("outlets: switching=%s open=%s labels=%s groups=%v present=%v",
+		m.switchingMode(), describeOpenOutlets(m.outletOpen), describeLabels(m.outletLabels),
+		!m.noRelayGroups, !m.noOutlets)
+	m.writeOutlets(w)
+}
+
+// applyOutletMove opens or closes whatever the request addressed, and reports
+// whether the request was valid.
+func (m *mock) applyOutletMove(w http.ResponseWriter, query url.Values, outlets []map[string]any) bool {
+	outlet, group := query.Get(paramOutlet), query.Get(paramGroup)
+	if outlet == "" && group == "" {
+		return true
+	}
+	if query.Get(paramState) == "" {
+		// An outlet can be addressed to be named rather than switched, so a
+		// missing state is only a mistake when there is nothing else to do to
+		// it. Saying which is better than silently doing nothing.
+		if _, naming := query["label"]; naming && group == "" {
+			return true
+		}
+		http.Error(w, "an addressed outlet or group needs a state: ?outlet=5&state=off", http.StatusBadRequest)
+		return false
+	}
+	open, ok := parseOutletState(w, query.Get(paramState))
+	if !ok {
+		return false
+	}
+
+	moved := map[int]bool{}
+	if group != "" {
+		wanted, err := strconv.Atoi(group)
+		if err != nil {
+			http.Error(w, "group must be a relay group number", http.StatusBadRequest)
+			return false
+		}
+		for _, o := range outlets {
+			index, known := outletIndex(o)
+			if got, grouped := outletGroup(o); known && grouped && got == wanted {
+				moved[index] = true
+			}
+		}
+		if len(moved) == 0 {
+			http.Error(w, "no captured outlet is in relay group "+group, http.StatusBadRequest)
+			return false
+		}
+	}
+	if outlet != "" {
+		wanted, err := strconv.Atoi(outlet)
+		if err != nil {
+			http.Error(w, "outlet must be an outlet index", http.StatusBadRequest)
+			return false
+		}
+		if !m.addressOutlet(w, wanted, outlets, moved) {
+			return false
+		}
+	}
+	for index := range moved {
+		m.outletOpen[index] = open
+	}
+	return true
+}
+
+// addressOutlet works out which outlets a request for ONE outlet actually
+// moves, which is the whole question #23 is blocked on: under switching=group
+// it is every outlet in that outlet's relay group.
+func (m *mock) addressOutlet(w http.ResponseWriter, wanted int, outlets []map[string]any, moved map[int]bool) bool {
+	var group int
+	grouped := false
+	for _, o := range outlets {
+		index, known := outletIndex(o)
+		if !known || index != wanted {
+			continue
+		}
+		group, grouped = outletGroup(o)
+		moved[wanted] = true
+	}
+	if !moved[wanted] {
+		http.Error(w, "no captured outlet has index "+strconv.Itoa(wanted), http.StatusBadRequest)
+		return false
+	}
+	if !m.outletGrouped || !grouped {
+		return true
+	}
+	for _, o := range outlets {
+		index, known := outletIndex(o)
+		if got, inGroup := outletGroup(o); known && inGroup && got == group {
+			moved[index] = true
+		}
+	}
+	return true
+}
+
+// applyOutletLabel names an outlet, which is what moves its key off the index.
+func (m *mock) applyOutletLabel(w http.ResponseWriter, query url.Values, outlets []map[string]any) bool {
+	label, given := query["label"]
+	if !given {
+		return true
+	}
+	raw := query.Get(paramOutlet)
+	if raw == "" {
+		http.Error(w, "label needs an outlet to name: ?outlet=5&label=nas", http.StatusBadRequest)
+		return false
+	}
+	wanted, err := strconv.Atoi(raw)
+	if err != nil {
+		http.Error(w, "outlet must be an outlet index", http.StatusBadRequest)
+		return false
+	}
+	for _, o := range outlets {
+		if index, known := outletIndex(o); known && index == wanted {
+			m.outletLabels[wanted] = label[0]
+			return true
+		}
+	}
+	http.Error(w, "no captured outlet has index "+raw, http.StatusBadRequest)
+	return false
+}
+
+// parseOutletState reads on/off, which is the vocabulary the state key uses
+// rather than the true/false the API carries.
+func parseOutletState(w http.ResponseWriter, state string) (open bool, ok bool) {
+	switch state {
+	case "off":
+		return true, true
+	case "on":
+		return false, true
+	default:
+		http.Error(w, `state must be "on" or "off"`, http.StatusBadRequest)
+		return false, false
+	}
+}
+
+func (m *mock) switchingMode() string {
+	if m.outletGrouped {
+		return "group"
+	}
+	return "individual"
+}
+
+// describeOutlets answers what the outlets are doing and, more importantly,
+// which of them share a relay group.
+func (m *mock) describeOutlets(w http.ResponseWriter, _ *http.Request) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.writeOutlets(w)
+}
+
+// writeOutlets renders the outlet picture. Callers hold the lock.
+func (m *mock) writeOutlets(w http.ResponseWriter) {
+	outlets := make([]any, 0, 8)
+	groups := map[string][]string{}
+	for _, o := range m.capturedOutlets() {
+		index, known := outletIndex(o)
+		if !known {
+			continue
+		}
+		name, _ := o[fieldName].(string)
+		if label := m.outletLabels[index]; label != "" {
+			name = label
+		}
+		state := "on"
+		if m.outletOpen[index] {
+			state = "off"
+		}
+		entry := map[string]any{fieldIndex: index, fieldName: name, paramState: state}
+		if group, grouped := outletGroup(o); grouped && !m.noRelayGroups {
+			entry[fieldRelayGroup] = group
+			key := strconv.Itoa(group)
+			groups[key] = append(groups[key], "outlet."+strconv.Itoa(index))
+		}
+		outlets = append(outlets, entry)
+	}
+	if m.noOutlets {
+		outlets, groups = nil, nil
+	}
+	writeJSON(w, map[string]any{
+		"outlets":     outlets,
+		"relayGroups": groups,
+		"switching":   m.switchingMode(),
+		keyNote: "the outlet table IS captured, unlike the PoE and thermal fields — but " +
+			"whether this UPS switches an outlet or a whole relay group is NOT known, and " +
+			"switching=group vs switching=individual is this mock imitating each guess. " +
+			"Reactor never writes an outlet; see issue #23 and hypothesis H1 on #60",
+	})
+}
+
+func describeOpenOutlets(open map[int]bool) string {
+	var indexes []int
+	for index, isOpen := range open {
+		if isOpen {
+			indexes = append(indexes, index)
+		}
+	}
+	if len(indexes) == 0 {
+		return "none"
+	}
+	slices.Sort(indexes)
+	parts := make([]string, 0, len(indexes))
+	for _, index := range indexes {
+		parts = append(parts, strconv.Itoa(index))
+	}
+	return strings.Join(parts, "/")
+}
+
+func describeLabels(labels map[int]string) string {
+	if len(labels) == 0 {
+		return "none"
+	}
+	parts := make([]string, 0, len(labels))
+	for _, index := range slices.Sorted(maps.Keys(labels)) {
+		parts = append(parts, strconv.Itoa(index)+"="+labels[index])
+	}
+	return strings.Join(parts, ",")
 }
 
 // overrideFor is the rewrite record for one captured device, created on first
@@ -2106,13 +2520,13 @@ func (m *mock) fireAlarm(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	for _, rule := range rules {
-		url, token := ruleURL(rule), ruleToken(rule)
-		if url == "" {
+		endpoint, token := ruleURL(rule), ruleToken(rule)
+		if endpoint == "" {
 			continue
 		}
-		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, url, bytes.NewReader(m.delivery))
+		req, err := http.NewRequestWithContext(r.Context(), http.MethodPost, endpoint, bytes.NewReader(m.delivery))
 		if err != nil {
-			log.Printf("delivery to %s could not be built: %v", url, err)
+			log.Printf("delivery to %s could not be built: %v", endpoint, err)
 			continue
 		}
 		req.Header.Set("Content-Type", "application/json")
@@ -2121,14 +2535,14 @@ func (m *mock) fireAlarm(w http.ResponseWriter, r *http.Request) {
 		}
 		resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
 		if err != nil {
-			log.Printf("delivery to %s failed: %v", url, err)
-			_, _ = fmt.Fprintf(w, "delivery to %s failed: %v\n", url, err)
+			log.Printf("delivery to %s failed: %v", endpoint, err)
+			_, _ = fmt.Fprintf(w, "delivery to %s failed: %v\n", endpoint, err)
 			continue
 		}
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
-		log.Printf("delivered to %s -> %s", url, resp.Status)
-		_, _ = fmt.Fprintf(w, "delivered to %s -> %s\n", url, resp.Status)
+		log.Printf("delivered to %s -> %s", endpoint, resp.Status)
+		_, _ = fmt.Fprintf(w, "delivered to %s -> %s\n", endpoint, resp.Status)
 	}
 }
 
@@ -2139,8 +2553,8 @@ func ruleURL(rule map[string]any) string {
 	if !ok {
 		return ""
 	}
-	url, _ := data["url"].(string)
-	return url
+	endpoint, _ := data["url"].(string)
+	return endpoint
 }
 
 func ruleToken(rule map[string]any) string {

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -132,11 +132,20 @@ type Client struct {
 
 	// mu guards previous only.
 	mu sync.Mutex
-	// previous remembers the last WAN signals so that a change in one can be
-	// checked against a change in the other. Nothing is ever derived from it:
-	// it exists so a disagreement between two independent signals is reported
-	// instead of one of them being silently trusted. See crossCheckOverTime.
-	previous struct{ wan, isp string }
+	// previous remembers what the last poll saw, so that a change can be
+	// described rather than merely reported. Nothing is ever derived from it —
+	// no state key's value depends on it — and it exists twice over:
+	//
+	//   - wan and isp, so a disagreement between two independent signals for
+	//     one fact is reported instead of one of them being silently trusted.
+	//     See crossCheckOverTime.
+	//   - outlets, so an outlet that moves can be reported together with how
+	//     much of its relay group moved with it, which is the readout of the
+	//     experiment #23 is waiting on. See reportOutlets.
+	previous struct {
+		wan, isp string
+		outlets  outletSnapshot
+	}
 }
 
 // NewClient creates a UniFi client. UniFi OS consoles serve a self-signed
@@ -203,6 +212,7 @@ type deviceRecord struct {
 	firmwareFields
 	temperatureFields
 	poeFields
+	outletFields
 }
 
 type wanPort struct {
@@ -272,6 +282,7 @@ type vbmsTable struct {
 //	temperature  normal  | high              (the hottest adopted device)
 //	wifi         ok | warning | error        (the WLAN subsystem as a whole)
 //	poe          ok | insufficient           (headroom on the worst switch)
+//	outlet.<n>   on | off                    (one switchable UPS outlet; read-only)
 //
 // ups and ups.battery are deliberately independent: a `when: {ups: on-battery}`
 // automation must stay matched for the whole outage, including as the battery
@@ -363,6 +374,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	var firmware firmwareTally
 	heat := newTemperatureTally(c.HighTemperatureCelsius)
 	poe := newPoETally(c.MaxPoEUtilizationPercent)
+	outlets := newOutletTally()
 
 	for _, d := range parsed.Data {
 		// The fleet keys are about devices the console manages, so an unadopted
@@ -374,6 +386,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 			firmware.observe(d)
 			heat.observe(ctx, d)
 			poe.observe(d)
+			outlets.observe(d)
 		} else {
 			logf.FromContext(ctx).WithName("unifi-devices").V(1).Info(
 				"Skipping a device that is not adopted", "model", d.Model, "type", d.Type)
@@ -408,6 +421,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	firmware.publish(ctx, state)
 	heat.publish(ctx, state)
 	poe.publish(ctx, state)
+	c.reportOutlets(ctx, outlets.publish(ctx, state))
 
 	if len(state) == 0 {
 		return nil, fmt.Errorf(

--- a/internal/providers/unifi/outlets.go
+++ b/internal/providers/unifi/outlets.go
@@ -1,0 +1,406 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
+)
+
+// This file READS outlet state and nothing else. There is deliberately no way
+// to change an outlet from here — not behind a flag, not through a helper, not
+// reachable at all — because nobody yet knows what a UniFi UPS does with a
+// per-index write.
+//
+// The whole reason to observe them first is in the captured table: outlets 1-4
+// report relay_group 1 and outlets 5-8 report relay_group 2. If the relay GROUP
+// is what the hardware switches, then asking for outlet 3 to go off takes
+// outlets 1-4 with it, and one of those may be carrying the gateway, the switch
+// or the storage. The documented write path — outlet_overrides via PUT
+// rest/device — comes from the USP-PDU-Pro and USP-Strip, which expose
+// per-outlet power, current and cycle_enabled and have no relay_group at all,
+// so it is documented for a different device class and settles nothing here.
+//
+// Observation is the instrument that settles it safely: with these keys
+// published, a human toggles ONE outlet by hand in the UniFi UI and reads off
+// whether one relay_state moved or four. That is hypothesis H1 on issue #60,
+// and reportOutlets below prints its answer in words rather than leaving it to
+// be reconstructed from a graph. Switching itself stays deferred in #23 until
+// that experiment has been run.
+
+// outletFields is the outlet block a UniFi UPS reports, embedded in
+// deviceRecord so it decodes from the same flat object.
+type outletFields struct {
+	// OutletTable is present on a UniFi UPS and absent on everything else in
+	// the captures. A device without one contributes no outlet keys at all,
+	// which is the same "omit what you cannot see" rule the rest of the state
+	// model follows.
+	OutletTable []outletRecord `json:"outlet_table"`
+}
+
+// outletRecord is one switchable outlet, exactly as captured. Every field this
+// derives anything from is a pointer, for the reason the fleet keys use
+// pointers: absent is absent. An outlet that does not report relay_state is not
+// an outlet that is off, and reading it as off would be the direction that
+// invents an outage.
+type outletRecord struct {
+	// Index is the outlet's position on the chassis, and the fallback the key
+	// is addressed by while nobody has named it.
+	Index *int `json:"index"`
+	// Name is "Outlet 1" … "Outlet 8" out of the box, which carries no
+	// information the index does not. A name a person chose is what makes the
+	// key readable; see outletSuffix.
+	Name string `json:"name"`
+	// RelayState is the switch position: true is closed, delivering mains.
+	RelayState *bool `json:"relay_state"`
+	// RelayGroup is the bank the outlet belongs to. NOTHING is derived from it
+	// — it is not part of any key, any value, or any decision — and it is read
+	// only so that it can be reported. It is the fact somebody has to know
+	// before writing an automation against an outlet, and #23 cannot be
+	// designed without it.
+	RelayGroup *int `json:"relay_group"`
+}
+
+// outletSuffix is what an outlet's key is addressed by: its index while it
+// carries the name the console gave it, and the slug of its name once somebody
+// has named it something.
+//
+// "Outlet 3" is not a name, it is the index spelled out, so it is treated as
+// the absence of one. Any name of that shape is — a UPS whose outlet 7 is
+// called "Outlet 3" is a mislabelled console, and keying it as outlet.3 would
+// put one outlet's state under another's address, which on a key that will one
+// day be used to cut mains power is the worst available failure.
+//
+// The index is the fallback rather than the plan. An automation matching
+// outlet.3 means something different the moment somebody re-plugs the rack,
+// which is the same argument that made portName required rather than optional
+// for unifi.poe.cycle in #66: hardware should be addressed by what it is, not
+// by where it happens to be plugged.
+func outletSuffix(index *int, name string) (string, bool) {
+	slug := slugify(name)
+	if slug != "" && !isConsoleOutletName(slug) {
+		return slug, true
+	}
+	if index == nil {
+		return "", false
+	}
+	return strconv.Itoa(*index), true
+}
+
+// isConsoleOutletName reports whether a slug is the console's own "Outlet N"
+// placeholder rather than a name anyone chose.
+func isConsoleOutletName(slug string) bool {
+	digits, isOutlet := strings.CutPrefix(slug, "outlet-")
+	if !isOutlet || digits == "" {
+		return false
+	}
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// outletTally accumulates one device's outlet table into per-outlet keys.
+//
+// One device's, not the fleet's: outlet indexes restart at 1 on every chassis,
+// so two devices reporting outlet tables would both claim outlet.1. The first
+// device reporting one wins, exactly as the first gateway and the first UPS do,
+// and a second is named in a log line rather than silently merged.
+type outletTally struct {
+	// device is the slug of the device the outlets belong to, for the
+	// diagnostic line.
+	device string
+	// claimed records that a device with an outlet table has been taken.
+	claimed bool
+	// perOutlet is each outlet's value, keyed by the full state key, and shared
+	// holds the keys more than one outlet landed on — a mislabelled console
+	// rather than an observation, published as neither outlet's state.
+	perOutlet map[string]string
+	shared    map[string]bool
+	// group is each key's relay group, and groups the reverse: which keys share
+	// a bank. Both are reported, never derived from.
+	group  map[string]int
+	groups map[int][]string
+	// ungrouped are outlets that report no relay group at all, which is a
+	// readable outlet whose blast radius is unknown.
+	ungrouped []string
+	// unreadable names the outlets that could not be read, so an outlet missing
+	// from the keys is explained rather than merely absent.
+	unreadable []string
+	// ignored names devices whose outlet tables were skipped because another
+	// device's table was already taken.
+	ignored []string
+}
+
+func newOutletTally() *outletTally {
+	return &outletTally{
+		perOutlet: map[string]string{},
+		shared:    map[string]bool{},
+		group:     map[string]int{},
+		groups:    map[int][]string{},
+	}
+}
+
+// observe folds one adopted device's outlet table into the tally.
+func (t *outletTally) observe(d deviceRecord) {
+	if len(d.OutletTable) == 0 {
+		return
+	}
+	name := slugify(d.Name)
+	if name == "" {
+		name = strings.ToLower(d.Model)
+	}
+	if t.claimed {
+		t.ignored = append(t.ignored, name)
+		return
+	}
+	t.claimed, t.device = true, name
+
+	for _, outlet := range d.OutletTable {
+		suffix, addressable := outletSuffix(outlet.Index, outlet.Name)
+		if !addressable {
+			// No index and no name is an outlet with no address. It exists, and
+			// there is nothing to publish it under.
+			t.unreadable = append(t.unreadable, "(unaddressable outlet)")
+			continue
+		}
+		key := stateKeyOutletPrefix + suffix
+		if outlet.RelayState == nil {
+			// Absent is not off. An outlet whose switch position is unknown
+			// publishes nothing, and is named here instead.
+			t.unreadable = append(t.unreadable, key+"=no relay_state")
+			continue
+		}
+
+		value := outletOff
+		if *outlet.RelayState {
+			value = outletOn
+		}
+		if _, already := t.perOutlet[key]; already {
+			t.shared[key] = true
+		}
+		t.perOutlet[key] = value
+
+		if outlet.RelayGroup == nil {
+			t.ungrouped = append(t.ungrouped, key)
+			continue
+		}
+		t.group[key] = *outlet.RelayGroup
+		t.groups[*outlet.RelayGroup] = append(t.groups[*outlet.RelayGroup], key)
+	}
+}
+
+// publish writes the outlet keys into the state map and returns what was
+// observed, so the next poll can say which outlets moved together.
+func (t *outletTally) publish(ctx context.Context, state map[string]string) outletSnapshot {
+	log := logf.FromContext(ctx).WithName("unifi-outlets")
+	if !t.claimed {
+		return outletSnapshot{}
+	}
+	if len(t.ignored) > 0 {
+		// Merging two chassis' outlet tables would put one device's outlet 1
+		// under the other's key. Naming the ignored device is the honest
+		// version of a limitation; #23 has to decide how a second one is
+		// addressed before either can be switched.
+		log.Info("More than one adopted device reports an outlet table; only the first is published, "+
+			"because outlet indexes restart on every chassis and merging them would put one device's "+
+			"outlet under another's key. Please report it on issue #23",
+			"published", t.device, "ignored", strings.Join(t.ignored, ","))
+	}
+
+	snapshot := outletSnapshot{
+		device: t.device,
+		state:  map[string]string{},
+		group:  map[string]int{},
+		groups: map[int][]string{},
+	}
+	for key, value := range t.perOutlet {
+		if t.shared[key] {
+			// Two outlets addressed the same way, which happens when a console
+			// has two outlets named the same thing, or one named after another
+			// one's index. Publishing either would be arbitrary, and on a key
+			// that names something carrying mains power the arbitrary choice is
+			// not one to make.
+			metrics.SignalsDisagreed(ProviderName, signalOutletNameShared)
+			log.Info("Two or more outlets are addressed by the same key, so that key reports neither of "+
+				"them; rename one on the console to tell them apart", "key", key)
+			continue
+		}
+		state[key] = value
+		snapshot.state[key] = value
+		if group, grouped := t.group[key]; grouped {
+			snapshot.group[key] = group
+			snapshot.groups[group] = append(snapshot.groups[group], key)
+		}
+	}
+	for _, members := range snapshot.groups {
+		slices.Sort(members)
+	}
+	snapshot.ungrouped = t.ungroupedPublished(snapshot.state)
+	snapshot.grouping = describeGrouping(snapshot.groups, snapshot.ungrouped)
+
+	log.V(1).Info("outlets", "device", t.device, "outlets", describeOutlets(snapshot.state),
+		"relayGroups", snapshot.grouping, "outletsUnreadable", strings.Join(t.unreadable, ","))
+	return snapshot
+}
+
+// ungroupedPublished is the outlets that reported no relay group and survived
+// the shared-key check.
+func (t *outletTally) ungroupedPublished(published map[string]string) []string {
+	var keys []string
+	for _, key := range t.ungrouped {
+		if _, ok := published[key]; ok {
+			keys = append(keys, key)
+		}
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// outletSnapshot is one poll's outlet picture, kept so the next poll can report
+// not just that an outlet moved but whether its whole relay group moved with
+// it. That comparison is the entire readout of hypothesis H1 on #60.
+type outletSnapshot struct {
+	device string
+	// state is each published key's value.
+	state map[string]string
+	// group is each key's relay group; groups is the reverse, sorted.
+	group  map[string]int
+	groups map[int][]string
+	// grouping is the rendered form, so "has the grouping changed" is a string
+	// comparison and the answer can be logged verbatim.
+	grouping string
+	// ungrouped are the published keys reporting no relay group.
+	ungrouped []string
+}
+
+// observed reports whether any outlet was seen at all.
+func (s outletSnapshot) observed() bool { return len(s.state) > 0 }
+
+// reportOutlets says out loud what an outlet change means, and it is the reason
+// this key ships before any way to write one.
+//
+// Two lines, both at INFO because the person running the experiment on #60 is
+// reading the default log stream rather than a debug one:
+//
+//   - the grouping itself, whenever it is first seen or changes. This is what
+//     has to be understood before an automation is written against an outlet.
+//   - what moved, whenever a relay_state changes, together with how much of its
+//     relay group moved with it. One outlet of four is the individually
+//     switchable answer; four of four is the relay-group answer, and #23's API
+//     has to be per-group and say so.
+//
+// The reading is taken from the raw observation rather than from reported
+// state, which is the same thing here: outlet keys are debounced at 1 sample,
+// because a relay is a switch position and not a measurement.
+func (c *Client) reportOutlets(ctx context.Context, current outletSnapshot) {
+	log := logf.FromContext(ctx).WithName("unifi-outlets")
+
+	c.mu.Lock()
+	previous := c.previous.outlets
+	c.previous.outlets = current
+	c.mu.Unlock()
+
+	if !current.observed() {
+		return
+	}
+	if !previous.observed() || previous.grouping != current.grouping {
+		log.Info("A UPS is reporting switchable outlets. Reactor only READS them — switching is deferred "+
+			"in issue #23 until the relay grouping below is understood: if the relay group is what the "+
+			"hardware switches, changing one outlet changes every outlet in its group. To settle it, "+
+			"toggle ONE outlet by hand in the UniFi UI and read the next line",
+			"device", current.device, "relayGroups", current.grouping,
+			"outlets", describeOutlets(current.state))
+		return
+	}
+
+	moved := map[int][]string{}
+	var movedUngrouped []string
+	for key, value := range current.state {
+		was, known := previous.state[key]
+		if !known || was == value {
+			continue
+		}
+		change := key + "=" + was + "->" + value
+		if group, grouped := current.group[key]; grouped {
+			moved[group] = append(moved[group], change)
+			continue
+		}
+		movedUngrouped = append(movedUngrouped, change)
+	}
+
+	for _, group := range slices.Sorted(maps.Keys(moved)) {
+		changes := moved[group]
+		slices.Sort(changes)
+		size := len(current.groups[group])
+		log.Info("Outlet state changed. If you are running the relay-group experiment on issue #60, "+
+			"this line is its readout", "moved", strings.Join(changes, ","),
+			"relayGroup", group, "movedInGroup", len(changes), "outletsInGroup", size,
+			"verdict", groupVerdict(len(changes), size))
+	}
+	if len(movedUngrouped) > 0 {
+		slices.Sort(movedUngrouped)
+		log.Info("Outlet state changed on outlets reporting no relay group, so nothing can be said "+
+			"about what else would move with them", "moved", strings.Join(movedUngrouped, ","))
+	}
+}
+
+// groupVerdict is what one poll's movement says about the question #23 is
+// blocked on. It is stated as a reading rather than a conclusion: one poll is
+// evidence, and the operator toggling the outlet is the one who knows whether
+// they touched one outlet or a bank.
+func groupVerdict(moved, size int) string {
+	switch {
+	case size <= 1:
+		return "inconclusive: a relay group of one cannot tell the two apart"
+	case moved < size:
+		return "outlets in this group moved independently of each other"
+	default:
+		return "every outlet in this group moved at once — if you toggled only one, " +
+			"the relay group is the switching unit and #23 must be per-group"
+	}
+}
+
+// describeGrouping renders which outlets share a bank: "1=[outlet.1 outlet.2]".
+func describeGrouping(groups map[int][]string, ungrouped []string) string {
+	parts := make([]string, 0, len(groups)+1)
+	for _, group := range slices.Sorted(maps.Keys(groups)) {
+		parts = append(parts, strconv.Itoa(group)+"=["+strings.Join(groups[group], " ")+"]")
+	}
+	if len(ungrouped) > 0 {
+		parts = append(parts, "none=["+strings.Join(ungrouped, " ")+"]")
+	}
+	return strings.Join(parts, " ")
+}
+
+// describeOutlets renders each outlet's current position, in key order.
+func describeOutlets(state map[string]string) string {
+	parts := make([]string, 0, len(state))
+	for _, key := range slices.Sorted(maps.Keys(state)) {
+		parts = append(parts, key+"="+state[key])
+	}
+	return strings.Join(parts, ",")
+}

--- a/internal/providers/unifi/outlets.go
+++ b/internal/providers/unifi/outlets.go
@@ -52,10 +52,14 @@ import (
 // outletFields is the outlet block a UniFi UPS reports, embedded in
 // deviceRecord so it decodes from the same flat object.
 type outletFields struct {
-	// OutletTable is present on a UniFi UPS and absent on everything else in
-	// the captures. A device without one contributes no outlet keys at all,
-	// which is the same "omit what you cannot see" rule the rest of the state
-	// model follows.
+	// OutletTable carries the outlets. A device without one contributes no
+	// outlet keys at all, which is the same "omit what you cannot see" rule the
+	// rest of the state model follows.
+	//
+	// An EMPTY one contributes nothing either, and that is not a hypothetical:
+	// the captured gateway reports "outlet_table": [], so having the field is
+	// not the same as having outlets. A device is the outlet-bearing one when
+	// it lists outlets, never when it merely mentions the field.
 	OutletTable []outletRecord `json:"outlet_table"`
 }
 

--- a/internal/providers/unifi/outlets_test.go
+++ b/internal/providers/unifi/outlets_test.go
@@ -26,6 +26,9 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // outlet builds one outlet_table entry. A nil relayState is an outlet that does
@@ -202,6 +205,22 @@ func TestNoOutletTableMeansNoKeys(t *testing.T) {
 	}
 }
 
+// The captured gateway reports "outlet_table": [], so a device that merely
+// mentions the field is not the outlet-bearing one. Taking the first device
+// with the field rather than the first with outlets would claim the gateway's
+// empty table and hide the UPS behind it.
+func TestAnEmptyOutletTableIsNotAnOutletBearingDevice(t *testing.T) {
+	gateway := adoptedDevice("Dream Machine Pro", deviceStateOnline)
+	gateway.OutletTable = []outletRecord{}
+	group := 1
+	state := outletState(t, gateway, upsWithOutlets("UPS 2U", outlet(1, "Outlet 1", boolPtr(true), &group)))
+
+	if state[stateKeyOutletPrefix+"1"] != outletOn {
+		t.Errorf("state[outlet.1] = %q, want the UPS behind the gateway's empty table to be read",
+			state[stateKeyOutletPrefix+"1"])
+	}
+}
+
 // Two outlets addressed the same way publish neither. Picking one would be
 // arbitrary, and this key names something carrying mains power.
 func TestOutletsSharingAKeyPublishNeither(t *testing.T) {
@@ -319,7 +338,7 @@ func TestBothRelayHypothesesAreObservable(t *testing.T) {
 			for _, index := range tt.off {
 				opened[index] = true
 			}
-			var second []outletRecord
+			second := make([]outletRecord, 0, len(capturedGrouping()))
 			for _, o := range capturedGrouping() {
 				if opened[*o.Index] {
 					o.RelayState = boolPtr(false)
@@ -342,6 +361,74 @@ func TestBothRelayHypothesesAreObservable(t *testing.T) {
 	}
 }
 
+// The log line is the deliverable, not a side effect: #61 exists so that a
+// human toggling one outlet by hand can read the answer to H1, and an answer
+// nobody can see is not one. Both readings are asserted through two
+// consecutive observations, at INFO, naming the relay group and how much of it
+// moved.
+func TestOutletChangeIsReportedWithItsRelayGroup(t *testing.T) {
+	tests := []struct {
+		name string
+		off  []int
+		want []string
+	}{
+		{
+			name: "one outlet of four",
+			off:  []int{5},
+			want: []string{"outlet.5=on->off", "movedInGroup\"=1", "outletsInGroup\"=4", "independently"},
+		},
+		{
+			name: "the whole bank",
+			off:  []int{5, 6, 7, 8},
+			want: []string{"outlet.8=on->off", "movedInGroup\"=4", "outletsInGroup\"=4", "switching unit"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var logged strings.Builder
+			ctx := logf.IntoContext(context.Background(), funcr.New(func(prefix, args string) {
+				logged.WriteString(prefix + " " + args + "\n")
+			}, funcr.Options{}))
+			c := NewClient("", nil, "", false)
+
+			if _, err := c.stateFromDevices(ctx, deviceStatResponse{
+				Data: []deviceRecord{upsWithOutlets("UPS 2U", capturedGrouping()...)},
+			}); err != nil {
+				t.Fatalf("first observation: %v", err)
+			}
+			// The first observation reports the grouping rather than a change,
+			// because there is nothing yet to have changed from.
+			if !strings.Contains(logged.String(), "1=[outlet.1 outlet.2 outlet.3 outlet.4]") {
+				t.Errorf("the first observation must report the relay grouping; got:\n%s", logged.String())
+			}
+			logged.Reset()
+
+			opened := map[int]bool{}
+			for _, index := range tt.off {
+				opened[index] = true
+			}
+			second := make([]outletRecord, 0, len(capturedGrouping()))
+			for _, o := range capturedGrouping() {
+				if opened[*o.Index] {
+					o.RelayState = boolPtr(false)
+				}
+				second = append(second, o)
+			}
+			if _, err := c.stateFromDevices(ctx, deviceStatResponse{
+				Data: []deviceRecord{upsWithOutlets("UPS 2U", second...)},
+			}); err != nil {
+				t.Fatalf("second observation: %v", err)
+			}
+
+			for _, want := range tt.want {
+				if !strings.Contains(logged.String(), want) {
+					t.Errorf("the readout must mention %q; got:\n%s", want, logged.String())
+				}
+			}
+		})
+	}
+}
+
 // Nothing here may change an outlet: not behind a flag, not through a helper,
 // not reachable. #61's acceptance criteria say so in as many words, and this is
 // the test that keeps it true after the issue is closed.
@@ -353,12 +440,11 @@ func TestBothRelayHypothesesAreObservable(t *testing.T) {
 // at all. Both must be deleted deliberately to implement #23, which is the
 // point.
 func TestNoOutletWritePathExists(t *testing.T) {
-	writer := reflect.TypeOf(&Writer{})
-	for i := range writer.NumMethod() {
-		name := strings.ToLower(writer.Method(i).Name)
+	for method := range reflect.TypeFor[*Writer]().Methods() {
+		name := strings.ToLower(method.Name)
 		if strings.Contains(name, "outlet") || strings.Contains(name, "relay") {
 			t.Errorf("Writer.%s can change an outlet; #23 is deferred and outlet state is read-only",
-				writer.Method(i).Name)
+				method.Name)
 		}
 	}
 

--- a/internal/providers/unifi/outlets_test.go
+++ b/internal/providers/unifi/outlets_test.go
@@ -1,0 +1,390 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// outlet builds one outlet_table entry. A nil relayState is an outlet that does
+// not report its switch position, which is not an outlet that is off.
+func outlet(index int, name string, relayState *bool, group *int) outletRecord {
+	return outletRecord{Index: &index, Name: name, RelayState: relayState, RelayGroup: group}
+}
+
+func boolPtr(v bool) *bool { return &v }
+func intPtr(v int) *int    { return &v }
+
+// upsWithOutlets is an adopted UPS carrying an outlet table.
+func upsWithOutlets(name string, outlets ...outletRecord) deviceRecord {
+	d := adoptedDevice(name, deviceStateOnline)
+	d.OutletTable = outlets
+	return d
+}
+
+// capturedGrouping is the UPS 2U's own layout: outlets 1-4 on relay group 1,
+// outlets 5-8 on relay group 2, all closed and unnamed.
+func capturedGrouping() []outletRecord {
+	var outlets []outletRecord
+	for i := 1; i <= 8; i++ {
+		group := 1
+		if i > 4 {
+			group = 2
+		}
+		outlets = append(outlets, outlet(i, "Outlet "+strconv.Itoa(i), boolPtr(true), &group))
+	}
+	return outlets
+}
+
+// outletState derives the outlet keys from a device list.
+func outletState(t *testing.T, devices ...deviceRecord) map[string]string {
+	t.Helper()
+	c := NewClient("", nil, "", false)
+	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	return state
+}
+
+// The committed capture is the whole reason this key exists, so it is asserted
+// against directly rather than against a hand-built record: eight outlets, all
+// closed, addressed by index because none of them is named.
+func TestOutletsFromTheCapture(t *testing.T) {
+	c := serve(t, merged(t, "stat-device-gateway.json", "stat-device-ups.json"))
+
+	state, err := c.Observe(context.Background())
+	if err != nil {
+		t.Fatalf("Observe: %v", err)
+	}
+	for i := 1; i <= 8; i++ {
+		key := stateKeyOutletPrefix + strconv.Itoa(i)
+		if state[key] != outletOn {
+			t.Errorf("state[%q] = %q, want %q", key, state[key], outletOn)
+		}
+	}
+	count := 0
+	for key := range state {
+		if strings.HasPrefix(key, stateKeyOutletPrefix) {
+			count++
+		}
+	}
+	if count != 8 {
+		t.Errorf("published %d outlet keys, want 8", count)
+	}
+}
+
+// The relay grouping is the fact #23 is blocked on, so the parser has to read
+// it off the capture rather than take anyone's word for it: 1-4 in one bank,
+// 5-8 in the other.
+func TestCapturedRelayGroupingIsReported(t *testing.T) {
+	c := serve(t, captured(t, "stat-device-ups.json"))
+
+	var parsed deviceStatResponse
+	if err := decodeDevices(t, c, &parsed); err != nil {
+		t.Fatalf("reading devices: %v", err)
+	}
+	tally := newOutletTally()
+	for _, d := range parsed.Data {
+		tally.observe(d)
+	}
+	snapshot := tally.publish(context.Background(), map[string]string{})
+
+	want := "1=[outlet.1 outlet.2 outlet.3 outlet.4] 2=[outlet.5 outlet.6 outlet.7 outlet.8]"
+	if snapshot.grouping != want {
+		t.Errorf("grouping = %q, want %q", snapshot.grouping, want)
+	}
+}
+
+// decodeDevices fetches and decodes the device endpoint the way Observe does,
+// so a test can work with the parsed records.
+func decodeDevices(t *testing.T, c *Client, out *deviceStatResponse) error {
+	t.Helper()
+	return c.get(context.Background(), "stat/device", out)
+}
+
+// "Outlet 3" is the console's placeholder rather than a name, so it addresses
+// nothing the index does not already. A name somebody chose replaces the index,
+// which is the entire argument for naming them.
+func TestOutletKeyPrefersANameOverAnIndex(t *testing.T) {
+	tests := []struct {
+		name  string
+		index *int
+		given string
+		want  string
+		ok    bool
+	}{
+		{name: "console placeholder falls back to the index", index: intPtr(3), given: "Outlet 3", want: "3", ok: true},
+		{name: "a placeholder naming another index is still a placeholder",
+			index: intPtr(7), given: "Outlet 3", want: "7", ok: true},
+		{name: "no name at all falls back to the index", index: intPtr(5), given: "", want: "5", ok: true},
+		{name: "a chosen name wins", index: intPtr(3), given: "NAS", want: "nas", ok: true},
+		{name: "a chosen name is slugified", index: intPtr(3), given: "Rack Switch 1", want: "rack-switch-1", ok: true},
+		{name: "a name survives a missing index", index: nil, given: "NAS", want: "nas", ok: true},
+		{name: "no index and no name is not addressable", index: nil, given: "Outlet 4", want: "", ok: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := outletSuffix(tt.index, tt.given)
+			if got != tt.want || ok != tt.ok {
+				t.Errorf("outletSuffix(%v, %q) = %q, %v; want %q, %v", tt.index, tt.given, got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
+func TestOutletValues(t *testing.T) {
+	group := 1
+	state := outletState(t, upsWithOutlets("UPS 2U",
+		outlet(1, "Outlet 1", boolPtr(true), &group),
+		outlet(2, "NAS", boolPtr(false), &group),
+	))
+
+	for key, want := range map[string]string{
+		stateKeyOutletPrefix + "1":   outletOn,
+		stateKeyOutletPrefix + "nas": outletOff,
+	} {
+		if state[key] != want {
+			t.Errorf("state[%q] = %q, want %q", key, state[key], want)
+		}
+	}
+}
+
+// Absent is not off. An outlet that will not say what it is doing publishes
+// nothing, because reading a missing relay_state as an open relay would invent
+// an outage on whatever is plugged into it.
+func TestOutletWithNoRelayStateIsOmitted(t *testing.T) {
+	group := 1
+	state := outletState(t, upsWithOutlets("UPS 2U",
+		outlet(1, "Outlet 1", nil, &group),
+		outlet(2, "Outlet 2", boolPtr(true), &group),
+	))
+
+	if _, published := state[stateKeyOutletPrefix+"1"]; published {
+		t.Error("an outlet reporting no relay_state must publish no key at all")
+	}
+	if state[stateKeyOutletPrefix+"2"] != outletOn {
+		t.Errorf("state[outlet.2] = %q, want %q", state[stateKeyOutletPrefix+"2"], outletOn)
+	}
+}
+
+// A device with no outlet table contributes nothing, so an install with no UPS
+// publishes no outlet key rather than a placeholder.
+func TestNoOutletTableMeansNoKeys(t *testing.T) {
+	state := outletState(t, adoptedDevice("Switch 48", deviceStateOnline))
+
+	for key := range state {
+		if strings.HasPrefix(key, stateKeyOutletPrefix) {
+			t.Errorf("published %q with no outlet table anywhere", key)
+		}
+	}
+}
+
+// Two outlets addressed the same way publish neither. Picking one would be
+// arbitrary, and this key names something carrying mains power.
+func TestOutletsSharingAKeyPublishNeither(t *testing.T) {
+	group := 1
+	state := outletState(t, upsWithOutlets("UPS 2U",
+		outlet(1, "NAS", boolPtr(true), &group),
+		outlet(2, "nas", boolPtr(false), &group),
+		outlet(3, "Outlet 3", boolPtr(true), &group),
+	))
+
+	if _, published := state[stateKeyOutletPrefix+"nas"]; published {
+		t.Error("a key two outlets share must report neither of them")
+	}
+	if state[stateKeyOutletPrefix+"3"] != outletOn {
+		t.Error("a collision must not take the outlets that did not collide with it")
+	}
+}
+
+// Outlet indexes restart on every chassis, so a second device's table is
+// ignored rather than merged into the first's keys.
+func TestOnlyTheFirstOutletTableIsPublished(t *testing.T) {
+	group := 1
+	state := outletState(t,
+		upsWithOutlets("UPS 2U", outlet(1, "Outlet 1", boolPtr(true), &group)),
+		upsWithOutlets("PDU", outlet(1, "Outlet 1", boolPtr(false), &group)),
+	)
+
+	if state[stateKeyOutletPrefix+"1"] != outletOn {
+		t.Errorf("state[outlet.1] = %q, want the first device's %q",
+			state[stateKeyOutletPrefix+"1"], outletOn)
+	}
+}
+
+// An outlet with no relay group is still readable — its position is a fact —
+// but nothing can be said about what else would move with it.
+func TestOutletWithNoRelayGroupIsStillPublished(t *testing.T) {
+	tally := newOutletTally()
+	tally.observe(upsWithOutlets("UPS 2U", outlet(1, "Outlet 1", boolPtr(true), nil)))
+	state := map[string]string{}
+	snapshot := tally.publish(context.Background(), state)
+
+	if state[stateKeyOutletPrefix+"1"] != outletOn {
+		t.Errorf("state[outlet.1] = %q, want %q", state[stateKeyOutletPrefix+"1"], outletOn)
+	}
+	if snapshot.grouping != "none=[outlet.1]" {
+		t.Errorf("grouping = %q, want the outlet reported as ungrouped", snapshot.grouping)
+	}
+}
+
+// The verdict is the sentence the H1 experiment on #60 is read off, so both
+// hypotheses have to come out of it in words.
+func TestGroupVerdictSaysWhichHypothesisHeld(t *testing.T) {
+	tests := []struct {
+		name        string
+		moved, size int
+		want        string
+	}{
+		{name: "one of four is the individually switchable answer", moved: 1, size: 4, want: "independently"},
+		{name: "four of four is the relay-group answer", moved: 4, size: 4, want: "switching unit"},
+		{name: "a group of one settles nothing", moved: 1, size: 1, want: "inconclusive"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := groupVerdict(tt.moved, tt.size); !strings.Contains(got, tt.want) {
+				t.Errorf("groupVerdict(%d, %d) = %q, want it to mention %q", tt.moved, tt.size, got, tt.want)
+			}
+		})
+	}
+}
+
+// Both hypotheses are rehearsed end to end, through two consecutive
+// observations, because a single poll cannot express either of them. This is
+// the parser side of what hack/mock-unifi's /outlets endpoint drives by hand.
+func TestBothRelayHypothesesAreObservable(t *testing.T) {
+	tests := []struct {
+		name string
+		// off is the outlet indexes that open on the second observation.
+		off  []int
+		want map[string]string
+	}{
+		{
+			name: "individual switching moves one outlet in the bank",
+			off:  []int{5},
+			want: map[string]string{
+				stateKeyOutletPrefix + "5": outletOff,
+				stateKeyOutletPrefix + "6": outletOn,
+				stateKeyOutletPrefix + "7": outletOn,
+				stateKeyOutletPrefix + "8": outletOn,
+			},
+		},
+		{
+			name: "group switching takes the whole bank",
+			off:  []int{5, 6, 7, 8},
+			want: map[string]string{
+				stateKeyOutletPrefix + "5": outletOff,
+				stateKeyOutletPrefix + "6": outletOff,
+				stateKeyOutletPrefix + "7": outletOff,
+				stateKeyOutletPrefix + "8": outletOff,
+				stateKeyOutletPrefix + "1": outletOn,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewClient("", nil, "", false)
+			ctx := context.Background()
+
+			if _, err := c.stateFromDevices(ctx, deviceStatResponse{
+				Data: []deviceRecord{upsWithOutlets("UPS 2U", capturedGrouping()...)},
+			}); err != nil {
+				t.Fatalf("first observation: %v", err)
+			}
+
+			opened := map[int]bool{}
+			for _, index := range tt.off {
+				opened[index] = true
+			}
+			var second []outletRecord
+			for _, o := range capturedGrouping() {
+				if opened[*o.Index] {
+					o.RelayState = boolPtr(false)
+				}
+				second = append(second, o)
+			}
+			state, err := c.stateFromDevices(ctx, deviceStatResponse{
+				Data: []deviceRecord{upsWithOutlets("UPS 2U", second...)},
+			})
+			if err != nil {
+				t.Fatalf("second observation: %v", err)
+			}
+
+			for key, want := range tt.want {
+				if state[key] != want {
+					t.Errorf("state[%q] = %q, want %q", key, state[key], want)
+				}
+			}
+		})
+	}
+}
+
+// Nothing here may change an outlet: not behind a flag, not through a helper,
+// not reachable. #61's acceptance criteria say so in as many words, and this is
+// the test that keeps it true after the issue is closed.
+//
+// Two guards, because "no write path" can be broken two ways. Writer is the
+// only thing in this package that sends anything to a console, so no method on
+// it may mention an outlet or a relay; and outlet_overrides is the field the
+// documented PDU write path uses, so it may not appear in this package's source
+// at all. Both must be deleted deliberately to implement #23, which is the
+// point.
+func TestNoOutletWritePathExists(t *testing.T) {
+	writer := reflect.TypeOf(&Writer{})
+	for i := range writer.NumMethod() {
+		name := strings.ToLower(writer.Method(i).Name)
+		if strings.Contains(name, "outlet") || strings.Contains(name, "relay") {
+			t.Errorf("Writer.%s can change an outlet; #23 is deferred and outlet state is read-only",
+				writer.Method(i).Name)
+		}
+	}
+
+	sources, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatalf("listing package sources: %v", err)
+	}
+	for _, source := range sources {
+		if strings.HasSuffix(source, "_test.go") {
+			continue
+		}
+		// String literals only, never comments: outlet_overrides is discussed
+		// at length in this package and implemented nowhere, and a guard that
+		// could not tell those apart would only teach people to stop explaining
+		// themselves.
+		parsed, err := parser.ParseFile(token.NewFileSet(), source, nil, 0)
+		if err != nil {
+			t.Fatalf("parsing %s: %v", source, err)
+		}
+		ast.Inspect(parsed, func(node ast.Node) bool {
+			literal, ok := node.(*ast.BasicLit)
+			if ok && literal.Kind == token.STRING && strings.Contains(literal.Value, "outlet_overrides") {
+				t.Errorf("%s builds outlet_overrides, the field the documented write path uses; "+
+					"outlet state is observed and never written until #23 is decided", source)
+			}
+			return true
+		})
+	}
+}

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -42,6 +42,13 @@ const (
 	// opt-in — see the note on StateVocabulary below.
 	stateKeyDevicePrefix = "device."
 
+	// stateKeyOutletPrefix is what one switchable UPS outlet is published
+	// under: outlet.<index> while the console's own "Outlet N" placeholder is
+	// still on it, outlet.<slugified name> once somebody has named it. Its name
+	// is open for the same reason device.<name>'s is, and its cardinality is
+	// not — see the note on StateVocabulary below.
+	stateKeyOutletPrefix = "outlet."
+
 	wanPrimary = "primary"
 	wanBackup  = "backup"
 
@@ -165,6 +172,13 @@ const (
 	// refuses a port, the camera is already off.
 	poeOK           = "ok"
 	poeInsufficient = "insufficient"
+
+	// outlet.<n> is the switch position of one UPS outlet: on is the relay
+	// closed and delivering mains. Two values, and a relay has no third — this
+	// is the least ambiguous key in this file, and the whole difficulty with it
+	// is on the write side, which is #23 and is not implemented anywhere.
+	outletOn  = "on"
+	outletOff = "off"
 )
 
 // The comparisons this provider makes between two independent signals for the
@@ -180,6 +194,7 @@ const (
 	signalWANHealthDisagrees  = "wan-health-disagrees"
 	signalDeviceNameShared    = "device-name-shared"
 	signalWiFiStatusDisagrees = "wifi-status-disagrees"
+	signalOutletNameShared    = "outlet-name-shared"
 )
 
 // StateVocabulary is the closed value set of every key this provider publishes
@@ -216,6 +231,39 @@ const (
 // devices key — one series, whatever the fleet size — is what ships on by
 // default. What any single device currently is stays in the Automation's status
 // and in a Kubernetes Event, exactly as isp's value does.
+//
+// outlet.<n> is absent too, and the reasoning is worth separating from
+// device.<name>'s, because only half of it carries over.
+//
+// The cardinality half does NOT. A UPS has eight outlets, a PDU six or so, and
+// nobody adds outlets to a chassis: the key count is bounded by hardware in a
+// way a rack full of adopted devices is not. So outlet keys are published
+// whenever a device reports an outlet table, with no opt-in — gating them
+// behind a setting would make them the one UPS key you have to ask for, next to
+// ups, ups.battery, ups.runtime and ups.load, which all appear the moment a UPS
+// does.
+//
+// The enumerability half does, and it is what decides this map. The key NAME is
+// the outlet's index until somebody names the outlet, and then it is the name —
+// which is the point, because outlet.3 means something different after the rack
+// is re-plugged and outlet.nas does not. This map is returned once at startup,
+// before any console has been polled, so it cannot contain a key it will not
+// learn until later; and hardcoding outlet.1 through outlet.8 would be writing
+// one UPS's chassis into this repository, silently leaving a larger PDU's ninth
+// outlet outside the metric.
+//
+// Declaring a prefix instead — outlet.* with two values — was considered and
+// rejected. reactor_state_info reports 0 for the values a key does not hold,
+// which is what stops a stale series sitting at 1 forever, and that requires
+// enumerating the values of a key that is NOT in the current observation.
+// A wildcard can only match keys that are present, so an outlet key that
+// vanished with its UPS would keep reporting 1 — the exact failure declaring a
+// vocabulary exists to prevent.
+//
+// So outlets are counted in reactor_state_transitions_total (one series each,
+// eight of them, which is what the H1 experiment on #60 reads), they are in
+// every referencing Automation's status and Events, and the provider logs the
+// grouping and every change in words. See outlets.go.
 func StateVocabulary() map[string][]string {
 	return map[string][]string{
 		stateKeyWAN:         {wanPrimary, wanBackup},

--- a/test/e2e/harness/mock.go
+++ b/test/e2e/harness/mock.go
@@ -206,6 +206,16 @@ func (m *Mock) WiFi(query string) error { return m.post("/wifi?" + query) }
 // powered port that reports no wattage, present=false for no PoE fields at all.
 func (m *Mock) PoE(query string) error { return m.post("/poe?" + query) }
 
+// Outlets drives the UPS outlet table: outlet=<n>&state=on|off for one outlet,
+// group=<n>&state=... for a whole relay group, outlet=<n>&label=<name> to name
+// one, present=false for a UPS reporting no outlets.
+//
+// switching=individual|group is the one that matters: it decides whether asking
+// for one outlet moves that outlet or its entire relay group, which is the
+// question #23 is deferred on and the two readings hypothesis H1 on #60 tells
+// apart. Reactor only ever reads these.
+func (m *Mock) Outlets(query string) error { return m.post("/outlets?" + query) }
+
 // Reachable reports whether the mock is answering yet.
 func (m *Mock) Reachable() error {
 	return m.request(http.MethodGet, "/proxy/network/api/s/default/stat/device")

--- a/test/e2e/reaction/outlet_test.go
+++ b/test/e2e/reaction/outlet_test.go
@@ -1,0 +1,184 @@
+//go:build e2e
+
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reaction
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The outlet keys are the instrument #23 is waiting on, so this file proves the
+// instrument works end to end: rehearsed console, poll, condition, action —
+// under BOTH answers to the question nobody has asked the hardware yet.
+//
+// It is the only e2e block whose console starts from a fully populated capture
+// rather than from absent fields: outlet_table is real, all eight relays are
+// closed, and outlets 1-4 and 5-8 are in two relay groups.
+//
+// Nothing here writes an outlet. There is no way to; that is #23.
+var _ = Describe("Observing UPS outlets", Ordered, func() {
+	const (
+		outletJob    = "outlet-batch"
+		outletPolicy = "shed-when-outlet-off"
+		namedPolicy  = "shed-when-nas-outlet-off"
+		baseline     = 2
+	)
+
+	outletCut := map[string]string{keyOutlet: outletOff}
+	namedCut := map[string]string{keyOutletNamed: outletOff}
+
+	// The captured banks, spelled once. Outlet 5 lives in bankTwo, and bankOne
+	// staying put is what makes a group switch a relay group rather than the
+	// UPS simply dropping everything.
+	bankOne := []string{"outlet.1", "outlet.2", "outlet.3", "outlet.4"}
+	bankTwo := []string{"outlet.5", "outlet.6", "outlet.7", "outlet.8"}
+	bankTwoOthers := bankTwo[1:]
+
+	BeforeAll(func() {
+		resetConsole()
+		Expect(cluster.Apply(workload(outletJob, baseline))).To(Succeed())
+		Expect(cluster.Apply(scaleAutomation(outletPolicy, outletCut, outletJob, 0))).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(conditionOf(automationOf(g, outletPolicy), conditionReady)).NotTo(BeNil())
+		}).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		Expect(mock.Outlets("reset=true")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+		Expect(cluster.Delete(scaleAutomation(outletPolicy, outletCut, outletJob, 0))).To(Succeed())
+		resetConsole()
+	})
+
+	// Eight keys, all on, addressed by index — because the console has named
+	// none of them, which is exactly the state a real UPS ships in.
+	It("publishes one key per outlet, addressed by index while nothing is named", func() {
+		Eventually(func(g Gomega) {
+			state := automationOf(g, outletPolicy).Status.ObservedState
+			for _, key := range append(append([]string{}, bankOne...), bankTwo...) {
+				g.Expect(state).To(HaveKeyWithValue(key, outletOn))
+			}
+		}).Should(Succeed())
+	})
+
+	// H1's first answer: one outlet moves and its three bank-mates do not. If
+	// this is what a real console does, #23 can ship a per-outlet allowlist.
+	It("reacts to one outlet opening, and leaves the rest of its relay group alone", func() {
+		Expect(mock.Outlets("switching=individual&outlet=5&state=off")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		state := automationOf(Default, outletPolicy).Status.ObservedState
+		Expect(state).To(HaveKeyWithValue(keyOutlet, outletOff))
+		for _, stillOn := range bankTwoOthers {
+			Expect(state).To(HaveKeyWithValue(stillOn, outletOn),
+				"switching one outlet must not move the rest of its relay group")
+		}
+
+		Expect(mock.Outlets("outlet=5&state=on")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+	})
+
+	// H1's second answer, and the dangerous one: the same request for outlet 5
+	// takes outlets 5-8 with it. An automation written as "switch outlet 5"
+	// would mean "cut outlets 5 to 8", which is why #23 is deferred rather than
+	// implemented behind a warning.
+	It("observes a whole relay group moving at once when one outlet is asked for", func() {
+		Expect(mock.Outlets("switching=group&outlet=5&state=off")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			state := automationOf(g, outletPolicy).Status.ObservedState
+			for _, key := range bankTwo {
+				g.Expect(state).To(HaveKeyWithValue(key, outletOff))
+			}
+			// The other bank is untouched, which is what makes this a relay
+			// group rather than the UPS simply dropping everything.
+			for _, key := range bankOne {
+				g.Expect(state).To(HaveKeyWithValue(key, outletOn))
+			}
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		Expect(mock.Outlets("reset=true")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+	})
+
+	// Naming an outlet on the console moves its key, which is the whole reason
+	// to name them — and it is also the reason an automation written against an
+	// index is fragile. The old key vanishing is read as lost visibility, so the
+	// claim is held rather than released, exactly as a renamed device is.
+	It("moves the key when an outlet is named, holding the old key's claim", func() {
+		Expect(mock.Outlets("outlet=5&state=off")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		Expect(cluster.Apply(workload(outletJob+"-named", baseline))).To(Succeed())
+		Expect(cluster.Apply(scaleAutomation(namedPolicy, namedCut, outletJob+"-named", 0))).To(Succeed())
+
+		By("naming outlet 5, which moves its key from outlet.5 to outlet.nas")
+		Expect(mock.Outlets("outlet=5&label=NAS")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			named := automationOf(g, namedPolicy).Status.ObservedState
+			g.Expect(named).To(HaveKeyWithValue(keyOutletNamed, outletOff))
+			g.Expect(named).NotTo(HaveKey(keyOutlet))
+			g.Expect(replicasOf(g, outletJob+"-named")).To(BeEquivalentTo(0))
+		}).Should(Succeed())
+
+		By("holding rather than releasing the automation whose key went away")
+		ready := conditionOf(automationOf(Default, outletPolicy), conditionReady)
+		Expect(ready).NotTo(BeNil())
+		Expect(ready.Reason).To(Equal("StateKeyUnavailable"),
+			"an outlet renamed out from under a key is lost visibility, not a recovery")
+		Expect(replicasOf(Default, outletJob)).To(BeEquivalentTo(0))
+
+		Expect(cluster.Delete(scaleAutomation(namedPolicy, namedCut, outletJob+"-named", 0))).To(Succeed())
+		Expect(mock.Outlets("reset=true")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(baseline))
+		}).Should(Succeed())
+	})
+
+	// A UPS that reports no outlet table publishes no outlet key, rather than a
+	// row of "on" that reads as eight healthy relays.
+	It("publishes nothing when the UPS reports no outlets", func() {
+		Expect(mock.Outlets("present=false")).To(Succeed())
+
+		Eventually(func(g Gomega) {
+			ready := conditionOf(automationOf(g, outletPolicy), conditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Reason).To(Equal("StateKeyUnavailable"))
+		}).Should(Succeed())
+
+		Expect(mock.Outlets("reset=true")).To(Succeed())
+		Eventually(func(g Gomega) {
+			g.Expect(automationOf(g, outletPolicy).Status.ObservedState).
+				To(HaveKeyWithValue(keyOutlet, outletOn))
+		}).Should(Succeed())
+	})
+})

--- a/test/e2e/reaction/outlet_test.go
+++ b/test/e2e/reaction/outlet_test.go
@@ -27,35 +27,71 @@ import (
 // instrument works end to end: rehearsed console, poll, condition, action —
 // under BOTH answers to the question nobody has asked the hardware yet.
 //
-// It is the only e2e block whose console starts from a fully populated capture
-// rather than from absent fields: outlet_table is real, all eight relays are
-// closed, and outlets 1-4 and 5-8 are in two relay groups.
+// The two answers are told apart by which Automation fires, which is the same
+// way an operator would find out. `shed-when-outlet-off` names one outlet;
+// `shed-when-bank-off` names all four in its relay group. Asking the console
+// for outlet 5 fires the first under either hypothesis and the second only
+// under the dangerous one — where "switch outlet 5" means "cut outlets 5 to 8".
+//
+// It is also the only e2e block whose console starts from a fully populated
+// capture rather than from absent fields: outlet_table is real, all eight
+// relays are closed, and outlets 1-4 and 5-8 are in two relay groups.
 //
 // Nothing here writes an outlet. There is no way to; that is #23.
 var _ = Describe("Observing UPS outlets", Ordered, func() {
 	const (
+		watchJob     = "outlet-watch"
 		outletJob    = "outlet-batch"
+		bankJob      = "bank-batch"
+		namedJob     = "named-batch"
+		watchPolicy  = "watch-every-outlet"
 		outletPolicy = "shed-when-outlet-off"
+		bankPolicy   = "shed-when-bank-off"
 		namedPolicy  = "shed-when-nas-outlet-off"
 		baseline     = 2
 	)
 
+	// The captured banks. Outlet 5 lives in bankTwo; bankOne staying put is
+	// what makes a group switch a relay group rather than the UPS dropping
+	// everything.
+	bankOne := []string{"outlet.1", "outlet.2", "outlet.3", "outlet.4"}
+	bankTwo := []string{keyOutlet, "outlet.6", "outlet.7", "outlet.8"}
+
+	// An Automation's status.observedState carries the keys it NAMES, so
+	// watching all eight takes an Automation that names all eight. It also
+	// makes the captured console's own answer — every relay closed — something
+	// a condition can hold rather than something only a log line knows.
+	everyOutletOn := map[string]string{}
+	for _, key := range append(append([]string{}, bankOne...), bankTwo...) {
+		everyOutletOn[key] = outletOn
+	}
+	wholeBankOff := map[string]string{}
+	for _, key := range bankTwo {
+		wholeBankOff[key] = outletOff
+	}
 	outletCut := map[string]string{keyOutlet: outletOff}
 	namedCut := map[string]string{keyOutletNamed: outletOff}
 
-	// The captured banks, spelled once. Outlet 5 lives in bankTwo, and bankOne
-	// staying put is what makes a group switch a relay group rather than the
-	// UPS simply dropping everything.
-	bankOne := []string{"outlet.1", "outlet.2", "outlet.3", "outlet.4"}
-	bankTwo := []string{"outlet.5", "outlet.6", "outlet.7", "outlet.8"}
-	bankTwoOthers := bankTwo[1:]
+	policies := []struct {
+		name   string
+		when   map[string]string
+		target string
+	}{
+		{watchPolicy, everyOutletOn, watchJob},
+		{outletPolicy, outletCut, outletJob},
+		{bankPolicy, wholeBankOff, bankJob},
+	}
 
 	BeforeAll(func() {
 		resetConsole()
-		Expect(cluster.Apply(workload(outletJob, baseline))).To(Succeed())
-		Expect(cluster.Apply(scaleAutomation(outletPolicy, outletCut, outletJob, 0))).To(Succeed())
+		for _, policy := range policies {
+			Expect(cluster.Apply(workload(policy.target, baseline))).To(Succeed())
+			Expect(cluster.Apply(scaleAutomation(policy.name, policy.when, policy.target, 0))).To(Succeed())
+		}
 		Eventually(func(g Gomega) {
-			g.Expect(conditionOf(automationOf(g, outletPolicy), conditionReady)).NotTo(BeNil())
+			for _, policy := range policies {
+				g.Expect(conditionOf(automationOf(g, policy.name), conditionReady)).NotTo(BeNil())
+			}
 		}).Should(Succeed())
 	})
 
@@ -63,8 +99,11 @@ var _ = Describe("Observing UPS outlets", Ordered, func() {
 		Expect(mock.Outlets("reset=true")).To(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(baseline))
+			g.Expect(replicasOf(g, bankJob)).To(BeEquivalentTo(baseline))
 		}).Should(Succeed())
-		Expect(cluster.Delete(scaleAutomation(outletPolicy, outletCut, outletJob, 0))).To(Succeed())
+		for _, policy := range policies {
+			Expect(cluster.Delete(scaleAutomation(policy.name, policy.when, policy.target, 0))).To(Succeed())
+		}
 		resetConsole()
 	})
 
@@ -72,28 +111,34 @@ var _ = Describe("Observing UPS outlets", Ordered, func() {
 	// none of them, which is exactly the state a real UPS ships in.
 	It("publishes one key per outlet, addressed by index while nothing is named", func() {
 		Eventually(func(g Gomega) {
-			state := automationOf(g, outletPolicy).Status.ObservedState
-			for _, key := range append(append([]string{}, bankOne...), bankTwo...) {
+			state := automationOf(g, watchPolicy).Status.ObservedState
+			for key := range everyOutletOn {
 				g.Expect(state).To(HaveKeyWithValue(key, outletOn))
 			}
+			// Every relay closed is the captured console's own answer, so the
+			// condition naming all eight holds and its target is shed.
+			g.Expect(replicasOf(g, watchJob)).To(BeEquivalentTo(0))
 		}).Should(Succeed())
 	})
 
-	// H1's first answer: one outlet moves and its three bank-mates do not. If
-	// this is what a real console does, #23 can ship a per-outlet allowlist.
+	// H1's first answer: one outlet moves and its three bank-mates do not, so
+	// the automation naming the whole bank never fires. If this is what a real
+	// console does, #23 can ship with a per-outlet allowlist.
 	It("reacts to one outlet opening, and leaves the rest of its relay group alone", func() {
 		Expect(mock.Outlets("switching=individual&outlet=5&state=off")).To(Succeed())
 
 		Eventually(func(g Gomega) {
 			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(0))
+			// The bank automation has seen the same observation — its own key
+			// moved — and did not fire, which is the assertion rather than a
+			// race: the other three are still closed.
+			bank := automationOf(g, bankPolicy).Status.ObservedState
+			g.Expect(bank).To(HaveKeyWithValue(keyOutlet, outletOff))
+			for _, stillOn := range bankTwo[1:] {
+				g.Expect(bank).To(HaveKeyWithValue(stillOn, outletOn))
+			}
+			g.Expect(replicasOf(g, bankJob)).To(BeEquivalentTo(baseline))
 		}).Should(Succeed())
-
-		state := automationOf(Default, outletPolicy).Status.ObservedState
-		Expect(state).To(HaveKeyWithValue(keyOutlet, outletOff))
-		for _, stillOn := range bankTwoOthers {
-			Expect(state).To(HaveKeyWithValue(stillOn, outletOn),
-				"switching one outlet must not move the rest of its relay group")
-		}
 
 		Expect(mock.Outlets("outlet=5&state=on")).To(Succeed())
 		Eventually(func(g Gomega) {
@@ -102,43 +147,47 @@ var _ = Describe("Observing UPS outlets", Ordered, func() {
 	})
 
 	// H1's second answer, and the dangerous one: the same request for outlet 5
-	// takes outlets 5-8 with it. An automation written as "switch outlet 5"
-	// would mean "cut outlets 5 to 8", which is why #23 is deferred rather than
-	// implemented behind a warning.
+	// takes outlets 5-8 with it, so both automations fire. An automation
+	// written as "switch outlet 5" would mean "cut outlets 5 to 8", which is
+	// why #23 is deferred rather than implemented behind a warning.
 	It("observes a whole relay group moving at once when one outlet is asked for", func() {
 		Expect(mock.Outlets("switching=group&outlet=5&state=off")).To(Succeed())
 
 		Eventually(func(g Gomega) {
-			state := automationOf(g, outletPolicy).Status.ObservedState
+			bank := automationOf(g, bankPolicy).Status.ObservedState
 			for _, key := range bankTwo {
-				g.Expect(state).To(HaveKeyWithValue(key, outletOff))
+				g.Expect(bank).To(HaveKeyWithValue(key, outletOff))
 			}
+			g.Expect(replicasOf(g, bankJob)).To(BeEquivalentTo(0))
+			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(0))
+
 			// The other bank is untouched, which is what makes this a relay
 			// group rather than the UPS simply dropping everything.
+			watched := automationOf(g, watchPolicy).Status.ObservedState
 			for _, key := range bankOne {
-				g.Expect(state).To(HaveKeyWithValue(key, outletOn))
+				g.Expect(watched).To(HaveKeyWithValue(key, outletOn))
 			}
-			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(0))
 		}).Should(Succeed())
 
 		Expect(mock.Outlets("reset=true")).To(Succeed())
 		Eventually(func(g Gomega) {
+			g.Expect(replicasOf(g, bankJob)).To(BeEquivalentTo(baseline))
 			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(baseline))
 		}).Should(Succeed())
 	})
 
 	// Naming an outlet on the console moves its key, which is the whole reason
-	// to name them — and it is also the reason an automation written against an
-	// index is fragile. The old key vanishing is read as lost visibility, so the
-	// claim is held rather than released, exactly as a renamed device is.
+	// to name them — and is also why an automation written against an index is
+	// fragile. The old key vanishing is read as lost visibility, so the claim
+	// is held rather than released, exactly as a renamed device's is.
 	It("moves the key when an outlet is named, holding the old key's claim", func() {
 		Expect(mock.Outlets("outlet=5&state=off")).To(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(0))
 		}).Should(Succeed())
 
-		Expect(cluster.Apply(workload(outletJob+"-named", baseline))).To(Succeed())
-		Expect(cluster.Apply(scaleAutomation(namedPolicy, namedCut, outletJob+"-named", 0))).To(Succeed())
+		Expect(cluster.Apply(workload(namedJob, baseline))).To(Succeed())
+		Expect(cluster.Apply(scaleAutomation(namedPolicy, namedCut, namedJob, 0))).To(Succeed())
 
 		By("naming outlet 5, which moves its key from outlet.5 to outlet.nas")
 		Expect(mock.Outlets("outlet=5&label=NAS")).To(Succeed())
@@ -146,18 +195,19 @@ var _ = Describe("Observing UPS outlets", Ordered, func() {
 		Eventually(func(g Gomega) {
 			named := automationOf(g, namedPolicy).Status.ObservedState
 			g.Expect(named).To(HaveKeyWithValue(keyOutletNamed, outletOff))
-			g.Expect(named).NotTo(HaveKey(keyOutlet))
-			g.Expect(replicasOf(g, outletJob+"-named")).To(BeEquivalentTo(0))
+			g.Expect(replicasOf(g, namedJob)).To(BeEquivalentTo(0))
 		}).Should(Succeed())
 
 		By("holding rather than releasing the automation whose key went away")
-		ready := conditionOf(automationOf(Default, outletPolicy), conditionReady)
-		Expect(ready).NotTo(BeNil())
-		Expect(ready.Reason).To(Equal("StateKeyUnavailable"),
-			"an outlet renamed out from under a key is lost visibility, not a recovery")
+		Eventually(func(g Gomega) {
+			ready := conditionOf(automationOf(g, outletPolicy), conditionReady)
+			g.Expect(ready).NotTo(BeNil())
+			g.Expect(ready.Reason).To(Equal("StateKeyUnavailable"),
+				"an outlet renamed out from under a key is lost visibility, not a recovery")
+		}).Should(Succeed())
 		Expect(replicasOf(Default, outletJob)).To(BeEquivalentTo(0))
 
-		Expect(cluster.Delete(scaleAutomation(namedPolicy, namedCut, outletJob+"-named", 0))).To(Succeed())
+		Expect(cluster.Delete(scaleAutomation(namedPolicy, namedCut, namedJob, 0))).To(Succeed())
 		Expect(mock.Outlets("reset=true")).To(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(replicasOf(g, outletJob)).To(BeEquivalentTo(baseline))
@@ -165,7 +215,7 @@ var _ = Describe("Observing UPS outlets", Ordered, func() {
 	})
 
 	// A UPS that reports no outlet table publishes no outlet key, rather than a
-	// row of "on" that reads as eight healthy relays.
+	// row of "on" that would read as eight healthy relays.
 	It("publishes nothing when the UPS reports no outlets", func() {
 		Expect(mock.Outlets("present=false")).To(Succeed())
 

--- a/test/e2e/reaction/suite_test.go
+++ b/test/e2e/reaction/suite_test.go
@@ -84,6 +84,11 @@ const (
 	keyTemperature = "temperature"
 	keyWiFi        = "wifi"
 	keyPoE         = "poe"
+	// keyOutlet is one UPS outlet, addressed by index because the captured
+	// console has not named any of them. keyOutletNamed is what the same outlet
+	// is called once it is named, which is the argument for naming them.
+	keyOutlet      = "outlet.5"
+	keyOutletNamed = "outlet.nas"
 	// keyUPSDevice is the per-device key the captured UPS publishes under, and
 	// the reason the suite installs with per-device keys on: they are opt-in,
 	// so an install that does not ask for them is the default rather than the
@@ -113,6 +118,8 @@ const (
 	wifiError          = "error"
 	poeOK              = "ok"
 	poeInsufficient    = "insufficient"
+	outletOn           = "on"
+	outletOff          = "off"
 
 	// settleWindow is how long a workload must hold a value for the suite to
 	// accept that nothing is going to move it. It spans several polls and at
@@ -231,6 +238,9 @@ func resetConsole() {
 	Expect(mock.Firmware("present=false")).To(Succeed())
 	Expect(mock.Temperature("present=false")).To(Succeed())
 	Expect(mock.PoE("present=false")).To(Succeed())
+	// Unlike the three above, the outlets ARE in the capture, so their reset is
+	// back to eight closed relays in two relay groups rather than to nothing.
+	Expect(mock.Outlets("reset=true")).To(Succeed())
 }
 
 // workload renders a target Deployment. The pods run the mock's image because

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -425,6 +425,46 @@ Zero and negative both mean "no estimate" and publish no `ups.runtime` key: `bat
 
 UniFi also has a `network:ups_overload_detected` alarm trigger, which corroborates `ups.load` but is not read: nothing derives state from a delivery payload.
 
+## Outlets (`outlet_table`) — captured, and read-only on purpose
+
+Every field the `outlet.<n>` keys need is in `api/stat-device-ups.json`, taken off a real console:
+
+```json
+{"index": 1, "name": "Outlet 1", "relay_state": true, "relay_group": 1}
+```
+
+Eight outlets. Outlets 1–4 report `relay_group: 1`; outlets 5–8 report `relay_group: 2`.
+
+| Field | In the capture | What the provider does with it |
+| --- | --- | --- |
+| `index` | `1`–`8` | the key's address while the outlet is unnamed: `outlet.3` |
+| `name` | `Outlet 1` … `Outlet 8` | the key's address once somebody names it: `outlet.nas`. `Outlet <number>` is treated as the index spelled out, not as a name |
+| `relay_state` | `true` on all eight | the value: `on` / `off`. A pointer, because absent is not off |
+| `relay_group` | `1` or `2` | **nothing.** Never derived from, only reported — see below |
+
+One more thing this capture settles, and it is easy to miss: the **gateway** record carries
+`"outlet_table": []`. Having the field is not having outlets, so a device is the outlet-bearing one
+when it lists outlets, never when it merely mentions the field.
+
+> ⚠️ **`relay_group` is the reason there is no write path.** If the relay group is what the hardware
+> switches, then asking for outlet 3 to go off takes outlets 1–4 with it. The documented write path —
+> `outlet_overrides` via `PUT rest/device` — comes from the **USP-PDU-Pro and USP-Strip**, which
+> expose `outlet_caps`, `outlet_power`, `outlet_current` and `cycle_enabled` per outlet and have no
+> `relay_group` at all. This UPS exposes none of those and does have relay groups, so the documented
+> path is documented for a different device class and confirms nothing here. Switching is
+> [#23](https://github.com/robbeverhelst/unifi-reactor/issues/23).
+
+The experiment that settles it needs no capture and no code — it needs the console. With Reactor
+running and this key published, toggle **one** outlet by hand in the UniFi UI, in a bank carrying
+nothing that matters, and read the line Reactor logs: `movedInGroup=1` of `4` means outlets switch
+individually, `4` of `4` means the relay group is the switching unit. That is hypothesis H1 on
+[#60](https://github.com/robbeverhelst/unifi-reactor/issues/60). While in the UI, **name the
+outlets** — the second half of the same visit, and what turns `outlet.3` into `outlet.nas`.
+
+`hack/mock-unifi`'s `/outlets` rehearses both answers (`switching=individual` and `switching=group`)
+so the parser is exercised against each. Unlike the WLAN table and the PoE switch there, this
+endpoint rewrites the real capture rather than inventing a shape.
+
 ## What the write path has, which is nothing
 
 `unifi.wlan.*` and `unifi.poe.cycle` write to the console, and **no capture backs any of it**. There


### PR DESCRIPTION
Closes #61. Read-only observation of the UPS outlets, and the last issue in the v1.1 milestone.

> **Stacked on #67.** This branch merges `robbeverhelst/device-state` so it can build on the per-entity-key precedent it settled. Until #67 merges, its commits show up here too; the outlet work is the two commits on top.

## What ships

One state key per switchable outlet — `on` while the relay is closed and delivering mains — published whenever an adopted device actually lists outlets, and omitted entirely when none does.

```yaml
  when:
    provider: unifi
    state:
      outlet.nas: off      # something cut power to the NAS
```

**There is no write path.** Not behind a flag, not through a helper, not reachable. Two tests keep it that way after this issue closes: no method on `Writer` may mention an outlet or a relay, and no string literal in the package may build `outlet_overrides` — the field the documented PDU write path uses. Both have to be deleted deliberately to implement #23. (The `outlet_overrides` guard walks the AST and inspects string literals only, never comments, because the field is discussed at length in this package and implemented nowhere; a guard that could not tell those apart would only teach people to stop explaining themselves. It was verified to fire by planting a struct tag.)

## Making the relay grouping impossible to miss

`relay_group` is read and **never derived from** — it is not part of any key, value or decision. It is read so it can be *reported*, at INFO rather than V(1), because the person running the experiment is reading the default log stream:

```text
A UPS is reporting switchable outlets. Reactor only READS them — switching is deferred in issue #23
until the relay grouping below is understood: if the relay group is what the hardware switches,
changing one outlet changes every outlet in its group. To settle it, toggle ONE outlet by hand in
the UniFi UI and read the next line
  device=ups-2u
  relayGroups="1=[outlet.1 outlet.2 outlet.3 outlet.4] 2=[outlet.5 outlet.6 outlet.7 outlet.8]"
```

That line fires on first sight and whenever the grouping changes. The provider then remembers the last outlet snapshot, so when a relay moves it can say *how much of its bank moved with it* — which is the experiment's readout in words rather than something to reconstruct from a graph:

```text
Outlet state changed. If you are running the relay-group experiment on issue #60, this line is its readout
  moved=outlet.5=on->off relayGroup=2 movedInGroup=1 outletsInGroup=4
  verdict="outlets in this group moved independently of each other"
```

The grouping is also in the README, the chart README, `docs/troubleshooting.md` §10f, `testdata/unifi/README.md`, and `GET /outlets` on the mock. It is hard to run the experiment without meeting it.

## The `StateVocabulary` decision, reached rather than assumed

The issue said the values are closed, so the key *can* be declared and get a value-labelled metric. Checked against what #67 settled for `device.<name>`, the answer is **no** — and the two halves of #67's argument come apart here, which is the interesting part:

- **The cardinality half does not carry over.** Eight outlets are bounded by a chassis, not by a rack; nobody adds outlets to a UPS; most installs have no outlet-bearing device at all. So these keys need **no opt-in** — making them the one UPS key you have to ask for, next to `ups`, `ups.battery`, `ups.runtime` and `ups.load`, would have been consistency with the wrong half.
- **The enumerability half does carry over**, and it decides the map. `StateVocabulary()` is handed over once at startup, before any console is polled, so it cannot contain a key named after an outlet nobody has named yet. Hardcoding `outlet.1`…`outlet.8` would write one UPS's chassis into this repository and silently leave a larger PDU's ninth outlet outside the metric.
- **Declaring `outlet.*` was considered and rejected**, and this is the sharp reason rather than a stylistic one: `reactor_state_info` reports `0` for the values a key does **not** hold, which is what stops a stale series sitting at `1`, and that requires enumerating the values of a key that is *missing* from the observation. A prefix can only match keys that are present, so an outlet key that vanished with its UPS would sit at `1` forever — the exact failure declaring a vocabulary exists to prevent. It would also weaken `internal/metrics`' one invariant to buy 16 series.

So: no `reactor_state_info`, one `reactor_state_transitions_total` series each (which is what the experiment reads), values in `status.observedState` and in Events, and the log lines above. `docs/adding-a-provider.md` gains the general lesson so the next per-entity key does not copy the wrong half.

## Addressing, and why naming matters

`outlet.<index>` while the outlet still carries the console's own `Outlet N` placeholder; `outlet.<slugified name>` once somebody names it. Any name of the form `Outlet <number>` is treated as the index spelled out — a UPS whose outlet 7 is called `Outlet 3` is a mislabelled console, and keying it as `outlet.3` would put one outlet's state under another's address.

The index is the fallback, not the plan, and the docs say so: an automation matching `outlet.3` means something different the day somebody re-plugs the rack — the same argument that made `portName` required rather than optional for `unifi.poe.cycle` in #66. Renaming makes the old key vanish, which is held as lost visibility (`StateKeyUnavailable`) rather than read as a recovery. Two outlets addressed alike publish **neither**, with a `outlet-name-shared` disagreement counted.

**Debounce: `outlet.*: 1`**, written into the shipped map even though it is the default. A relay is a switch position, not a measurement — nothing hovers on a threshold, there is no reading to settle — which is exactly why `wan` and `ups` are 1. Stating it means raising `default` cannot quietly delay an outlet by a poll.

## One thing the capture settled that was not in the issue

The captured **gateway** reports `"outlet_table": []`. Having the field is not having outlets, so the outlet-bearing device is the first that *lists* outlets, never the first that mentions the field. Taking the first with the field would have claimed the gateway's empty table and hidden the UPS behind it. It has its own test, and it is called out in `testdata/unifi/README.md`.

## Rehearsing both hypotheses

`hack/mock-unifi` gains `/outlets`, driven by hand like `/flip`, `/ups`, `/internet` and `/quality`. Unlike the WLAN table and the PoE switch beside it, this endpoint **rewrites the real capture** rather than inventing a shape.

```sh
curl http://localhost:9443/outlets                             # states, and the relay grouping
curl -X POST 'http://localhost:9443/outlets?switching=individual&outlet=5&state=off'
curl -X POST 'http://localhost:9443/outlets?switching=group&outlet=5&state=off'   # takes 5-8
curl -X POST 'http://localhost:9443/outlets?group=2&state=on'
curl -X POST 'http://localhost:9443/outlets?outlet=5&label=nas'          # key becomes outlet.nas
curl -X POST 'http://localhost:9443/outlets?groups=false'                # no relay_group reported
curl -X POST 'http://localhost:9443/outlets?present=false'               # no outlet_table at all
```

`switching=` is the point: asking for outlet 5 has to be able to move outlet 5 alone **or** take outlets 5–8 with it, because a parser that only ever saw one of those is a parser tested against a guess. Both are covered by unit tests across two consecutive observations, and by an e2e block through an Automation that matches on the key.

Also here: a merge artefact of #66 and #67 landing together. Both registered `POST /poe` on the mock's mux, which **panics at startup**. #67's drives the `poe` state key; #66's drives the synthetic switch port the write action cycles. The write side is now `/poe-port`.

## Checks

`make test` and `make lint` pass; `make manifests generate` produces no drift; `hack/verify-testdata.sh` passes and no fixture changed — `outlet_table` was already captured, so nothing new was needed.

Every mock query above was also round-tripped through the real `Client.Observe` against the running mock, which is what the e2e block automates:

```text
capture                      outlet.1=on outlet.2=on ... outlet.8=on
individual, outlet 5 off     outlet.1=on ... outlet.5=off outlet.6=on outlet.7=on outlet.8=on
group, outlet 5 off          outlet.1=on ... outlet.5=off outlet.6=off outlet.7=off outlet.8=off
group 1 off                  outlet.1=off ... outlet.4=off outlet.5=on ... outlet.8=on
outlet 5 named NAS, off      outlet.1=on ... outlet.4=on outlet.6=on ... outlet.8=on outlet.nas=off
no outlet table              (no outlet keys)
```

The e2e suite itself was compiled and vetted (`go vet -tags e2e ./test/...`) but **not executed** — it needs a kind cluster, which was out of scope for this change.

---

## LIVE VERIFICATION

Nothing below has been done against real hardware. The first item is the one this whole issue exists for.

**1. H1 — does the UPS switch outlets individually, or in relay groups? (issue #60, decides #23)**

*Do:* with this shipped and Reactor observing, open the UniFi UI and pick **one** outlet in `relay_group: 2` (outlets 5–8). Check first that nothing you care about is plugged into that bank — the gateway, the switch and storage are the ones that matter. Toggle that single outlet off, then back on. While you are in there, **name all eight outlets**, which is the other half of the same visit.

*Look for:* the line Reactor logs immediately afterwards.

```sh
kubectl -n reactor-system logs deploy/reactor -f | grep unifi-outlets
```

- `movedInGroup=1 outletsInGroup=4` → outlets are **individually switchable**. #23 can ship with a per-outlet allowlist defaulting to empty.
- `movedInGroup=4 outletsInGroup=4` → the **relay group is the switching unit**. "Switch outlet 3" would mean "cut outlets 1–4", so #23's API must be per-group, named as such, with the blast radius in the docs.

Post the line on #60. That one line unblocks #23, and it is the only thing standing between here and there.

**2. Does naming outlets in the UI actually change `name` in `outlet_table`?**

*Do:* after naming them in step 1, re-run `./hack/capture-unifi.sh`.

*Look for:* whether `name` now carries what you typed. Reactor's key derivation assumes it does — `NAS` → `outlet.nas`. If UniFi keeps `Outlet 5` in `name` and puts the label somewhere else, every outlet key stays on its index and the naming advice in the README is wrong. Check the state keys directly:

```sh
kubectl -n reactor-system get automation -o jsonpath='{..status.observedState}' | tr ',' '\n' | grep outlet
```

**3. Does `relay_state` move at all through the API, or only in the UI?**

*Look for:* whether the observed key changes within a poll or two of the toggle. If `relay_state` in `stat/device` lags the UI badly or does not move, then observation itself is weaker than it looks and #23 needs to know that before anything is built on it.

**4. Is `relay_group` stable across reboots and firmware?**

*Look for:* whether the grouping line reappears with the same membership after the UPS reboots or takes a firmware update. Reactor logs it whenever it changes, so a second grouping line in the log is itself the finding. If the banks renumber, indexes are an even worse address than the docs already say.

**5. Do outlets survive the UPS going to battery?**

*Do:* during the next real outage (or a controlled one, if you are willing), watch the outlet keys alongside `ups: on-battery`.

*Look for:* whether the outlet table keeps reporting, and whether any relay opens on its own as the battery drains — a UPS shedding a bank at a low charge would show up here as an outlet change nobody asked for, and would be worth knowing before writing any automation that reacts to one.
