### PR TITLE
distribution: list the chart on Artifact Hub, and write down what this does not yet qualify for

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+          # Full history and tags: the Artifact Hub changes annotation is
+          # derived from the commits between this tag and the one before it,
+          # and a shallow clone has neither.
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
@@ -74,6 +78,18 @@ jobs:
 
       - name: Set up Helm
         uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+
+      - name: Add the Artifact Hub changes annotation
+        run: |
+          # Written onto the runner's copy of Chart.yaml, never committed: it
+          # describes one release, so a version of it in git would be stale the
+          # moment the next tag is cut. A release with nothing to list is a
+          # normal outcome and is not an error.
+          ./hack/artifacthub-changes.sh --write "${GITHUB_REF_NAME}" \
+            || echo "::warning::no artifacthub.io/changes annotation for ${GITHUB_REF_NAME}"
+          # Whatever happened above, the chart must still parse — checked here,
+          # before anything is published, rather than on Artifact Hub after.
+          helm show chart charts/reactor > /dev/null
 
       - name: Package and push Helm chart (OCI)
         id: chart

--- a/README.md
+++ b/README.md
@@ -1367,6 +1367,7 @@ See the [chart reference](charts/reactor/README.md#webhook-fast-path-optional-of
 - [UniFi Alarm Manager API](docs/unifi-alarm-manager-api.md) — reverse-engineered notes on configuring UniFi's outbound webhooks programmatically
 - [Writing to a UniFi console](docs/unifi-write-api.md) — what the `unifi.*` actions send, split into what was observed on real hardware and what is inferred
 - [Development](docs/development.md) — building, testing, and running against a local cluster
+- [Distribution](docs/distribution.md) — the Artifact Hub listing, why the chart carries no `signKey`, and which lists this project does and does not qualify for
 - [Contributing](CONTRIBUTING.md) — the dev loop, conventional commits, and the fixture capture policy
 - [Security policy](SECURITY.md) — the outbound-action threat model, how to report a vulnerability, and how to verify a signed release
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,29 @@
+# Artifact Hub repository metadata.
+#
+# This file is what proves to Artifact Hub that whoever registers the chart
+# repository is the person who publishes it. It is not read from this
+# repository: the chart is published to an OCI registry, and Artifact Hub looks
+# for this file there, pushed as a separate artifact under the reserved tag
+# `artifacthub.io`. It lives here so that it is reviewed, versioned and
+# diffable like anything else, and is pushed from here.
+#
+#   oras push \
+#     ghcr.io/robbeverhelst/charts/reactor:artifacthub.io \
+#     --config /dev/null:application/vnd.cncf.artifacthub.config.v1+yaml \
+#     artifacthub-repo.yml:application/vnd.cncf.artifacthub.repository-metadata.layer.v1.yaml
+#
+# The full runbook, including which steps can only be done from a signed-in
+# Artifact Hub session, is in docs/distribution.md.
+
+# The email below must match the address the Artifact Hub account signs in
+# with, or the ownership claim is refused. It is this project's commit-author
+# address; change it here before pushing if a different one is used.
+owners:
+  - name: Robbe Verhelst
+    email: robbe.verhelst@gmail.com
+# repositoryID is issued by Artifact Hub when the repository is first added, so
+# it cannot be filled in before that. It is what earns the Verified publisher
+# badge; the ownership claim above works without it. Add it, then push this
+# file again with the same oras command.
+#
+# repositoryID: <issued by Artifact Hub — see docs/distribution.md>

--- a/charts/reactor/Chart.yaml
+++ b/charts/reactor/Chart.yaml
@@ -14,3 +14,116 @@ keywords:
   - automation
   - operator
   - homelab
+  - ups
+  - wan-failover
+# Contact is deliberately a GitHub handle rather than an address: it is the
+# channel CODE_OF_CONDUCT.md and SECURITY.md already name, and it is the one
+# that keeps working when an address does not. There is no
+# artifacthub.io/maintainers annotation for the same reason — that annotation
+# exists to override this list by matching on email, and there is no email
+# here to match.
+maintainers:
+  - name: Robbe Verhelst
+    url: https://github.com/robbeverhelst
+
+# Artifact Hub metadata. The registration runbook, and the two steps that can
+# only be done from a signed-in Artifact Hub session, are in
+# docs/distribution.md.
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/operator: "true"
+  artifacthub.io/category: networking
+  artifacthub.io/prerelease: "false"
+
+  # There is deliberately no artifacthub.io/signKey.
+  #
+  # Both the image and the chart are cosign-signed keylessly from the release
+  # workflow, and Artifact Hub detects that on its own: for any OCI-backed Helm
+  # repository its tracker asks the registry whether a cosign signature is
+  # attached to each version, and badges the version `cosign` when one is. No
+  # annotation opts into it.
+  #
+  # artifacthub.io/signKey is a different thing — it describes a PGP key used
+  # for Helm's provenance-file signing, and it takes a `fingerprint` and a
+  # `url` to a public key. Keyless signing has neither: there is no key, which
+  # is the point of it. Filling those fields with anything would render a
+  # fingerprint in the UI that verifies nothing. The cosign identity and issuer
+  # a reader actually needs are in SECURITY.md, linked below.
+  artifacthub.io/links: |
+    - name: source
+      url: https://github.com/robbeverhelst/unifi-reactor
+    - name: support
+      url: https://github.com/robbeverhelst/unifi-reactor/issues
+    - name: Documentation
+      url: https://reactor.robbeverhelst.com
+    - name: Chart reference
+      url: https://github.com/robbeverhelst/unifi-reactor/blob/main/charts/reactor/README.md
+    - name: Verifying a signed release
+      url: https://github.com/robbeverhelst/unifi-reactor/blob/main/SECURITY.md#verifying-a-release
+    - name: Changelog
+      url: https://github.com/robbeverhelst/unifi-reactor/releases
+
+  artifacthub.io/crds: |
+    - kind: Automation
+      version: v1alpha1
+      name: automations.reactor.robbeverhelst.com
+      displayName: Automation
+      description: |
+        Reacts to observed provider state. `spec.when` names a provider and the
+        state keys that must hold; `spec.actions` declares what the cluster
+        should look like while they do, and `spec.onExit` what it should look
+        like once they stop. Namespaced. A target shared by several Automations
+        is arbitrated to the most restrictive level any of them asks for, and
+        `status` reports the level in force and which Automation set it.
+
+  artifacthub.io/crdsExamples: |
+    - apiVersion: reactor.robbeverhelst.com/v1alpha1
+      kind: Automation
+      metadata:
+        name: pause-downloads-on-backup-wan
+        namespace: media
+      spec:
+        when:
+          provider: unifi
+          state:
+            wan: backup
+        actions:
+          - type: kubernetes.scale
+            target:
+              kind: Deployment
+              name: qbittorrent
+            replicas: 0
+        onExit:
+          - type: kubernetes.scale
+            target:
+              kind: Deployment
+              name: qbittorrent
+            replicas: 1
+    - apiVersion: reactor.robbeverhelst.com/v1alpha1
+      kind: Automation
+      metadata:
+        name: shed-load-on-battery
+        namespace: media
+      spec:
+        when:
+          provider: unifi
+          state:
+            ups: on-battery
+        actions:
+          - type: kubernetes.scale
+            target:
+              kind: Deployment
+              name: qbittorrent
+            replicas: 0
+          - type: kubernetes.cronjob.suspend
+            target:
+              kind: CronJob
+              name: velero-backup
+              namespace: velero
+
+  # artifacthub.io/changes is written at package time by
+  # hack/artifacthub-changes.sh, from the commits in the tag being released —
+  # the same source the GitHub release notes are generated from. It is not
+  # hand-maintained here for the reason CHANGELOG.md gives for not
+  # hand-maintaining a changelog at all: two sources of truth drift, and a
+  # stale one is worse than none because it is confidently wrong.

--- a/docs/community-posts.md
+++ b/docs/community-posts.md
@@ -1,0 +1,391 @@
+# Community posts — drafts, unposted
+
+**Nothing in this file has been posted anywhere.** These are drafts for the maintainer to send, edit, or
+discard. They are checked in rather than kept in a scratchpad so that the claims in them can be reviewed
+against the code the same way any other documentation is, and so that a claim that stops being true shows
+up in a diff.
+
+Every factual statement below is meant to match what the repository actually ships. Two things in
+particular are deliberately stated as limits rather than left out, because they are the first things a
+reader who knows this hardware will ask about:
+
+- a genuine WAN failover has never been observed against real hardware ([#34]), so `wan` is inferred from
+  one capture in which only one uplink was live;
+- three state keys — `firmware`, `temperature`, `poe` — are parsed against UniFi's documented field shape
+  rather than a captured response, because no capture in the repository contains those fields.
+
+If a draft is edited before sending, keep those two caveats in it. They are the reason the project reads
+as honest rather than as marketing, and dropping them to make a post shorter is the one edit that would
+make the post wrong.
+
+## Before sending anything
+
+- [ ] Read the [Rules of the road](#rules-of-the-road) at the bottom. Several of these communities have
+      self-promotion rules that a first-time poster will otherwise trip.
+- [ ] Check the current release tag and update any version mentioned.
+- [ ] Do not describe your own network. Every example here uses documentation-safe values on purpose.
+- [ ] Post to one place at a time and answer replies there before moving to the next.
+
+---
+
+## r/Ubiquiti
+
+**Framing:** this audience owns the gear. What they want to know is what it talks to, what it can see, and
+whether it does anything unsupported to their console. The Kubernetes half is the payload, not the hook.
+
+**Title:** `Kubernetes operator that reads UniFi state — WAN uplink, UPS, PoE headroom, firmware — as a list of keys you can act on`
+
+**Body:**
+
+> I have been building an operator that polls the UniFi Network API and turns what the console already
+> knows into a small vocabulary of state keys. It reads with an API key from Settings → Control Plane →
+> Integrations, and everything on the read path is a normal `GET`.
+>
+> What it publishes today, one key per line, only when the matching hardware is adopted:
+>
+> - `wan` — `primary` / `backup`, which uplink the gateway is using
+> - `wan.quality` — `good` / `degraded`, against configurable thresholds
+> - `isp` — the carrier your console geolocated your public address to, as a slug
+> - `internet` — `ok` / `degraded` / `down`, from the console's own `www` health subsystem
+> - `ups`, `ups.battery`, `ups.runtime`, `ups.load` — a UniFi UPS on mains or on battery, plus charge,
+>   remaining runtime and draw
+> - `devices` and, opt-in, `device.<name>` — adopted devices reachable or not
+> - `firmware` — whether anything adopted has an update waiting
+> - `temperature` — the hottest adopted device, bucketed
+> - `wifi` — the WiFi subsystem from the console's own AP counts
+> - `poe` — PoE headroom on the worst switch
+> - `outlet.<n>` — a switchable UPS outlet, read-only
+>
+> The first observation logs every key it can see, so those log lines are an inventory of what your
+> console is willing to tell you. That part has been useful to me independently of the automation.
+>
+> Two honest caveats, because this sub will spot both.
+>
+> **A real WAN failover has never been observed.** `wan` is derived from which port reports `is_uplink`,
+> inferred from a single capture in which only one uplink was live. Whether `is_uplink` follows the live
+> traffic or just marks the port configured as primary is unconfirmed. It is not guessing silently — the
+> gateway's own uplink interface is used as a second opinion, `isp` is compared against `wan` on every
+> observation, and a disagreement is logged rather than resolved — but it is not the same as knowing. If
+> you have a gateway with two working uplinks, there is a fifteen-minute capture runbook in the repo and
+> one capture would close it.
+>
+> **`firmware`, `temperature` and `poe` are written to the shape UniFi's API documents, not to a capture.**
+> I own a UDM Pro and a UniFi UPS 2U and neither reports those fields, so no committed capture contains
+> them. Each fails by publishing nothing rather than by publishing a reassuring value: no thermals means
+> no `temperature` key, not `temperature: normal`. One `stat/device` capture from a switch or an AP would
+> settle all three.
+>
+> Verified against UniFi Network 10.5.67 on a UDM Pro with a UniFi UPS 2U. Other UniFi OS consoles are
+> expected to work — it warns and carries on rather than refusing to start.
+>
+> There is a write path too — enable or disable a WLAN, cycle a PoE port — and I want to be blunt about
+> it: those endpoints are inferred from an undocumented API and only the authentication has been seen
+> working against real hardware. They are off by default, they need an explicit allowlist of exactly which
+> SSIDs and which named ports may be touched, a switch's uplink port is never cycled whatever you
+> allowlist, and every step reads the object and confirms it is the one you meant before it writes. A bug
+> in the inference degrades to a refused action rather than a wrong one. That is the property the
+> check-before-write discipline exists to give, and it is why I would rather describe it this way than
+> ship it quietly.
+>
+> Apache 2.0, one static binary, no database and no UI. Repo: https://github.com/robbeverhelst/unifi-reactor
+
+---
+
+## r/homelab
+
+**Framing:** the power-cut story. This audience runs the cluster and the UPS in the same rack, and has
+personally watched a battery drain into a transcode.
+
+**Title:** `The UPS knows it is on battery; the cluster does not. I wrote an operator that closes that gap.`
+
+**Body:**
+
+> The failure that started this: the power drops, the UPS starts counting down its runtime, and the
+> cluster spends that runtime transcoding video and running the nightly backup. Nothing in Kubernetes
+> knows anything happened. The UPS knows. The two just never talk.
+>
+> UniFi Reactor is a Kubernetes operator that polls the UniFi Network API and reconciles your cluster
+> against what it observes. A UniFi UPS reports `ups: online` or `ups: on-battery`, plus remaining charge,
+> remaining runtime and current load, and you write what should happen:
+>
+> ```yaml
+> apiVersion: reactor.robbeverhelst.com/v1alpha1
+> kind: Automation
+> metadata:
+>   name: shed-load-on-battery
+>   namespace: media
+> spec:
+>   when:
+>     provider: unifi
+>     state:
+>       ups: on-battery
+>
+>   actions:
+>     - type: kubernetes.scale
+>       target: { kind: Deployment, name: qbittorrent }
+>       replicas: 0
+>     - type: kubernetes.cronjob.suspend
+>       target: { kind: CronJob, name: velero-backup, namespace: velero }
+> ```
+>
+> Omit `onExit` and it puts things back the way it found them — the value each target held before Reactor
+> first claimed it is recorded in an annotation on the target itself, so it survives a controller restart
+> and you can read it with `kubectl get deploy -o jsonpath='{.metadata.annotations}'` at 3am.
+>
+> Some things I decided on purpose, because they are the parts that matter when it fires for real:
+>
+> **Runtime is a better trigger than charge.** "30% battery" means nothing without knowing the load —
+> 30% carrying a light rack is twenty minutes and 30% carrying a heavy one is four. The UPS already
+> computes remaining runtime against its actual current draw, so `ups.runtime` is `ample` / `short` /
+> `critical` and that is the key I reach for.
+>
+> **Suspending a CronJob does not kill a Job already running.** Deliberate, and Reactor is granted no
+> permission over Jobs at all, so it could not delete one if it tried. Declining to start more work is a
+> very different act from killing work in flight, and killing work in flight is not a decision an outage
+> should make for you.
+>
+> **There is no `kubernetes.drain`, and there will not be.** In a three-node homelab on one UPS, draining
+> assumes somewhere else for the pods to go, and there is nowhere — they go `Pending`, so you lose the
+> workload *before* the battery runs out instead of when it does. `kubernetes.cordon` gets the actual
+> benefit, which is that replacements land on the node still on mains. Cordoning is opt-in and is the only
+> permission it asks for that reaches outside the workloads you installed it to manage; nodes are
+> cluster-scoped, so turning it on creates a `ClusterRole` even in a namespaced install.
+>
+> It does the metered-uplink case with the same shape — `wan: backup` instead of `ups: on-battery` — and
+> point both at the same Deployment and it stays down until neither wants it down.
+>
+> Caveat worth stating up front for this crowd: the UPS path is the well-tested one, verified against a
+> UniFi UPS 2U on a UDM Pro. A genuine WAN failover has never been observed on real hardware, so treat
+> `wan` as less battle-tested than `ups`.
+>
+> One static binary in a distroless image, no database, no queue, no UI. Helm chart and image are both
+> signed. Apache 2.0. https://github.com/robbeverhelst/unifi-reactor
+
+---
+
+## r/selfhosted
+
+**Framing:** same power-cut story, but this audience cares more about what it costs to run and what it
+can reach than about rack topology. Lead with the operational footprint.
+
+**Title:** `Operator that pauses self-hosted workloads when the UPS goes to battery or the WAN fails over`
+
+**Body:**
+
+> Two failures that cost me something before I automated them: the WAN failing over to the 5G backup at
+> 3am while qBittorrent kept seeding into a data cap, and the power dropping while the cluster spent the
+> UPS's runtime on a transcode.
+>
+> UniFi Reactor polls the UniFi Network API and turns what your console observes — which uplink is live,
+> which carrier is behind it, whether the UPS is on mains — into declarative actions on Kubernetes. One
+> `Automation` resource says what to do while a condition holds and what it wants once it stops:
+>
+> ```yaml
+> apiVersion: reactor.robbeverhelst.com/v1alpha1
+> kind: Automation
+> metadata:
+>   name: pause-downloads-on-backup-wan
+>   namespace: media
+> spec:
+>   when:
+>     provider: unifi
+>     state:
+>       wan: backup
+>
+>   actions:
+>     - type: kubernetes.scale
+>       target: { kind: Deployment, name: qbittorrent }
+>       replicas: 0
+>
+>   onExit:
+>     - type: kubernetes.scale
+>       target: { kind: Deployment, name: qbittorrent }
+>       replicas: 1
+> ```
+>
+> What it can do: scale Deployments and StatefulSets, suspend CronJobs, cordon nodes, roll a Deployment,
+> send a notification (ntfy, Discord, Slack), call an arbitrary HTTP API, call a Home Assistant service,
+> pause and resume qBittorrent, and switch a UniFi WLAN or cycle a PoE port.
+>
+> The part I would want to read about first if someone else had written this is the outbound story,
+> because an operator that will make HTTP requests on demand is a confused deputy: it runs inside the
+> cluster with a network position, and `spec.actions` is writable by anyone who can create an `Automation`
+> in their own namespace. So destinations are an install-time allowlist, empty by default, with no
+> per-`Automation` override and no way to widen it from a namespace. Redirects are never followed, because
+> a redirect names a destination the allowlist never approved. Loopback and link-local — where cloud
+> metadata services live — are refused in the dialer, on the address actually connected to, so a hostname
+> that resolves somewhere other than it appears to is refused too. Private ranges are *not* blocked,
+> because an ntfy box on your LAN is a first-class destination for this and no address rule can tell that
+> apart from a `ClusterIP` Service; the allowlist is what draws that line, which is why it is default-deny.
+> Credentials come from Secrets in the `Automation`'s own namespace only, and the Secret read permission
+> is granted only if you actually enabled outbound actions.
+>
+> Footprint: one static Go binary in a distroless image, multi-arch, no database, no queue, no UI. It
+> needs a UniFi API key with read access and RBAC over the workloads you point it at — not `cluster-admin`.
+> Image and Helm chart are both cosign-signed keylessly from the release workflow, and the image carries an
+> SBOM and build provenance.
+>
+> Honest limits: verified against UniFi Network 10.5.67 on a UDM Pro and a UniFi UPS 2U. A real WAN
+> failover has never been observed, so `wan` is inferred rather than confirmed. Three keys — `firmware`,
+> `temperature`, `poe` — are parsed against UniFi's documented field shape rather than a capture, and each
+> publishes nothing rather than a reassuring default when the fields are absent. It is pre-1.0 and
+> `v1alpha1`, so expect breaking changes between minor versions.
+>
+> Apache 2.0. https://github.com/robbeverhelst/unifi-reactor
+
+---
+
+## Ubiquiti Community forum
+
+**Framing:** more formal than Reddit, and the audience skews toward people who will actually go and look
+at what requests you make of their console. Lead with the integration surface and be explicit about read
+versus write.
+
+**Category:** UniFi Network → Feature/Integration discussion (check the current category list before posting)
+
+**Title:** `Open-source Kubernetes operator built on the Network API — state keys from the console, and what I could not verify`
+
+**Body:**
+
+> I have written an open-source operator that consumes the UniFi Network API and reacts to what the
+> console reports. Posting it here partly to share it and partly because there are three things I cannot
+> verify from the hardware I own, and this is where the people who can are.
+>
+> **What it reads.** It authenticates with an API key created under Settings → Control Plane →
+> Integrations and polls `stat/device` and `stat/health` on an interval (30s by default). It normalizes
+> those into a small set of keys — which uplink is live, the carrier behind it, whether the outside world
+> is reachable, UPS mains/battery plus charge, runtime and load, adopted devices reachable or not, pending
+> firmware, the hottest device, the WiFi subsystem, PoE headroom, and the state of each switchable UPS
+> outlet. Keys degrade one at a time: a console with no UPS still reports uplink state, and a console that
+> answers one endpoint but not the other publishes whatever it can.
+>
+> It logs the Network version it finds and compares it against what the project was verified against, then
+> carries on. Refusing to start against a console that would have worked fine seemed like a worse failure
+> than a warning.
+>
+> **What it writes, and why that is separate.** There are three write actions: enable a WLAN, disable a
+> WLAN, and cycle a PoE port. These go to the one console configured at install time, over the
+> undocumented internal API, with credentials that are install configuration and cannot be supplied by a
+> user of the operator. They are off by default and controlled by two allowlists that name exactly which
+> SSIDs and which ports may be touched — there is deliberately no wildcard, because "any SSID" and "any
+> port" are not choices worth offering. A PoE entry must name the switch *and* what the port is called,
+> and that name is checked against the switch's own port table before anything is sent, so re-patching a
+> rack turns into a refused action rather than a power cut to the wrong device. A switch's own uplink port
+> is never cycled whatever you allowlist. Each action logs in, acts, and logs out; no session is cached.
+>
+> **What I could not verify, stated plainly.** Every endpoint on that write path is inferred rather than
+> observed — only the authentication has been seen working against real hardware. The repository splits
+> the two in a document rather than blurring them. Separately, `firmware`, `temperature` and `poe` are
+> parsed against the field names UniFi's API documents, because nothing I own reports them: the UDM Pro
+> capture carries no upgrade fields and the UPS 2U reports no thermals at all. And a genuine WAN failover
+> has never been observed, so the derivation of `wan` from `is_uplink` is inferred from a capture with one
+> live uplink.
+>
+> In every one of those cases the code fails by declining or by publishing nothing, never by publishing a
+> confident wrong answer.
+>
+> If you run a UniFi switch or an AP, or a gateway with two working uplinks, there is a capture script in
+> the repository that produces a sanitized JSON fixture. One of each would settle all four open questions
+> above. Verified so far: UniFi Network 10.5.67, UDM Pro on gateway firmware 5.1.26, UniFi UPS 2U
+> (`USWDA26`, firmware 1.6.1).
+>
+> Apache 2.0, no telemetry, nothing phones home: https://github.com/robbeverhelst/unifi-reactor
+
+---
+
+## Show HN
+
+**Framing:** HN wants the design decision and the reasoning behind it, not the feature list. The two ideas
+worth the post are *state, not events* and *arbitration across automations sharing a target*. Everything
+else is context for those.
+
+**Title:** `Show HN: UniFi Reactor – a Kubernetes operator that reconciles against state, not events`
+
+**URL:** `https://github.com/robbeverhelst/unifi-reactor`
+
+**First comment (post immediately after submitting):**
+
+> The problem is small and specific: my UniFi gateway knows when it has failed over to the 5G backup and
+> my UniFi UPS knows when it is on battery, and my Kubernetes cluster knows neither, so it keeps seeding
+> torrents into a metered uplink and transcoding video on battery runtime.
+>
+> The obvious build is webhooks: the console fires an event, something in the cluster reacts. I built the
+> other thing, and the two design decisions behind that are what I would actually like feedback on.
+>
+> **1. State, not events.** It polls and reconciles against what it observes. There is no event log and no
+> queue. A dropped webhook, a network blip, or a controller restart cannot strand the cluster in the wrong
+> mode, because the next observation corrects it. Webhooks exist in the project as a latency optimization
+> and are never the mechanism of record — they cause an immediate poll rather than carrying information.
+>
+> The consequence that makes it worth doing: observing `wan: backup` fifty times does nothing forty-nine
+> extra times. Scaling is expressed as a desired level, not as a command, so the result is a pure function
+> of which conditions currently hold and is independent of the order they were observed in. Retrying is
+> free. Crash recovery is not a code path — it is the same code path.
+>
+> **2. Arbitration, not last-write-wins.** qBittorrent genuinely should pause for both a metered uplink
+> and a power cut, and those are two separate automations written by someone who was not thinking about
+> the other one. The naive implementation has whichever automation saw a transition most recently write
+> the replica count, which means the WAN recovering brings the workload back up while the building is
+> still on battery.
+>
+> Instead, every automation pointing at a target declares a level, and the target is continuously
+> reconciled to the most restrictive level anyone currently asks for. The workload comes back only when
+> *no* automation wants it down. The automation that lost says so in its status, naming the one that
+> outvoted it:
+>
+> ```
+> {"ref":"Deployment/media/qbittorrent","desired":1,"effective":0,
+>  "deferredBy":["media/shed-on-battery"]}
+> ```
+>
+> "Most restrictive" is a total order and nothing more: for replicas it is the lower count, and for
+> CronJob suspension and node cordoning it is the suspended and cordoned end. So suspended wins over
+> running for exactly the same reason 0 replicas wins over 3, and there is no second rule to learn.
+>
+> **The line that fell out of this, which I did not design and only noticed afterward.** Some actions can
+> be arbitrated and some cannot, and the discriminator is not whether the action expresses a level. Pausing
+> a torrent plainly expresses a level; so does a WLAN being enabled. Both are edge actions anyway. What
+> decides it is whether there is somewhere to record the value the target held *before* the operator
+> claimed it — because without that, release cannot put it back, and an automation that cannot hand a
+> target back has no business claiming it. For a Kubernetes object that place is an annotation on the
+> object. For anything outside the cluster there is no answer, which is why every arbitrated action so far
+> is a `kubernetes.*` one and everything that leaves the cluster is named as a verb and owns nothing.
+>
+> **What I deliberately did not build.** There is no `drain` action. Every other action declares a level
+> that is a pure function of current conditions, and a drain has no such value — there is no state a node
+> can be held at that means "drained", so reversal cannot express undoing it and a flapping input would
+> empty the node again on every flap with nothing to correct it. The RBAC that would make it possible is
+> not granted under any setting. Cordoning gets the real benefit in a small cluster, which is that
+> replacement pods land on the node still on mains.
+>
+> **What is not verified, since it is the first thing I would want to know.** A genuine WAN failover has
+> never been observed on real hardware — the uplink derivation is inferred from a single capture in which
+> only one uplink was live. It is not silent about that: the gateway's own uplink interface is used as a
+> second opinion, the observed carrier is compared against the uplink on every observation, and a
+> disagreement is logged rather than resolved. Three state keys are parsed against the field shape
+> UniFi's API documents rather than against a captured response, because the hardware I own does not
+> report those fields, and each publishes nothing rather than a reassuring default when they are absent.
+> Parsers here are written against real captured responses committed to the repository, and the three
+> exceptions are listed as exceptions.
+>
+> Pre-1.0, `v1alpha1`, Apache 2.0. Go, one static binary, no database.
+
+---
+
+## Rules of the road
+
+Checked before drafting; re-check before sending, since community rules change.
+
+| Venue | The rule that matters | What it means here |
+| --- | --- | --- |
+| r/Ubiquiti | Self-promotion is tolerated for genuinely relevant open-source work, but low-effort link drops are removed. | Post the body above in full as a text post. Do not post a bare link. |
+| r/homelab | Rule 3 forbids advertising and low-effort self-promotion; projects are welcome when the post explains the thing rather than selling it. | The body is the post. No link-only submission, no crossposting the same text to r/selfhosted the same day. |
+| r/selfhosted | Self-promotion is allowed for free and open-source software, and the software must actually be self-hostable. | Both hold. Flair the post as a release/project if the sub uses flair. |
+| Ubiquiti Community | Registered account required, and posts belong in a product-specific category. | Check the current UniFi Network category list; do not cross-post to several. |
+| Hacker News | Show HN is for something people can try. No "we/our" marketing voice, and the submitter should be in the thread to answer. | Submit the repo URL, then post the first comment above immediately. Be around for a few hours. |
+
+One more, which is not a written rule anywhere but is the thing most likely to go wrong: **do not describe
+your own network.** No SSIDs, no addresses, no device names, no cluster context. Every example in this
+file uses documentation-safe values, and a reply written quickly in a thread is where that slips.
+
+[#34]: https://github.com/robbeverhelst/unifi-reactor/issues/34

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,157 @@
+# Distribution
+
+Where this project is published, what is automated, and what is left for a human to do. Everything here
+is a fact about the repository or a criterion quoted from somebody else's contribution rules — where a
+project does not meet one, that is written down rather than worked around.
+
+- [Artifact Hub](#artifact-hub) — the chart listing, and the two steps only the maintainer can do
+- [Why there is no `signKey`](#why-there-is-no-signkey)
+- [OperatorHub.io](#operatorhubio) — scoped, and deliberately not started
+- [Lists](#lists) — what each one requires, and when this project qualifies
+- [Community posts](#community-posts) — drafted, unposted
+- [Things only the maintainer can do](#things-only-the-maintainer-can-do)
+
+## Artifact Hub
+
+The chart is published to an OCI registry, so nothing about the listing works the way the HTTP-repository
+documentation describes. Two things follow from that and both are already in the repository.
+
+**The chart metadata** is in [`charts/reactor/Chart.yaml`](../charts/reactor/Chart.yaml) as
+`artifacthub.io/*` annotations: the license and category, `operator: "true"`, the links, and the
+`Automation` CRD together with two working examples — pausing downloads on a backup uplink, and shedding
+load when the UPS goes to battery. Artifact Hub renders each CRD as a card and each example as something
+you can open from it. The examples are the ones from the README, so there is one shape to keep right
+rather than two.
+
+**`artifacthub.io/changes` is not in that file.** It describes a single release, so a copy of it in git
+would be stale the moment the next tag is cut — the failure [CHANGELOG.md](../CHANGELOG.md) refuses to
+sign up for anywhere else in this repository. It is generated at package time instead, by
+[`hack/artifacthub-changes.sh`](../hack/artifacthub-changes.sh), from the commits between the tag being
+released and the one before it. That is the same source the GitHub release notes come from, which is why
+conventional commits are required. Run it by hand to see what a tag would publish:
+
+```sh
+./hack/artifacthub-changes.sh v1.1.0
+```
+
+Commit types that carry no user-visible change — `docs`, `test`, `ci`, `build`, `chore`, `style` — are
+dropped rather than folded into `changed`, because a release note listing a lint fix hides the two lines
+that mattered. A release containing nothing else is a normal outcome: the annotation is simply absent,
+the workflow logs a warning, and the release proceeds.
+
+**The ownership metadata** is [`artifacthub-repo.yml`](../artifacthub-repo.yml) at the repository root.
+For an OCI-backed repository Artifact Hub does not fetch this over HTTP — it pulls it from the registry,
+as a separate artifact under the reserved tag `artifacthub.io`. The file lives in git so that it is
+reviewed and diffable, and is pushed from there with `oras`; the command is in the file's own header.
+
+### Why there is no `signKey`
+
+The image and the chart are both cosign-signed keylessly from the release workflow, and Artifact Hub
+picks that up without being told: for any OCI-backed Helm repository, its tracker asks the registry
+whether a cosign signature is attached to each chart version and badges the version `cosign` when one is.
+There is no annotation that opts into this and none that improves it.
+
+`artifacthub.io/signKey` is a different mechanism. It takes a `fingerprint` and a `url`, and it describes
+a **PGP key** used for Helm's provenance-file signing — the `helm package --sign` path. Keyless signing
+has no key and no fingerprint, which is the entire point of it: the signature records the workflow and
+the tag that produced the artifact, and there is nothing to hold or leak. Filling those two fields with
+anything at all would render a fingerprint in the Artifact Hub UI that verifies nothing.
+
+So the annotation is omitted, and the `Verifying a signed release` link in `artifacthub.io/links` points
+at [SECURITY.md](../SECURITY.md#verifying-a-release), which carries the certificate identity and the OIDC
+issuer that a reader actually needs to run `cosign verify`.
+
+### Security report
+
+Artifact Hub scans container images with Trivy on its own schedule and needs no annotation to do it: it
+extracts the images from a dry-run install using the chart's default values. There is deliberately no
+`artifacthub.io/images` annotation, because that annotation exists to declare images the dry run would
+miss, and this chart renders exactly one container from its defaults.
+
+## OperatorHub.io
+
+**Scoped, and deliberately not started** — tracked as
+[#79](https://github.com/robbeverhelst/unifi-reactor/issues/79) rather than half-built here, because a
+partial bundle is worse than none: it would publish an install path nobody tests.
+
+Reactor does qualify on the surface — it is an operator, it owns a CRD, it has a defined upgrade path.
+What a listing actually costs is a bundle, and the bundle is not the hard part:
+
+- `bundle/manifests/` containing a ClusterServiceVersion and the CRD, plus `bundle/metadata/annotations.yaml`
+  and a `bundle.Dockerfile`, passing `operator-sdk bundle validate --select-optional suite=operatorframework`.
+- A CSV that restates the Deployment, the ServiceAccount and **every RBAC rule** in its own schema. That
+  is the objection that matters. [SECURITY.md](../SECURITY.md) argues from the permissions the chart
+  grants, and several of those are conditional — `get` on Secrets only when outbound actions are
+  configured, a `ClusterRole` over nodes only when `rbac.allowNodeActions` is on, and two whole RBAC modes
+  from `rbac.clusterWide`. A CSV expresses one install. Restating the rules there creates a second source
+  of truth for exactly the thing that argument depends on being single, and the two would drift silently.
+- An upgrade graph maintained by hand — a channel plus `replaces`/`skips` per version — and a PR to
+  `k8s-operatorhub/community-operators` for **every release**, with its own CI to keep passing.
+- An icon, base64-encoded into the CSV. None exists ([see below](#things-only-the-maintainer-can-do)).
+- Verification that OLM can actually install it into a cluster, which is not something this repository's
+  tests cover today.
+
+The honest order is: settle whether the conditional RBAC can be represented without duplicating it,
+then build the bundle, then list. Note also that `operator-framework/awesome-operators` — one of the
+lists below — is archived and points at OperatorHub.io as its replacement, so the two are one piece of
+work rather than two.
+
+## Lists
+
+Each list's own rules, checked on 2026-08-14. Three of the four are blocked on criteria this project does
+not meet, and the honest reading of that is that it is three days old rather than that the rules are
+wrong.
+
+| List | The rule | Status |
+| --- | --- | --- |
+| [AwesomeHomelab/awesome-homelab](https://github.com/AwesomeHomelab/awesome-homelab) | No stated age or popularity floor. Entries are a `name`/`url` pair in `data/<category>.yaml`; `README.md` is generated by `pnpm build` and must not be hand-edited. | **PR open** — [#120](https://github.com/AwesomeHomelab/awesome-homelab/pull/120), added to `data/automation.yaml` in the house style. |
+| [ramitsurana/awesome-kubernetes](https://github.com/ramitsurana/awesome-kubernetes) | PR template: "Minimum of 25 GitHub Stars", "Minimum of 3+ contributors", "Proper documentation". Exception only for a project "hosted by a recognized organization". | **Not eligible.** One star, one contributor. Documentation is not the blocker. Resubmit when both counts are met. |
+| [awesome-selfhosted](https://github.com/awesome-selfhosted/awesome-selfhosted-data) | PR checklist: "Any software project you are adding was first released more than 4 months ago." Entries are `software/<name>.yml` in the data repository, not the markdown one. | **Not eligible until 2026-12-12.** First release `v0.1.0` was 2026-08-12. See the scope question below before submitting. |
+| [operator-framework/awesome-operators](https://github.com/operator-framework/awesome-operators) | — | **Archived.** Its README reads "Repository is obsolete… archived in favor of operatorhub.io". No PR is possible; this is subsumed by [OperatorHub.io](#operatorhubio) above. |
+
+The awesome-selfhosted scope question, worth settling before December rather than in a PR thread: its
+rules exclude "anything that is a generic container/deployment automation/virtualization/… tool" as
+better suited to [awesome-sysadmin](https://github.com/awesome-foss/awesome-sysadmin). Reactor is not
+generic deployment automation — it is a specific integration between one vendor's network hardware and a
+cluster — but a Kubernetes operator is close enough to that line that the submission should say so in one
+sentence rather than leave a maintainer to guess. awesome-sysadmin is the fallback and may simply be the
+better list.
+
+## Community posts
+
+Drafted and **unposted**, in [`docs/community-posts.md`](community-posts.md): r/Ubiquiti, r/homelab,
+r/selfhosted, the Ubiquiti community forum, and a Show HN. Each has its own framing and each carries the
+project's two documented uncertainties — the unobserved WAN failover, and the three keys parsed against a
+documented shape rather than a capture. That file also records the self-promotion rule for each venue,
+which is the thing most likely to get a first post removed.
+
+Sending them is the maintainer's decision. Nothing in this repository posts anything anywhere.
+
+## Things only the maintainer can do
+
+In order. The first four are the Artifact Hub listing and are worth doing together.
+
+1. **Fix the GitHub repository description.** It currently reads "A Kubernetes Operator that turns UniFi
+   *events* into infrastructure actions" — which contradicts the design the README opens with, and is the
+   one line that appears in GitHub search, in link previews, and in the generated awesome-homelab table.
+   Something like "A Kubernetes operator that reacts to observed UniFi state — WAN failover, UPS on
+   battery — with declarative actions on your cluster" matches what ships. It is a repository setting, not
+   a file.
+2. **Add the repository on Artifact Hub**, signed in as the account whose email matches the `owners` entry
+   in [`artifacthub-repo.yml`](../artifacthub-repo.yml). Kind: Helm charts. URL, exactly:
+   `oci://ghcr.io/robbeverhelst/charts/reactor`. One OCI repository is one chart; the package name comes
+   from `Chart.yaml`, not from the URL.
+3. **Push the ownership metadata** with the `oras` command in that file's header, then take the
+   `repositoryID` Artifact Hub issues, uncomment it in the file, commit, and push the file again. The
+   ownership claim works without it; the Verified publisher badge does not.
+4. **Check the listing renders**: the CRD card with both examples, the `cosign` signature badge, and the
+   Trivy security report. The annotations reach Artifact Hub with the **next release** — the current
+   published chart, v1.1.0, was packaged before they existed.
+5. **Decide the `Documentation` link.** `artifacthub.io/links` points at `https://reactor.robbeverhelst.com`,
+   which does not exist yet ([#74](https://github.com/robbeverhelst/unifi-reactor/issues/74)). It is there
+   because the Artifact Hub record should be right the day the site lands and metadata is cheap to update.
+   Nothing else in this repository links to it. If the site is not up when the next tag is cut, delete
+   those two lines from `Chart.yaml` and put them back later.
+6. **An icon, eventually.** `helm lint` asks for one, Artifact Hub shows a placeholder without one, and a
+   community-operators CSV would require one. The only artwork here is a wide banner, and cropping it
+   would look like a cropped banner. This is a design task, most naturally done alongside the docs site.

--- a/hack/artifacthub-changes.sh
+++ b/hack/artifacthub-changes.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env bash
+# Render an artifacthub.io/changes annotation from the commits in a release.
+#
+#   ./hack/artifacthub-changes.sh v1.1.0            # since the previous tag
+#   ./hack/artifacthub-changes.sh v1.1.0 v1.0.0     # since an explicit one
+#   ./hack/artifacthub-changes.sh --write v1.1.0    # into charts/reactor/Chart.yaml
+#
+# Prints the annotation value — a YAML list — on stdout, and nothing at all if
+# the range contains no commit worth listing. With --write it inserts the
+# annotation into charts/reactor/Chart.yaml instead; the release workflow does
+# that just before `helm package`, on the runner's copy, and nothing is
+# committed. Uses nothing but git, awk and sed, because the one place it runs
+# unattended is the release, and a release is a bad place to discover that a
+# tool was assumed to be on the runner.
+#
+# Why generate it rather than write it by hand: CHANGELOG.md refuses to keep a
+# hand-maintained changelog, on the grounds that two sources of truth drift and
+# a stale one is confidently wrong. An artifacthub.io/changes block committed in
+# Chart.yaml would be exactly that file — it describes one release, and the
+# release after it would ship the previous release's notes to Artifact Hub with
+# no diff to notice. So it comes from the same place the GitHub release notes
+# come from: the commits in the tag. Conventional commits are already required
+# for that reason, which is what makes the mapping below possible.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+WRITE=""
+if [ "${1:-}" = "--write" ]; then WRITE="yes"; shift; fi
+
+TAG="${1:-}"
+[ -n "$TAG" ] || { echo "usage: $0 [--write] <tag> [previous-tag]" >&2; exit 2; }
+
+CHART=charts/reactor/Chart.yaml
+
+PREV="${2:-}"
+if [ -z "$PREV" ]; then
+  # The tag before this one, by tag order rather than by date: a release cut
+  # from an older commit must not be described as containing everything since.
+  PREV="$(git tag --list 'v*' --sort=-v:refname | grep -A1 -x -- "$TAG" | tail -n1 || true)"
+  [ "$PREV" = "$TAG" ] && PREV=""
+fi
+
+RANGE="$TAG"
+[ -n "$PREV" ] && RANGE="$PREV..$TAG"
+
+# Artifact Hub accepts exactly six kinds: added, changed, deprecated, removed,
+# fixed, security. Conventional-commit types map onto them as below. Types with
+# no meaningful entry — docs, test, ci, build, chore, style — are dropped
+# rather than forced into `changed`, because a release note listing a lint fix
+# is noise that hides the two lines that mattered.
+kind_for() {
+  case "$1" in
+    feat)     echo added ;;
+    fix)      echo fixed ;;
+    perf)     echo changed ;;
+    refactor) echo changed ;;
+    revert)   echo removed ;;
+    security) echo security ;;
+    deprecate|deprecated) echo deprecated ;;
+    *)        echo "" ;;
+  esac
+}
+
+emitted=0
+out=""
+
+while IFS=$'\t' read -r sha subject; do
+  [ -n "$subject" ] || continue
+
+  # type(scope)!: description  —  the scope and the ! are optional.
+  header="${subject%%:*}"
+  [ "$header" = "$subject" ] && continue          # not a conventional commit
+  desc="${subject#*: }"
+  [ -n "$desc" ] || continue
+
+  breaking=""
+  case "$header" in *"!") breaking="yes"; header="${header%!}" ;; esac
+  type="${header%%(*}"
+  type="$(printf '%s' "$type" | tr '[:upper:]' '[:lower:]' | tr -d ' ')"
+
+  kind="$(kind_for "$type")"
+  # A breaking change is a change whatever its type: a feat! removes the old
+  # behaviour as surely as it adds the new one, and `added` would undersell it.
+  [ -n "$breaking" ] && kind=changed
+  [ -n "$kind" ] || continue
+
+  # YAML-quote by doubling single quotes, so a description containing a colon,
+  # a quote or a leading dash cannot end the scalar early or start a new node.
+  safe="$(printf '%s' "$desc" | sed "s/'/''/g")"
+  [ -n "$breaking" ] && safe="breaking: $safe"
+
+  out+="- kind: $kind"$'\n'
+  out+="  description: '$safe'"$'\n'
+  out+="  links:"$'\n'
+  out+="    - name: Commit"$'\n'
+  out+="      url: https://github.com/robbeverhelst/unifi-reactor/commit/$sha"$'\n'
+  emitted=$((emitted + 1))
+done < <(git log --no-merges --format=$'%H\t%s' "$RANGE" 2>/dev/null || true)
+
+# Nothing to say is a valid outcome — a release of nothing but docs and CI. It
+# is not an error, and it must not leave an empty annotation behind either.
+[ "$emitted" -gt 0 ] || exit 0
+
+if [ -z "$WRITE" ]; then
+  printf '%s' "$out"
+  exit 0
+fi
+
+[ -f "$CHART" ] || { echo "no $CHART" >&2; exit 1; }
+grep -qx 'annotations:' "$CHART" || { echo "$CHART has no annotations block" >&2; exit 1; }
+if grep -q 'artifacthub.io/changes:' "$CHART"; then
+  echo "$CHART already carries artifacthub.io/changes; refusing to add a second" >&2
+  exit 1
+fi
+
+# Inserted immediately after the `annotations:` line rather than appended to
+# the file, so it does not depend on that block staying last.
+#
+# The block goes through a file rather than `awk -v`, because a -v assignment
+# containing newlines is a GNU extension: BSD awk rejects it, and rejects it by
+# writing a warning and carrying on rather than by failing, so the first
+# symptom would be a released chart quietly missing the annotation.
+BLOCK="$(mktemp)"
+trap 'rm -f "$BLOCK" "$CHART.tmp"' EXIT
+{ printf '  artifacthub.io/changes: |\n'; printf '%s' "$out" | sed 's/^/    /'; } > "$BLOCK"
+
+awk -v blockfile="$BLOCK" '
+  !inserted && $0 == "annotations:" {
+    print
+    while ((getline line < blockfile) > 0) print line
+    close(blockfile)
+    inserted = 1
+    next
+  }
+  { print }
+' "$CHART" > "$CHART.tmp"
+
+grep -q '^  artifacthub.io/changes: |$' "$CHART.tmp" || {
+  echo "insertion into $CHART produced nothing; leaving it alone" >&2
+  exit 1
+}
+mv "$CHART.tmp" "$CHART"
+
+echo "wrote $emitted change entries into $CHART" >&2


### PR DESCRIPTION
Closes #78.

Artifact Hub has five UniFi charts and every one of them is the controller itself. Nothing there automates against it, so the listing is the open lane #78 describes, and it is the part of this that had to land.

## Artifact Hub

`charts/reactor/Chart.yaml` gains the annotations Artifact Hub reads — license, `category: networking`, `operator: "true"`, the links, and the `Automation` CRD with two working examples lifted from the README so there is one shape to keep right rather than two. Both examples were checked against the CRD's own schema: the action types, the target kinds and the required fields are all in the enums `make manifests` generates.

`artifacthub-repo.yml` at the repository root carries the ownership claim. For an OCI-backed repository Artifact Hub does not fetch this over HTTP — it pulls it from the registry as a separate artifact under the reserved tag `artifacthub.io` — so the file lives in git to be reviewed and diffed, and is pushed from there with `oras`. The command is in the file's header.

### There is no `artifacthub.io/signKey`, on purpose

#78 asked for it. Read against the implementation, it is the wrong annotation for what this project does, so it is omitted and the reasoning is written down in `Chart.yaml` and in `docs/distribution.md`.

Artifact Hub detects cosign signatures on OCI-backed Helm repositories by asking the registry whether one is attached to each chart version, and badges the version `cosign`. No annotation opts into that. `artifacthub.io/signKey` is a different mechanism: it takes a `fingerprint` and a `url` and describes a **PGP** key used for Helm's provenance-file signing. Keyless signing has neither — that is the point of it — and filling those fields with anything would render a fingerprint in the UI that verifies nothing. The `Verifying a signed release` link points at `SECURITY.md` instead, which carries the certificate identity and OIDC issuer `cosign verify` actually needs.

### `artifacthub.io/changes` is generated, not committed

It describes a single release, so a copy in git is stale the moment the next tag is cut — the failure `CHANGELOG.md` already refuses to sign up for. `hack/artifacthub-changes.sh` derives it at package time from the commits between the tag and the one before it, which is the same source the release notes come from and what conventional commits were already for. Commit types carrying no user-visible change are dropped rather than folded into `changed`; a release with nothing to list is a normal outcome, not an error.

The release workflow now checks out full history (the commits between two tags are not in a shallow clone) and re-parses the chart after injection, so a mangled `Chart.yaml` fails before anything is published rather than after. Exercised locally end to end against `v1.1.0`: 23 entries, `helm show chart` parses it, `helm package` carries it into the tarball, and a second write is refused.

## Lists — one PR open, three documented skips

Each rule below is quoted from the list's own contribution guide.

| List | Outcome |
| --- | --- |
| AwesomeHomelab/awesome-homelab | **PR open**: https://github.com/AwesomeHomelab/awesome-homelab/pull/120 — `data/automation.yaml`, house style, no hand-edit of the generated `README.md`. No stated age or popularity floor. |
| ramitsurana/awesome-kubernetes | **Skipped.** Its PR template requires 25 stars and 3+ contributors. This has 1 and 1. |
| awesome-selfhosted | **Skipped.** Its checklist requires the first release to be more than 4 months old; `v0.1.0` is two days old, so 2026-12-12 is the earliest. |
| operator-framework/awesome-operators | **Cannot.** Archived — "obsolete… in favor of operatorhub.io". |

Three days old is the reason for those, not a disagreement with the rules. `docs/distribution.md` records each threshold so resubmitting later is a lookup rather than a re-investigation.

## OperatorHub — scoped, deliberately not started

Filed as #79. The blocker is a design question rather than a chore: a CSV expresses one install, and several of this operator's permissions are conditional on chart values — `get` on Secrets only with outbound actions configured, a node `ClusterRole` only with `rbac.allowNodeActions`, two whole RBAC modes from `rbac.clusterWide`. Restating them in a CSV creates a second source of truth for exactly the thing `SECURITY.md` argues from. Half a bundle would publish an install path nobody tests.

## Community posts — drafted, unposted

`docs/community-posts.md` has five: r/Ubiquiti, r/homelab, r/selfhosted, the Ubiquiti forum, a Show HN. Distinct framings — what it can observe from their gear, the power-cut story, and state-not-events plus arbitration. Every draft carries the two documented uncertainties, because a post that dropped them would be the one piece of writing here that oversells the project. **Nothing has been posted anywhere**, and the file records each venue's self-promotion rule.

## What needs a human

Listed in full at the end of `docs/distribution.md`. The two that matter:

- The GitHub **repository description** says "turns UniFi *events* into infrastructure actions", which contradicts the design the README opens with, and it is the line that appears in search results and in the generated awesome-homelab table. It is a repository setting, not a file.
- The `Documentation` link points at `reactor.robbeverhelst.com`, which does not exist yet (#74). It is there because the record should be right the day the site lands and this metadata only reaches Artifact Hub on the next release. Nothing else in the repository links to it. If the site is not up when the next tag is cut, drop those two lines.

Also worth confirming: `artifacthub-repo.yml` uses this project's commit-author address as the owner, because the ownership claim is refused unless it matches the Artifact Hub sign-in email. Change it there if a different account will be used.

## Checks

`make test` (no manifest drift), `make lint` (0 issues), `go test ./test/chart/...` and `helm lint` all pass. Rebased onto `main` after #73 merged.