### PR TITLE
docs: point analytics at the real Umami website

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -35,7 +35,7 @@ export default defineConfig({
           tag: 'script',
           attrs: {
             src: 'https://analytics.robbeverhelst.be/script.js',
-            'data-website-id': 'REPLACE-ME-UMAMI-WEBSITE-ID',
+            'data-website-id': '9da009e0-9ebf-4a7d-8648-07235ea45669',
             defer: true,
           },
         },


### PR DESCRIPTION
One line. `docs/astro.config.mjs` shipped with `REPLACE-ME-UMAMI-WEBSITE-ID` because the Umami site did not exist when #81 landed; it does now.

The website id is a public client identifier — it is embedded in the page and visible to every visitor — so it belongs in the repo rather than in a secret. That matches how `routess` wires the same analytics.

Site: https://analytics.robbeverhelst.be — `reactor.robbeverhelst.com` is now reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated analytics configuration with the correct website identifier, enabling accurate website usage tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->