### PR TITLE
docs: five task-shaped guides, written to how people actually search

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -50,6 +50,35 @@ export default defineConfig({
           ],
         },
         {
+          // Task-shaped, and ordered by how many people arrive looking for
+          // each one rather than by how the features are grouped. A guide is
+          // titled with the sentence somebody typed into a search box, which
+          // is why none of these labels matches a section name above.
+          label: 'Guides',
+          items: [
+            {
+              label: 'Shut down Kubernetes when the UPS is on battery',
+              slug: 'guides/shut-down-kubernetes-when-the-ups-is-on-battery',
+            },
+            {
+              label: 'Pause downloads on a metered connection',
+              slug: 'guides/pause-downloads-on-a-metered-connection',
+            },
+            {
+              label: 'Get notified when the WAN fails over',
+              slug: 'guides/get-notified-when-the-wan-fails-over',
+            },
+            {
+              label: 'Suspend CronJobs during an outage',
+              slug: 'guides/suspend-cronjobs-during-an-outage',
+            },
+            {
+              label: 'Run alongside an HPA',
+              slug: 'guides/run-alongside-an-hpa',
+            },
+          ],
+        },
+        {
           label: 'Concepts',
           items: [
             { label: 'State, not events', slug: 'concepts/state-not-events' },

--- a/docs/src/content/docs/guides/get-notified-when-the-wan-fails-over.md
+++ b/docs/src/content/docs/guides/get-notified-when-the-wan-fails-over.md
@@ -1,0 +1,282 @@
+---
+title: "Get a notification when your WAN fails over"
+description: "Send a push to ntfy, Discord or Slack from Kubernetes the moment your UniFi gateway switches uplinks — and another when it comes back. The allowlist and Secret it needs first."
+---
+
+Your WAN fails over to the 5G backup at 03:00 and nothing tells you. You find
+out on Thursday, from the bill.
+
+This is the smallest useful thing Reactor does, and the one that requires you to
+configure something: two install-level decisions, one Secret, one Automation.
+
+## What this assumes
+
+- Reactor is installed and `Ready` — [Install](/start/install/).
+- You have somewhere to send a message: an [ntfy](https://ntfy.sh) topic, a
+  Discord webhook, or a Slack incoming webhook.
+- You can run `helm upgrade` against the release, because the allowlist is a
+  chart value.
+
+## 1. Allow the destination
+
+**Outbound actions are refused by default.** The allowlist is install
+configuration and deliberately not an Automation field:
+
+```yaml
+# values.yaml
+actions:
+  allowedDestinations:
+    - https://ntfy.example.com
+    - https://discord.com
+```
+
+```sh
+helm upgrade reactor oci://ghcr.io/robbeverhelst/charts/reactor \
+  --namespace reactor-system --reuse-values \
+  --set 'actions.allowedDestinations={https://ntfy.example.com,https://discord.com}'
+```
+
+Worth understanding rather than pasting: anyone who can create an `Automation`
+in their own namespace can ask Reactor to make a request, and that request leaves
+from inside the cluster with the **operator's** network position rather than
+theirs — reaching `ClusterIP` Services, your gateway, and whatever else this pod
+can route to. Which destinations that is worth is a cluster decision, so it
+lives here.
+
+Entries are matched on scheme, host and port only:
+
+- A path is rejected — `https://ntfy.example.com/alerts` is not a valid entry.
+- No port means the scheme's default, so a destination on `:8080` has to be
+  written out: `http://hooks.example.com:8080`.
+- One leading wildcard label is allowed: `https://*.example.com`.
+- `*` on its own allows any host, and is an explicit choice rather than a
+  default.
+
+Two things are refused whatever you list: the loopback interface, and link-local
+addresses (`169.254.0.0/16`, `fe80::/10`) where cloud instance metadata services
+live. Redirects are never followed. Private ranges are **not** blocked — an ntfy
+box on the LAN is a legitimate destination, which is exactly why the list is
+default-deny.
+
+Setting this adds one RBAC rule — `get` on `secrets`, in whatever scope the
+manager already has. Leave the list empty and the permission is not granted at
+all.
+
+## 2. Put the destination in a Secret
+
+For every transport shipped, the webhook URL **is** the credential — so a
+notification has no `url` field at all. It comes from a Secret in the
+Automation's own namespace:
+
+```sh
+kubectl -n media create secret generic ntfy-credentials \
+  --from-literal=url=https://ntfy.example.com/your-topic \
+  --from-literal=authorization="Bearer tk_example"
+```
+
+| Secret key | Used for |
+| --- | --- |
+| `url` | the destination. Required |
+| `authorization` | sent as the `Authorization` header. Optional |
+| `header-<Name>` | sent as the header `<Name>`, e.g. `header-X-Api-Key`. Optional |
+
+There is deliberately no namespace field on a `secretRef`: an Automation may
+only ever read credentials from the namespace it lives in, because anyone who can
+create an Automation there can already create a Secret there. Nothing from the
+Secret is ever logged, put in status, or attached to an Event.
+
+For Discord or Slack the shape is identical — the incoming webhook URL goes in
+`url`, and the action type changes:
+
+```sh
+kubectl -n media create secret generic discord-credentials \
+  --from-literal=url=https://discord.com/api/webhooks/000000/xxxxxxxx
+```
+
+## 3. The Automation
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: notify-on-wan-failover
+  namespace: media
+spec:
+  when:
+    provider: unifi
+    state:
+      wan: backup
+
+  actions:
+    - type: notification.ntfy
+      notification:
+        secretRef: { name: ntfy-credentials }
+        title: "WAN failed over"
+        message: "{{ .Key }} moved from {{ .From }} to {{ .To }} at {{ .Time }}. Uplink is now {{ .State.wan }}."
+
+  onExit:
+    - type: notification.ntfy
+      notification:
+        secretRef: { name: ntfy-credentials }
+        title: "WAN recovered"
+        message: "{{ .Key }} back to {{ .To }} at {{ .Time }}"
+```
+
+Transports shipped: `notification.ntfy`, `notification.discord`,
+`notification.slack`. Telegram is not among them — its bot token lives in the
+URL path alongside a separate chat id, which does not fit the "the URL is the
+credential" shape the others share.
+
+Notifications are **edge** actions: they fire on this Automation's own
+transitions, own no target and arbitrate with nothing. An edge action in an
+`onExit` block still fires on this Automation's own edge, which is why the
+recovery message above works.
+
+### What you can put in a message
+
+`title` and `message` are Go [`text/template`](https://pkg.go.dev/text/template)
+— the standard library, no Sprig:
+
+| | |
+| --- | --- |
+| `.Automation` `.Namespace` `.Name` | who reacted |
+| `.Provider` `.Matching` | which provider, and which direction the edge went |
+| `.Key` `.From` `.To` | the transition that flipped `matching` |
+| `.State` | every key this Automation watches, e.g. `{{ .State.wan }}` |
+| `.Time` | when the transition was observed, RFC 3339 |
+| `json` | quotes a value for embedding in JSON: `{"wan": {{ json .To }}}` |
+
+**`.State` carries the keys this Automation matches on, and nothing else.** It is
+the observed value of every key in `spec.when.state`, so an Automation triggered
+on `wan` alone cannot put `{{ .State.isp }}` in its message — a key that is not
+there is an **error** rather than the words `no value`, and the message does not
+go out. That is deliberate: a typo fails loudly at the moment it would have been
+sent rather than delivering a sentence with a hole in it. If you want the carrier
+in the message, match on it as well.
+
+The rule has one hole worth knowing: `{{ .State.wan }}` is checked, but a dotted
+key needs the `index` builtin — `{{ index .State "ups.battery" }}` — and that
+one returns an empty string for a missing key instead of failing.
+
+Only the message is templated. The URL and the headers are literal on purpose:
+the destination is what the allowlist decided, and letting observed state edit
+it would hand back exactly the choice the allowlist exists to take away.
+
+## What you will see when it fires
+
+```sh
+kubectl -n media describe automation notify-on-wan-failover
+```
+```text
+Type    Reason          Age   From        Message
+----    ------          ----  ----        -------
+Normal  StateEntered    31s   automation  wan moved from "primary" to "backup", so the condition started holding
+Normal  EdgeActionSent  31s   automation  notification.ntfy delivered to https://ntfy.example.com:443 after 1 attempt(s)
+```
+
+```sh
+kubectl -n media get automation notify-on-wan-failover -o jsonpath='{.status.edgeActions}'
+# [{"type":"notification.ntfy","status":"Success","attempts":1,
+#   "destination":"https://ntfy.example.com:443","time":"2026-08-15T03:00:12Z"}]
+```
+
+`destination` is the **origin only** — scheme, host and port. The path and query
+are left out everywhere, because for these transports that is where the
+credential is.
+
+`Applied` reports `NoTargets`: "this automation only has edge actions, so it
+holds no target". That is `Applied=True` and healthy.
+
+### When it fails
+
+```text
+Warning  EdgeActionFailed  8s  automation  notification.ntfy was not delivered: https://ntfy.example.com:443: responded 502 Bad Gateway
+```
+
+**A failed notification never fails the Automation.** If the same Automation had
+also scaled something, the scale is the thing that had to happen and the
+notification is the report of it — so the failure is recorded in
+`status.edgeActions`, raised as a Warning Event, and `Ready` stays whatever the
+target reconciliation made it.
+
+The delivery rules, stated plainly because they are choices:
+
+- **At most once per transition.** The transition is written to status *before*
+  anything is sent, so a failed or conflicting status write cannot send the same
+  message twice. Nothing is re-sent on a later reconcile — that reconcile has no
+  new transition, so it would be a duplicate rather than a retry.
+- **Retries happen inside the one reconcile.** A notification is a publish, so
+  it is tried three times against a timeout, a 5xx or a 429.
+- **A desired-state action goes first.** A transition whose target could not be
+  written is not committed, so nothing announces a workload was paused while it
+  is still running.
+- **A suspended Automation sends nothing**, the same way a deleted one does not.
+- **Nothing fires on deletion.** A "WAN recovered" message caused by a
+  `kubectl delete` would be a lie.
+
+If the destination is not on the allowlist, nothing leaves the cluster and the
+reason names the fix:
+
+```sh
+kubectl -n media get automation notify-on-wan-failover -o jsonpath='{.status.edgeActions[0].reason}'
+# outbound actions are disabled on this install: no destination is allowed, so https://ntfy.example.com:443 was refused
+```
+
+## What this does not cover
+
+- **No reminders.** Events fire on edges, not on states: you get one message when
+  the condition starts holding and one when it stops, not one an hour while the
+  outage lasts.
+- **No Telegram**, for the reason above. A bot API call is expressible as
+  [`http.request`](/actions/notifications-and-http/#httprequest) if you want it.
+- **No response handling.** The outbound client drains and discards every
+  response body, so nothing a destination replies can reach an Automation beyond
+  the status code.
+- **No delivery guarantee.** Three attempts inside one reconcile, then it is a
+  Warning and a missed message. If you need alerting you can rely on, alert on
+  [`reactor_state_info` in Prometheus](/operations/metrics-and-alerts/) instead —
+  Reactor exports the same state as metrics, and Alertmanager is built for the
+  job a notification action is not.
+- **It does not tell you the link is *bad*.** `wan: backup` is a failover.
+  `internet: down` and `wan.quality: degraded` are two other questions —
+  [WAN and internet state keys](/state-keys/wan-and-internet/).
+
+## Worth knowing about the trigger
+
+`wan` is the one state key whose mapping has **never been confirmed against a
+real failover** ([#34](https://github.com/robbeverhelst/unifi-reactor/issues/34)):
+it is derived from which port reports `is_uplink`, inferred from a capture in
+which only one uplink was live. A notification is the safest possible place to
+find that out — it writes nothing, and a message that never arrives costs you an
+evening rather than a workload.
+
+Which makes this Automation a good first one to install even if you plan to
+scale things later: it tells you whether `wan` moves on your hardware before
+anything depends on it.
+
+Reactor already keeps a second opinion on this. `isp` — the carrier behind the
+live uplink — comes from a different endpoint, and any disagreement between the
+two is
+[logged rather than resolved](/troubleshooting/state-keys/#10-wan-and-isp-disagree-about-a-failover).
+To get that carrier into the message you have to match on it, since `.State`
+only carries the keys in `spec.when.state`:
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      wan: backup
+      isp: your-carrier-slug   # now {{ .State.isp }} renders
+```
+
+That is a narrower condition, not just a richer message — both keys have to
+match. Look your slug up first with
+`kubectl -n reactor-system logs deploy/reactor | grep 'key=isp'`.
+
+## Where to go next
+
+- [Notifications and HTTP requests](/actions/notifications-and-http/) — `http.request`, headers, bodies and the full threat model.
+- [Home Assistant and qBittorrent actions](/actions/external-services/) — calling a service instead of sending a message.
+- [Events and status](/operations/events/) — reading the whole incident with `kubectl describe`.
+- [Automation API reference](/reference/automation/) — every field of `notification` and `request`.
+- [Chart values reference](/reference/values/) — `actions.allowedDestinations` and what it grants.

--- a/docs/src/content/docs/guides/pause-downloads-on-a-metered-connection.md
+++ b/docs/src/content/docs/guides/pause-downloads-on-a-metered-connection.md
@@ -1,0 +1,260 @@
+---
+title: "Pause downloads when Kubernetes falls back to a metered connection"
+description: "Your WAN fails over to 5G and qBittorrent keeps saturating it. Two ways to stop that from Kubernetes — scaling the Deployment, or pausing the torrents — and which one to actually pick."
+---
+
+The uplink drops, the gateway fails over to the 5G backup, and the download
+client in your cluster carries on at 40Mbit against a metered SIM. Nothing in
+Kubernetes knows the connection changed underneath it.
+
+Reactor knows, because the console does. There are two ways to react and they
+are not equally good — but the better one is not the one you should always
+reach for, and the reason is worth two minutes.
+
+## What this assumes
+
+- Reactor is installed and `Ready` — [Install](/start/install/).
+- Your gateway has a second uplink and reports `wan` — a console with one WAN
+  publishes the key but it never moves off `primary`.
+- qBittorrent runs in the cluster as a `Deployment`.
+
+## The crude answer: scale the Deployment to zero
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: pause-downloads-on-backup-wan
+  namespace: media
+spec:
+  when:
+    provider: unifi
+    state:
+      wan: backup
+
+  actions:
+    - type: kubernetes.scale
+      target: { kind: Deployment, name: qbittorrent }
+      replicas: 0
+```
+
+That is the whole thing. No Secret, no allowlist, no credential, no outbound
+request — Reactor writes to the API server it is already authenticated to. With
+`onExit` omitted the replica count is restored from
+`reactor.robbeverhelst.com/baseline-replicas`, recorded on the Deployment before
+the first claim.
+
+It is also blunt: it kills the container, drops every in-progress peer
+connection, and relies on qBittorrent recovering its session from disk when it
+comes back.
+
+## The better answer: pause the torrents
+
+Pausing is what you actually wanted. Traffic stops, session state is preserved,
+resume is instant:
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: pause-torrents-on-backup-wan
+  namespace: media
+spec:
+  when:
+    provider: unifi
+    state:
+      wan: backup
+
+  actions:
+    - type: qbittorrent.pause
+      qbittorrent:
+        url: http://qbittorrent.media.svc.cluster.local:8080
+        secretRef: { name: qbittorrent-credentials }
+
+  onExit:
+    - type: qbittorrent.resume
+      qbittorrent:
+        url: http://qbittorrent.media.svc.cluster.local:8080
+        secretRef: { name: qbittorrent-credentials }
+```
+
+It needs two things set up first, and both are install-level decisions rather
+than Automation ones.
+
+**1. Allow the destination.** Outbound actions are refused by default, including
+to a Service inside your own cluster:
+
+```yaml
+# values.yaml
+actions:
+  allowedDestinations:
+    - http://qbittorrent.media.svc.cluster.local:8080
+```
+
+Entries are matched on scheme, host and **port** only — a path is rejected, and
+a non-default port has to be written out, as above. This is a chart value and
+not an Automation field on purpose: anyone who can create an Automation in their
+own namespace can ask Reactor to make a request, and it leaves with the
+operator's network position rather than theirs.
+
+**2. Put the credentials in a Secret**, in the Automation's own namespace:
+
+```sh
+kubectl -n media create secret generic qbittorrent-credentials \
+  --from-literal=username=reactor \
+  --from-literal=password='...'
+```
+
+Both are required. qBittorrent issues a session cookie rather than accepting a
+static token, and that login round trip is the entire reason this is a named
+action instead of an `http.request`. Reactor logs in inside the one action,
+holds the cookie in a local variable, and logs out again — there is no session
+cache.
+
+## So which one
+
+The pause is better at the job. The scale is better at composing with everything
+else you will write, and that is usually what decides it.
+
+| | `kubernetes.scale` | `qbittorrent.pause` |
+| --- | --- | --- |
+| Arbitrated across Automations | **yes** | no |
+| Baseline recorded, restored on release | **yes** | no |
+| Handed back when Reactor is uninstalled | **yes**, by the pre-delete sweep | no |
+| Needs an allowlist entry and a Secret | no | yes |
+| Keeps session state and peer connections | no | **yes** |
+
+**Arbitration is the reason to keep the crude one.** Downloads genuinely should
+stop for a metered uplink *and* for a power cut, and those are two Automations
+with unrelated conditions. Point both at the same Deployment and nothing has to
+be coordinated: the workload sits at the most restrictive level anyone asked for,
+and comes back only when **neither** wants it down. The one that lost says so:
+
+```sh
+kubectl -n media get automation pause-downloads-on-backup-wan -o jsonpath='{.status.targets[0]}'
+# {"ref":"Deployment/media/qbittorrent","desired":1,"effective":0,
+#  "deferredBy":["media/shed-load-on-battery"]}
+```
+
+Two `qbittorrent.pause` Automations do not do that. Each fires on its own
+transition and **whichever resumes first resumes everything** — including
+torrents you had paused by hand before Reactor ever ran, because nothing
+recorded which those were.
+
+That is not an oversight, it is a stated limit. What makes arbitration possible
+is not the fold: it is that the target is a Kubernetes object, so the value it
+held before Reactor claimed it can be written as an annotation *on that object*,
+where it outlives the Automation and Reactor itself. A qBittorrent instance
+reached over HTTP has nowhere to put one. [The two shapes an action
+has](/concepts/levels-and-occurrences/) is the general form of this;
+[Home Assistant and qBittorrent actions](/actions/external-services/) has the
+three alternatives that were considered and rejected.
+
+**You can have both.** Pause on the way in for the graceful stop, and let a
+`kubernetes.scale` claim the Deployment for the cases where the fold matters —
+the scale still arbitrates normally, because a Deployment is still a Deployment.
+
+## Matching the carrier instead of the port
+
+`wan: backup` says which uplink is selected. If what you actually mean is "we
+are on the metered SIM", `isp` says who is carrying the traffic:
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      isp: your-carrier-slug
+```
+
+`isp` is the one key whose values are not a closed set — it is the carrier your
+console geolocated your public address to, lowercased with everything
+non-alphanumeric turned into a hyphen. Look yours up before matching on it:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'key=isp'
+# INFO state transition provider=unifi key=isp from= to=telenet
+```
+
+It is debounced at 2 samples, because a geolocation lookup on a freshly assigned
+address can report `unknown` for a poll or two — which is exactly during a
+failover.
+
+## What you will see when it fires
+
+```sh
+kubectl -n media describe automation pause-torrents-on-backup-wan
+```
+```text
+Type    Reason          Age   From        Message
+----    ------          ----  ----        -------
+Normal  StateEntered    12s   automation  wan moved from "primary" to "backup", so the condition started holding
+Normal  EdgeActionSent  12s   automation  qbittorrent.pause applied at http://qbittorrent.media.svc.cluster.local:8080 after 1 attempt(s)
+```
+
+```sh
+kubectl -n media get automation pause-torrents-on-backup-wan -o jsonpath='{.status.edgeActions}'
+# [{"type":"qbittorrent.pause","status":"Success","attempts":1,
+#   "destination":"http://qbittorrent.media.svc.cluster.local:8080","time":"..."}]
+```
+
+`Applied` reports `NoTargets` — "this automation only has edge actions, so it
+holds no target" — and that is `Applied=True`, not a fault. The scaling version
+instead reports `TargetHeld`, a `status.targets[]` entry, and the annotations on
+the Deployment.
+
+If the destination is not allowed, nothing is sent and the reason says exactly
+what to add:
+
+```sh
+kubectl -n media get automation pause-torrents-on-backup-wan -o jsonpath='{.status.edgeActions[0].reason}'
+# outbound actions are disabled on this install: no destination is allowed, so
+# http://qbittorrent.media.svc.cluster.local:8080 was refused
+```
+
+## What this does not cover
+
+- **It does not throttle.** There is no rate limit action; downloads are either
+  running or not.
+- **It is all torrents or none.** No category or tag filter, because narrowing
+  would mean reading a response body back into Reactor, and the outbound client
+  drains and discards every one — a response can echo a request back,
+  credentials included.
+- **It does not know your data cap.** `wan: backup` is a link state, not a
+  quota. Reactor has no meter.
+- **It does not cover other clients.** SABnzbd, a sync daemon, anything with an
+  HTTP API: use [`http.request`](/actions/notifications-and-http/#httprequest),
+  or scale it.
+- **A resume does not un-pause selectively.** See above — there is no baseline.
+
+## One honesty note about `wan`
+
+**A genuine WAN failover has never been observed on real hardware**
+([#34](https://github.com/robbeverhelst/unifi-reactor/issues/34)). `wan` is
+derived from which port reports `is_uplink`, inferred from a single capture in
+which only one uplink was live, so whether that field follows the traffic or
+merely marks the port configured as primary is unconfirmed. The provider is
+exercised against five different hypotheses about what a failover looks like and
+reports something defensible under all of them — which is not the same as
+knowing.
+
+What that means for this guide, practically:
+
+- Treat `wan` as less battle-tested than `ups`, and watch for the
+  [disagreement warnings](/troubleshooting/state-keys/#10-wan-and-isp-disagree-about-a-failover)
+  Reactor raises when `wan` and `isp` do not move together.
+- `internet: down` answers a different question — whether the outside world is
+  reachable at all — and comes from the console's own `www` health subsystem
+  rather than from `is_uplink`. It is debounced at 3 samples, so about 90s at
+  the default poll before an outage or a recovery is believed. `wan` is
+  debounced at 1 and reacts on the first observation.
+- If you have a gateway with two working uplinks, the [capture
+  runbook](https://github.com/robbeverhelst/unifi-reactor/blob/main/testdata/unifi/README.md#capturing-a-real-failover)
+  is fifteen minutes that would close this for everyone.
+
+## Where to go next
+
+- [WAN and internet state keys](/state-keys/wan-and-internet/) — `wan`, `internet` and `wan.quality` are three different questions.
+- [Home Assistant and qBittorrent actions](/actions/external-services/) — the full reasoning behind the edge-action shape.
+- [Arbitration](/concepts/arbitration/) — what a shared workload does.
+- [Automation API reference](/reference/automation/) — every field, generated from the types.
+- [Chart values reference](/reference/values/) — `actions.allowedDestinations` and the debounce table.

--- a/docs/src/content/docs/guides/run-alongside-an-hpa.md
+++ b/docs/src/content/docs/guides/run-alongside-an-hpa.md
@@ -1,0 +1,211 @@
+---
+title: "Scaling down a Deployment that has a HorizontalPodAutoscaler"
+description: "Reactor scales to 0 to shed load, the HPA scales it back from metrics, and the Deployment oscillates forever. What Reactor does about it, and what to write instead."
+---
+
+You add a power-cut Automation that scales `api` to zero. `api` has a
+HorizontalPodAutoscaler. Fifteen seconds later it is back at three replicas, and
+fifteen seconds after that it is at zero again, and this continues until one of
+you is removed.
+
+Nobody is malfunctioning. Both controllers write `spec.replicas` through the same
+`/scale` subresource, both believe they own it, and neither has any way to see
+the other. This guide is what Reactor does about that and what to write instead.
+
+## Why it cannot be arbitrated away
+
+Reactor's answer to two Automations wanting the same workload is
+[arbitration](/concepts/arbitration/): every claim on a target is folded to the
+most restrictive one, so two Automations pausing a workload for unrelated reasons
+resolve to a single claim. That works because Reactor can see every claimant —
+they are all `Automation` objects it already lists.
+
+An HPA is not one. There is nothing to fold it into, so writing anyway is a fight
+rather than a resolution, and it is a fight that got *louder* in v1.0: claims are
+re-asserted on every reconcile rather than once per transition. A reconcile
+happens at least every 15 seconds. Same disagreement, forever, on a timer.
+
+## Turn detection on
+
+```sh
+helm upgrade reactor oci://ghcr.io/robbeverhelst/charts/reactor \
+  --namespace reactor-system --reuse-values --set safety.detectHPA=true
+```
+
+It is **off by default** — it changes what an install already in that fight does,
+and it costs a permission nothing else needs — but there is no Automation it
+makes worse, so turning it on is the recommendation.
+
+With it on, Reactor lists the HorizontalPodAutoscalers in a target's namespace
+before claiming it. If one names the target, it writes **nothing**: not the
+replica count, and not the baseline annotation either, because a baseline
+captured from a value the HPA is actively changing would restore a meaningless
+number later.
+
+**The permission this grants** is `list` on
+`autoscaling/horizontalpodautoscalers`, in whatever scope the manager already
+has, and it is rendered only when the value is set. That is a read of an
+autoscaling *policy* — including metric thresholds and replica bounds. It grants
+no write to an HPA, so Reactor cannot suspend one to win, and nothing over the
+workloads an HPA manages. There is no `get` (a namespace is listed, not a name
+looked up) and no `watch` (HPAs are read uncached, so nothing starts an
+informer).
+
+If the permission is missing while detection is on, a claim **fails** rather than
+proceeding blind, and the error names the fix.
+
+## What a declined target looks like
+
+Take the Automation that started this:
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: shed-load-on-battery
+  namespace: media
+spec:
+  when:
+    provider: unifi
+    state:
+      ups: on-battery
+
+  actions:
+    - type: kubernetes.scale
+      target: { kind: Deployment, name: api }       # an HPA drives this one
+      replicas: 0
+    - type: kubernetes.scale
+      target: { kind: Deployment, name: qbittorrent }
+      replicas: 0
+```
+
+```sh
+kubectl -n media get automation shed-load-on-battery -o jsonpath='{.status.targets[0]}'
+# {"ref":"Deployment/media/api","desired":0,
+#  "managedBy":"HorizontalPodAutoscaler/media/api-hpa"}
+```
+
+```sh
+kubectl -n media describe automation shed-load-on-battery
+```
+```text
+Type     Reason              Age   From        Message
+----     ------              ----  ----        -------
+Normal   StateEntered        20s   automation  ups moved from "online" to "on-battery", so the condition started holding
+Warning  TargetManagedByHPA  20s   automation  not claiming Deployment/media/api is driven by HorizontalPodAutoscaler/media/api-hpa: arbitration cannot resolve a claimant it cannot see, and writing anyway would oscillate rather than win
+Normal   TargetHeld          20s   automation  Deployment/media/qbittorrent held at 0 replicas
+```
+
+Four things to read out of that:
+
+- **`Ready` stays `True`.** The Automation is correctly configured; it simply
+  cannot act on that one target. `Applied` is `False` with reason
+  `TargetManagedByHPA`.
+- **Its other targets are unaffected.** `qbittorrent` was claimed normally in
+  the same reconcile.
+- **It is a `Warning`, unlike being outvoted by a peer.** Losing an arbitration
+  is the design working and is reported `Normal`. Being unable to arbitrate at
+  all is an Automation that cannot do its job, and no amount of waiting fixes
+  it — somebody has to decide which controller owns the workload.
+- **It is counted**, as `reactor_arbitrations_total{outcome="declined"}`, so it
+  is alertable rather than only discoverable by describing a resource.
+
+### A target Reactor was already holding
+
+If the HPA appears *over* a workload Reactor is already holding at zero, going
+quiet would strand it: an HPA does not scale a workload up from zero, so neither
+controller would ever move it. So Reactor hands it back to its recorded baseline
+first, and then lets go:
+
+```text
+Warning  TargetManagedByHPA  3s  automation  Deployment/media/api is now driven by HorizontalPodAutoscaler/media/api-hpa; handed it back at 3 replicas and stopped claiming it
+```
+
+## What to do instead
+
+Detection stops the oscillation. It does not shed the load you wanted shed, and
+nothing Reactor could do would — so pick one of these deliberately.
+
+**1. Shed load somewhere nothing autoscales.** Usually the best answer, because
+the workloads with an HPA are typically the ones that should survive an outage
+anyway. Nothing autoscales a CronJob or a Node:
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: shed-load-on-battery
+  namespace: media
+spec:
+  when:
+    provider: unifi
+    state:
+      ups: on-battery
+
+  actions:
+    - type: kubernetes.cronjob.suspend
+      target: { kind: CronJob, name: nightly-reindex }
+    - type: kubernetes.scale
+      target: { kind: Deployment, name: qbittorrent }
+      replicas: 0
+    - type: notification.ntfy
+      notification:
+        secretRef: { name: ntfy-credentials }
+        title: "On battery"
+        message: "{{ .Key }} is {{ .To }}. api is HPA-driven and was not touched — scale it by hand if this lasts."
+```
+
+That is a complete, working replacement: a
+[suspended CronJob](/guides/suspend-cronjobs-during-an-outage/), a scaled
+workload nothing else claims, and a
+[notification](/guides/get-notified-when-the-wan-fails-over/) telling a human
+about the part Reactor deliberately would not do. The notification needs
+`actions.allowedDestinations` and a Secret first — drop that action if you have
+not set those up.
+
+**2. Let the HPA do it.** During a real outage the traffic that justified those
+replicas usually goes away too, and the HPA will scale down on its own metrics.
+That is not shedding on *your* schedule, but it is not nothing.
+
+**3. Remove or suspend the HPA for the workloads that must shed.** Reactor will
+not do this for you at any setting. Suspending an HPA means patching somebody's
+`minReplicas`/`maxReplicas`, which needs **write** access to an autoscaling
+policy — a much larger permission and a separate decision, taken by a person
+rather than by an operator during an incident.
+
+**4. Cordon instead of scaling.** [`kubernetes.cordon`](/actions/kubernetes/#closing-a-node-to-new-work)
+closes a node to new work, and no autoscaler contests `spec.unschedulable`. It
+needs `rbac.allowNodeActions`, and it moves nothing already running.
+
+## There is deliberately no `force`
+
+Overriding would mean writing `spec.replicas` harder, which *is* the
+oscillation — not a way out of it. The only thing that actually resolves the
+disagreement is deciding which controller owns the field, and that decision is
+not Reactor's to take.
+
+## What detection does not cover
+
+- **Only HorizontalPodAutoscalers.** KEDA, a GitOps controller correcting drift,
+  and a cron job running `kubectl scale` own `spec.replicas` just as hard, and
+  none of them is discoverable through a stable API. **An empty `managedBy` means
+  nothing was found, not that the field is uncontested.**
+- **Only scalable kinds.** A CronJob's `spec.suspend` and a Node's
+  `spec.unschedulable` are not fields an HPA writes, so detection does not apply
+  to them and does not need to.
+- **The HPA's version is not compared, its group is.** A `scaleTargetRef` written
+  years ago against `apps/v1beta2` still drives the same Deployment today, and
+  reading a version mismatch as "not managed" would put Reactor straight back in
+  the fight.
+- **It does not suspend, pause or edit the HPA.** No write permission exists for
+  that, under any setting.
+- **It does not tell the HPA anything.** The two controllers remain unaware of
+  each other; one of them has simply stopped writing.
+
+## Where to go next
+
+- [Arbitration](/concepts/arbitration/) — the model this is the exception to.
+- [Kubernetes actions](/actions/kubernetes/) — the actions nothing else contests.
+- [Events and condition reasons](/reference/events/) — every reason `Ready` and `Applied` can carry.
+- [Automation API reference](/reference/automation/) — `status.targets[].managedBy` and the rest of status.
+- [Chart values reference](/reference/values/) — `safety.detectHPA` and the RBAC it renders.

--- a/docs/src/content/docs/guides/shut-down-kubernetes-when-the-ups-is-on-battery.md
+++ b/docs/src/content/docs/guides/shut-down-kubernetes-when-the-ups-is-on-battery.md
@@ -1,0 +1,284 @@
+---
+title: "Shut down Kubernetes when the UPS goes on battery"
+description: "A power cut buys you minutes. Three Automations that shed load the moment a UniFi UPS goes on battery, escalate as its remaining runtime drops, and close a node before it runs out."
+---
+
+The power goes at 02:40. The UPS carries the rack for eleven minutes. Nothing in
+the cluster knows, so all of it keeps running at full draw until the battery
+ends and every node loses power mid-write.
+
+Reactor sees the UPS because your UniFi console already does. This guide builds
+the escalation ladder: shed the cheap load immediately, close a node when the
+runtime gets short, and stop the things that need a clean stop when it gets
+critical.
+
+## What this assumes
+
+- Reactor is installed and `Ready` — [Install](/start/install/).
+- **A UniFi UPS is adopted by the same console Reactor polls.** The `ups`,
+  `ups.battery`, `ups.runtime` and `ups.load` keys do not exist otherwise. An
+  Automation matching a key nothing publishes holds its last known matching —
+  `false`, for one you just created — and reports `Ready=False` with
+  `StateKeyUnavailable` naming the key, so it fails visibly rather than
+  silently. A third-party UPS over NUT is a different provider and is not this
+  one.
+- Your workloads are `Deployment`s or `StatefulSet`s in a namespace Reactor can
+  reach. Cross-namespace targets need `rbac.clusterWide` (the default).
+
+Check the keys are actually there before writing anything:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep 'key=ups'
+# INFO state transition provider=unifi key=ups from= to=online
+# INFO state transition provider=unifi key=ups.runtime from= to=ample
+```
+
+## 1. Shed the cheap load the moment mains goes
+
+The first rung costs nothing to get wrong: workloads that can disappear for the
+length of an outage without anyone minding.
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: shed-load-on-battery
+  namespace: media
+spec:
+  when:
+    provider: unifi
+    state:
+      ups: on-battery
+
+  actions:
+    - type: kubernetes.scale
+      target: { kind: Deployment, name: qbittorrent }
+      replicas: 0
+    - type: kubernetes.scale
+      target: { kind: Deployment, name: plex }
+      replicas: 0
+```
+
+There is no `onExit`, and that is the point. With it omitted the reversal policy
+is `Baseline`: Reactor records what each workload was set to before it first
+claimed it — in the annotation
+`reactor.robbeverhelst.com/baseline-replicas`, on the workload itself — and
+restores exactly that when mains comes back. You do not have to remember that
+Plex runs at 1 and something else runs at 3, and the annotation outlives both
+the Automation and Reactor. See
+[Reversal and baselines](/concepts/reversal-and-baselines/).
+
+`ups` is debounced at 1 sample, so this fires on the first observation that says
+`on-battery` — within one `pollInterval`, 30s by default. A UPS switching to
+battery is a switch position, not a measurement, and it does not flap.
+
+## 2. Escalate on remaining runtime, not on charge
+
+`ups.battery` is the obvious escalation key and the wrong one. It reports charge
+against a threshold, and charge ignores load: 30% at 300W and 30% at 900W are
+the same value and completely different situations. `ups.runtime` is the UPS's
+own estimate of how long it can carry **what is plugged into it right now**,
+bucketed to `ample` / `short` / `critical` against thresholds you set.
+
+That is what a shutdown should match on, and it gets better as the ladder works:
+every workload rung 1 scaled down raises the runtime the UPS reports for the
+rest.
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: stop-database-on-critical-runtime
+  namespace: data
+spec:
+  when:
+    provider: unifi
+    state:
+      ups: on-battery
+      ups.runtime: critical
+
+  actions:
+    - type: kubernetes.scale
+      target: { kind: StatefulSet, name: postgres }
+      replicas: 0
+
+  onExit:
+    - type: kubernetes.scale
+      target: { kind: StatefulSet, name: postgres }
+      replicas: 1
+```
+
+Both keys must match — every entry in a `state` block is an AND. Here `onExit`
+is written out rather than left to the baseline, because a database is the one
+workload where "whatever it was before" is worth stating explicitly instead of
+inferring.
+
+**Where the thresholds come from**, and why they are set together rather than
+one at a time:
+
+| Value | Default | What it does |
+| --- | --- | --- |
+| `unifi.ups.shortRuntimeSeconds` | `600` | at or below this, `ups.runtime` is `short` |
+| `unifi.ups.criticalRuntimeSeconds` | `180` | at or below this, `ups.runtime` is `critical` |
+| `unifi.pollInterval` | `30s` | how often the console is polled |
+| `unifi.debounce.keys[ups.runtime]` | `2` | consecutive samples before a change is believed |
+
+Two samples at a 30s poll is 60 seconds between the UPS saying `critical` and
+Reactor believing it. Against the default 180s threshold that leaves two minutes
+to get the database down. Lower `criticalRuntimeSeconds` and that headroom goes
+with it. Every value is in the [chart values reference](/reference/values/).
+
+### Why two Automations rather than one escalating key
+
+Because a single enum that dropped from `on-battery` to `low-battery` would
+**leave** the matching state, and leaving a matching state runs the reversal —
+scaling your workloads back **up** in the middle of a power failure, at the
+worst possible moment.
+
+So `ups`, `ups.battery`, `ups.runtime` and `ups.load` are four independent axes,
+and escalation is expressed by matching more of them rather than by one key
+moving. The first Automation stays matched for the whole outage while the second
+comes and goes underneath it. [Power and UPS state keys](/state-keys/power-and-ups/)
+has the full argument.
+
+If two rungs ever claim the **same** workload, that is fine and needs no
+coordination: a shared target sits at the most restrictive level any Automation
+asked for and comes back only when none of them want it down. See
+[Arbitration](/concepts/arbitration/).
+
+## 3. Close a node before the battery ends
+
+The endgame of a power cut is a graceful shutdown, not a hard cut. Cordoning a
+worker on the failing UPS stops new pods landing there, so replacements come up
+on a node that is still on mains:
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: cordon-worker-on-short-runtime
+  namespace: reactor-system
+spec:
+  when:
+    provider: unifi
+    state:
+      ups: on-battery
+      ups.runtime: short
+
+  actions:
+    - type: kubernetes.cordon
+      target: { kind: Node, name: worker-03 }
+```
+
+A `Node` is cluster-scoped, so the target takes **no** `namespace` — the CRD
+rejects one at admission rather than looking somewhere that cannot succeed.
+
+Three things to know before adding this rung:
+
+- **It is only worth anything if some nodes are not on the failing UPS.** In a
+  homelab where the whole rack is on one UPS, cordoning buys nothing: there is
+  nowhere else for a pod to go.
+- **It needs a permission Reactor does not otherwise ask for.**
+  `--set rbac.allowNodeActions=true` creates a `ClusterRole` even in a
+  namespace-scoped install, and grants `get` and `patch` on nodes — and
+  Kubernetes cannot narrow `patch` to one field. Without it, the Automation
+  reports the node as unreachable and names the value to set. The plain manifest
+  bundle does not offer it at all.
+- **Cordoning moves nothing that is already running.** There is deliberately no
+  `kubernetes.drain`: an eviction cannot be un-evicted, so it has no level to
+  arbitrate and no reversal to declare, and in a three-node cluster the evicted
+  pods go `Pending` rather than anywhere useful. [Why there is no drain](/actions/kubernetes/#why-there-is-no-kubernetesdrain).
+
+Omitting `onExit` here restores the baseline, which includes **leaving a node
+cordoned that you had already cordoned by hand** — recorded in
+`reactor.robbeverhelst.com/baseline-unschedulable` before Reactor touched it.
+
+## What you will see when the power goes
+
+```sh
+kubectl -n media get automation
+# NAME                   PROVIDER   MATCHING   SUSPENDED   READY   AGE
+# shed-load-on-battery   unifi      true       false       True    6d
+```
+
+```sh
+kubectl -n media describe automation shed-load-on-battery
+```
+```text
+Type    Reason        Age   From        Message
+----    ------        ----  ----        -------
+Normal  StateEntered  42s   automation  ups moved from "online" to "on-battery", so the condition started holding
+Normal  TargetHeld    42s   automation  Deployment/media/qbittorrent held at 0 replicas
+Normal  TargetHeld    42s   automation  Deployment/media/plex held at 0 replicas
+```
+
+The workload itself says who is holding it down and what it was:
+
+```sh
+kubectl -n media get deploy qbittorrent -o jsonpath='{.metadata.annotations}'
+# {"reactor.robbeverhelst.com/baseline-replicas":"1",
+#  "reactor.robbeverhelst.com/claimed-by":"media/shed-load-on-battery",
+#  "reactor.robbeverhelst.com/claimed-at":"2026-08-15T02:40:11Z"}
+```
+
+And when mains returns:
+
+```text
+Normal  StateExited     8s   automation  ups moved from "on-battery" to "online", so the condition stopped holding
+Normal  TargetReleased  8s   automation  Deployment/media/qbittorrent released; no automation claims it any more
+```
+
+`TargetHeld` and `TargetReleased` are raised only when a write actually
+happened. A target already at the right value produces nothing, so a long outage
+is three Events and not one every fifteen seconds.
+
+### If the console goes down with the power
+
+Likely, if your gateway is on the same UPS. Reactor holds the last known state
+and **keeps acting on it** — it does not treat losing sight of the UPS as the
+outage ending, because that would scale everything back up in the middle of one.
+You get `Ready=False` with `StateKeyUnavailable` (a key vanished) or
+`ObservationStale` (the console stopped answering entirely, on an install that
+set `unifi.maxObservationAge`), and the claims stay exactly where they were.
+[When Reactor cannot see](/concepts/when-reactor-cannot-see/).
+
+## What this does not cover
+
+- **It does not shut down machines.** Nothing here powers off a node or a NAS.
+  Cordoning closes a node to new work; the shutdown itself is still yours, and a
+  `notification.*` action telling you to run it is the honest shape — see
+  [Get told when the WAN fails over](/guides/get-notified-when-the-wan-fails-over/)
+  for the setup, which is identical for a UPS message.
+- **It does not stop a running Job.** Suspending a CronJob is a separate rung
+  and stops only *new* Jobs — [Suspend scheduled work during an outage](/guides/suspend-cronjobs-during-an-outage/).
+- **It does not switch a UPS outlet.** Reactor reads `outlet.<n>` and never
+  writes one, so "cut power to outlet 3" is not part of any plan you can write
+  today. (Toggling a single outlet by hand on a UniFi UPS 2U moved only that
+  outlet, and `relay_group` turns out to separate battery-backed outlets from
+  surge-only ones rather than naming a switching bank — but no write action has
+  shipped, and [#23](https://github.com/robbeverhelst/unifi-reactor/issues/23)
+  is where that is decided.)
+- **It cannot help a workload an HPA drives.** Reactor declines those rather
+  than fighting — [Run alongside a HorizontalPodAutoscaler](/guides/run-alongside-an-hpa/).
+
+## Before you trust it with a shutdown
+
+`ups.runtime` is derived from the UPS's `timeToRemain` field, and **its unit is
+inferred to be seconds** from a single observation on a UPS that was not
+discharging. Nothing in Reactor depended on it before this key existed. The
+`ups` key itself is verified against a real capture; the runtime *thresholds*
+are not verified against a real discharge.
+
+So: put the ladder in with [`spec.dryRun`](/operations/suspend-and-dry-run/)
+first, pull the mains lead, and watch what `ups.runtime` actually reports as the
+battery drains against a clock.
+[#7](https://github.com/robbeverhelst/unifi-reactor/issues/7) has the procedure,
+and confirming it is fifteen minutes that would settle the key for everybody.
+
+## Where to go next
+
+- [Power and UPS state keys](/state-keys/power-and-ups/) — the four keys and why they are four.
+- [Kubernetes actions](/actions/kubernetes/) — cordon, suspend, restart, and the drain that is deliberately missing.
+- [Arbitration](/concepts/arbitration/) — what happens when two rungs claim one workload.
+- [Automation API reference](/reference/automation/) — every field of `spec`, generated from the types.
+- [Chart values reference](/reference/values/) — every threshold, debounce and RBAC switch named above.

--- a/docs/src/content/docs/guides/suspend-cronjobs-during-an-outage.md
+++ b/docs/src/content/docs/guides/suspend-cronjobs-during-an-outage.md
@@ -1,0 +1,197 @@
+---
+title: "Suspend a Kubernetes CronJob during an outage"
+description: "The nightly backup starts at 02:00 while the rack is on battery. Suspend the CronJob from a UniFi state key instead, and unsuspend it when power or the uplink comes back."
+---
+
+Scaling cannot express "do not start the nightly backup tonight". A CronJob has
+no replica count to hold at zero — it has a schedule, and at 02:00 it will
+create a Job whatever the rest of the cluster is doing.
+
+That is the single highest-value thing to stop during a power cut or on a
+metered uplink, and it is one field: `spec.suspend`.
+
+## What this assumes
+
+- Reactor is installed and `Ready` — [Install](/start/install/).
+- The CronJob exists. Reactor never creates one.
+- It is in a namespace Reactor can reach. A target in a different namespace
+  from the Automation needs `rbac.clusterWide` (the default); with it false,
+  an Automation can only target its own namespace.
+- The state key you match on is published — `ups*` only with a UniFi UPS
+  adopted, `wan`/`internet` only with a gateway. See [State keys](/state-keys/).
+
+## Stop the backup while the rack is on battery
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: hold-backups-on-battery
+  namespace: velero
+spec:
+  when:
+    provider: unifi
+    state:
+      ups: on-battery
+
+  actions:
+    - type: kubernetes.cronjob.suspend
+      target: { kind: CronJob, name: velero-backup, namespace: velero }
+```
+
+That is complete. `suspended` defaults to `true` — it is what the action is
+named after — and with `onExit` omitted the reversal policy is `Baseline`:
+Reactor recorded whether the CronJob was suspended **before** it first claimed
+it, in `reactor.robbeverhelst.com/baseline-suspend` on the CronJob itself, and
+restores exactly that.
+
+That default matters here more than it looks. If you had suspended the backup by
+hand last Tuesday and forgotten, the baseline is `true` and Reactor leaves it
+suspended when the power comes back, rather than quietly starting a job you had
+switched off.
+
+If you would rather say it out loud:
+
+```yaml
+  onExit:
+    - type: kubernetes.cronjob.suspend
+      target: { kind: CronJob, name: velero-backup, namespace: velero }
+      suspended: false
+```
+
+Now the CronJob is unsuspended on the way out regardless of what it was — which
+is the right choice when the schedule matters more than the manual override, and
+the wrong one if anybody ever pauses it by hand.
+
+## For an offsite backup, match the uplink instead
+
+A backup that ships to S3 has a different failure mode: the rack has power, the
+uplink is the metered one, and a 400GB sync is about to leave over 5G.
+
+```yaml
+apiVersion: reactor.robbeverhelst.com/v1alpha1
+kind: Automation
+metadata:
+  name: hold-offsite-sync-on-backup-wan
+  namespace: backup
+spec:
+  when:
+    provider: unifi
+    state:
+      wan: backup
+
+  actions:
+    - type: kubernetes.cronjob.suspend
+      target: { kind: CronJob, name: restic-offsite }
+```
+
+Omitting `namespace` on the target means the Automation's own namespace, which
+is the common case and needs no cluster-wide RBAC.
+
+## Suspending stops new Jobs, and nothing else
+
+**A Job already running keeps running.** Suspending sets `spec.suspend` on the
+CronJob, which stops the controller creating more Jobs; it does not touch, evict
+or delete the one that started at 01:59.
+
+That is deliberate, and it is enforced rather than promised: Reactor is granted
+no permission over `jobs` at all, so it could not delete one if it wanted to.
+Declining to start more work is a very different act from killing work in
+flight, and killing work in flight is not a decision an outage should take on
+your behalf. If a running backup is what needs stopping, stop it yourself.
+
+**Unsuspending does not run what was missed.** The CronJob controller does not
+catch up on schedules that passed while it was suspended (subject to the
+CronJob's own `startingDeadlineSeconds`). A four-hour outage means the 02:00
+backup did not happen, not that it happens at 06:00.
+
+## What you will see when it fires
+
+```sh
+kubectl -n velero describe automation hold-backups-on-battery
+```
+```text
+Type    Reason        Age   From        Message
+----    ------        ----  ----        -------
+Normal  StateEntered  15s   automation  ups moved from "online" to "on-battery", so the condition started holding
+Normal  TargetHeld    15s   automation  CronJob/velero/velero-backup held at suspended
+```
+
+The level is reported in words rather than as a number, because a bare `0` stops
+explaining itself once a target's level is a switch rather than a count:
+
+```sh
+kubectl -n velero get automation hold-backups-on-battery -o jsonpath='{.status.targets[0]}'
+# {"ref":"CronJob/velero/velero-backup","desired":0,"effective":0,"level":"suspended"}
+```
+
+Underneath, it is an ordinary `kubectl` change with an ordinary audit trail:
+
+```sh
+kubectl -n velero get cronjob velero-backup
+# NAME            SCHEDULE     TIMEZONE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+# velero-backup   0 2 * * *    <none>     True      0        14h             97d
+
+kubectl -n velero get cronjob velero-backup -o jsonpath='{.metadata.annotations}'
+# {"reactor.robbeverhelst.com/baseline-suspend":"false",
+#  "reactor.robbeverhelst.com/claimed-by":"velero/hold-backups-on-battery",
+#  "reactor.robbeverhelst.com/claimed-at":"2026-08-15T02:40:11Z"}
+```
+
+And on the way back:
+
+```text
+Normal  StateExited     6s   automation  ups moved from "on-battery" to "online", so the condition stopped holding
+Normal  TargetReleased  6s   automation  CronJob/velero/velero-backup released; no automation claims it any more
+```
+
+## Two Automations, one CronJob
+
+Suspending is a **desired-state** action, so it is arbitrated exactly as scaling
+is. Point one Automation at the backup for `ups: on-battery` and another at the
+same backup for `wan: backup`, and the CronJob stays suspended while **either**
+condition holds, coming back only when neither does. Nothing has to be
+coordinated, and the one that is currently outvoted says so:
+
+```sh
+kubectl -n velero get automation hold-backups-on-battery -o jsonpath='{.status.targets[0]}'
+# {"ref":"CronJob/velero/velero-backup","desired":1,"effective":0,"level":"suspended",
+#  "deferredBy":["backup/hold-offsite-sync-on-backup-wan"]}
+```
+
+`Applied=False` with reason `DeferredToOtherAutomation` is **not** a fault, and
+the Event for it is `Normal`. Being outvoted by a more restrictive claim is how
+two Automations sharing a target are meant to behave.
+[Arbitration](/concepts/arbitration/) has the whole model.
+
+One thing to avoid: if both Automations write an explicit `onExit`, make them
+agree. Two Automations declaring *different* levels for one target once nothing
+claims it cannot both be right — a CronJob has one normal setting — so Reactor
+takes the most restrictive, and raises a `ReversalDisagreement` Warning naming
+both specs so somebody can fix one. It is raised while the disagreement exists
+rather than at release, because the point of knowing is finding out before the
+outage ends. [Reversal and baselines](/concepts/reversal-and-baselines/).
+
+## What this does not cover
+
+- **Not Jobs.** No permission, on purpose. See above.
+- **Not the workloads the job talks to.** Suspending the backup CronJob does not
+  scale down the database it dumps —
+  [that is a separate action](/guides/shut-down-kubernetes-when-the-ups-is-on-battery/).
+- **Not schedules outside Kubernetes.** A cron entry on a NAS is invisible to
+  Reactor. A [`notification.*`](/guides/get-notified-when-the-wan-fails-over/)
+  or an [`http.request`](/actions/notifications-and-http/#httprequest) is the
+  reach it has there.
+- **Not a Job that is already `Pending` for other reasons.** Suspension is about
+  creation, not scheduling.
+- **No `kubernetes.drain`.** Deliberately not implemented — an eviction cannot
+  be un-evicted, so it has no level to arbitrate and no reversal to declare.
+  [The four reasons](/actions/kubernetes/#why-there-is-no-kubernetesdrain).
+
+## Where to go next
+
+- [Kubernetes actions](/actions/kubernetes/) — the rest of what Reactor can do to a Kubernetes object.
+- [Levels vs occurrences](/concepts/levels-and-occurrences/) — why suspending arbitrates and restarting does not.
+- [Shut down Kubernetes when the UPS goes on battery](/guides/shut-down-kubernetes-when-the-ups-is-on-battery/) — the rung this one belongs on.
+- [Automation API reference](/reference/automation/) — `suspended`, `target`, `reversal` and everything else.
+- [Chart values reference](/reference/values/) — `rbac.clusterWide` and the rest of the install surface.

--- a/docs/src/content/docs/start/first-automation.md
+++ b/docs/src/content/docs/start/first-automation.md
@@ -40,6 +40,7 @@ Shedding load during a power cut is the same shape, matching `ups: on-battery` i
 
 ## Where to go next
 
+- [Guides](/guides/shut-down-kubernetes-when-the-ups-is-on-battery/) — the same shape applied to a real job: shedding load on battery, pausing downloads on a metered uplink, suspending a CronJob, getting told about a failover.
 - [The two shapes an action has](/concepts/levels-and-occurrences/) — why some actions are arbitrated and some just fire.
 - [Kubernetes actions](/actions/kubernetes/) — suspending a CronJob, cordoning a node, restarting a workload.
 - [State keys](/state-keys/) — everything else Reactor can match on.

--- a/docs/src/content/docs/state-keys/wan-and-internet.md
+++ b/docs/src/content/docs/state-keys/wan-and-internet.md
@@ -14,7 +14,7 @@ description: "wan says which uplink is selected, internet says whether the outsi
       internet: down      # regardless of which uplink is carrying it
 ```
 
-Both keys are [debounced at 3 samples](/concepts/settling-a-noisy-signal/), so at the default 30s `pollInterval` an outage takes about **90 seconds** to be believed — and a recovery the same. That is a deliberate trade for not shedding load on one bad probe round; if you need it faster, lower `pollInterval` rather than the debounce, because the three samples are what make the signal trustworthy.
+`internet` is [debounced at 3 samples](/concepts/settling-a-noisy-signal/), so at the default 30s `pollInterval` an outage takes about **90 seconds** to be believed — and a recovery the same. That is a deliberate trade for not shedding load on one bad probe round; if you need it faster, lower `pollInterval` rather than the debounce, because the three samples are what make the signal trustworthy. `wan` is different: it is a switch position rather than a probe, so it ships at the default of 1 sample and reacts on the first observation.
 
 `wan.quality` answers a third question, over a different time horizon: not *is the internet there* but *has this uplink been any good*. It buckets the availability and average latency the console measures against its uptime monitors into two levels, using [thresholds you configure](/operations/configuration/). Those numbers are averages over the console's uptime window — 24 hours on the hardware they were captured from — so `wan.quality` describes a link that has been bad rather than one that spiked, and a long outage keeps it `degraded` for the rest of that window.
 


### PR DESCRIPTION
Closes #77.

The Guides section did not exist. It does now: five task-shaped pages, each titled with the sentence somebody would actually type into a search box rather than with the feature it happens to use, plus the sidebar section that holds them.

## The five

| Guide | Answers |
| --- | --- |
| [Shut down Kubernetes when the UPS goes on battery](https://reactor.robbeverhelst.com/guides/shut-down-kubernetes-when-the-ups-is-on-battery/) | `shut down kubernetes when ups on battery`, `kubernetes scale down on power failure`, `homelab ups automation kubernetes` |
| [Pause downloads when Kubernetes falls back to a metered connection](https://reactor.robbeverhelst.com/guides/pause-downloads-on-a-metered-connection/) | `pause downloads metered connection kubernetes` |
| [Get a notification when your WAN fails over](https://reactor.robbeverhelst.com/guides/get-notified-when-the-wan-fails-over/) | `notify when wan fails over kubernetes` |
| [Suspend a Kubernetes CronJob during an outage](https://reactor.robbeverhelst.com/guides/suspend-cronjobs-during-an-outage/) | `suspend cronjob during outage` |
| [Scaling down a Deployment that has a HorizontalPodAutoscaler](https://reactor.robbeverhelst.com/guides/run-alongside-an-hpa/) | `kubernetes operator and hpa fighting over replicas` |

Each one has a complete Automation that can be pasted as it stands, a list of what it assumes, the `kubectl describe` output it produces when it fires, and a section saying what it does *not* cover. The mechanism is linked to Concepts rather than re-explained, and field detail to the generated Reference rather than restated.

The flagship guide is the escalation ladder — shed on `ups: on-battery`, cordon on `ups.runtime: short`, stop the database on `critical` — and it argues runtime over charge, because charge ignores load and load is most of the answer.

The metered-uplink guide gives both answers and is honest about why you might still take the crude one: `kubernetes.scale` is arbitrated and has a baseline on the object; `qbittorrent.pause` is neither, so whichever Automation resumes first resumes everything, including torrents you had paused by hand.

The HPA guide explains the decline path, `safety.detectHPA`, the `list`-only permission it grants, the hand-back-to-baseline case, why there is no `force`, and four things to write instead — one of which is a complete working replacement Automation.

## Two corrections, both in pages the guides link to

Found while checking claims against `internal/` and the generated reference:

1. **`wan` is debounced at 1 sample, not 3.** `state-keys/wan-and-internet.md` said "both keys are debounced at 3". Only `internet` and `wan.quality` are in `unifi.debounce.keys`; `wan` is a switch position and takes the default of 1. The generated `/reference/values/` was already right, so the two pages disagreed.
2. **A notification template's `.State` carries only the keys in `spec.when.state`.** `evaluate()` populates it from `spec.when.state` alone, and templates run with `missingkey=error` — so `{{ .State.isp }}` on a `wan`-only Automation is a template error and the message never goes out. The guide says so and shows the fix (match `isp` too, and that this narrows the condition).

## Checks

- `make test` — pass.
- `make lint` — pass. (It failed first against a stale golangci-lint cache pointing at a sibling worktree that no longer exists; `golangci-lint cache clean` and it is 0 issues.)
- `make manifests generate docs` — no drift; nothing under `docs/src/content/docs/reference/` was touched.
- `bun run build` in `docs/` — 54 pages, clean.
- Every internal link and anchor in the five new pages checked against the built HTML.
- No cluster touched, no real console contacted. `README.md` and `charts/reactor/README.md` are unchanged.

## Live verification

What these guides claim that has **not** been run against real hardware, stated here because the guides state it too rather than implying it is proven:

- **`ups.runtime` thresholds have never been validated against a real discharge.** `timeToRemain`'s unit is *inferred* to be seconds from one observation on a UPS that was not discharging (#7). The `ups` on-battery/online key itself is verified against a real capture; the runtime bucketing is not. The flagship guide says so in its own section and tells you to dry-run it and pull the mains lead before trusting it with a shutdown.
- **A genuine WAN failover has still never been observed** (#34). `wan` is derived from `is_uplink`, inferred from a capture in which only one uplink was live. Both WAN guides say so; the notification guide argues it is the safest possible place to find out, since it writes nothing.
- **The `unifi.*` console write actions have never run against real hardware.** No guide here uses one — deliberately. `unifi.wlan.*` and `unifi.poe.cycle` are mentioned only where the reasoning is being cited.
- **The three parsers written to a documented shape rather than a capture** (`firmware`, `temperature`, `poe`) are not used as triggers by any of these guides.
- **Every `kubectl describe` block is reconstructed from the emitting code**, not pasted from a live cluster. The message formats are the real ones — `describeManaged`, `edgeVerbs`, the `TargetHeld`/`TargetReleased` formats in `events.go` — and the timings and object names are illustrative.
- **HPA detection has been exercised in tests, not against a live HPA fight.** `hpa_test.go` covers the decline and the hand-back; the oscillation it prevents is described from the code path, not from a captured incident.

## One thing noticed and deliberately left alone

Two facts settled on real hardware today: toggling a single UPS outlet moved only that outlet, and `relay_group` partitions battery-backed outlets from surge-only ones rather than naming a switching bank. That answers the open question in `state-keys/outlets.md`, which still reads "nobody has confirmed which it is".

The power-cut guide mentions the finding in one parenthesis, in the context of why an outlet still cannot be part of a shutdown plan — no outlet write action has shipped, which is unchanged either way. Updating the state-keys page and reconsidering #23 is that issue's work, not this PR's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Guides section with task-oriented documentation for UPS shutdowns, metered downloads, WAN failover notifications, CronJob suspension, and HPA integration.
  * Added a guide link to the first-automation documentation.
* **Documentation**
  * Documented configuration, security, observability, limitations, and recovery behavior for each new integration.
  * Clarified that internet status is debounced, while WAN status reacts to the first observation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->