### PR TITLE
ci: skip the e2e suites for documentation-only changes

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,8 +1,37 @@
 name: E2E Tests
 
+# These suites cost roughly 13 and 3 minutes because each one builds a Kind
+# cluster, so a change that provably cannot reach the reaction flow should not
+# pay for them. The list below is deliberately short: only the documentation
+# site, Markdown anywhere, the two README banners and the licence. Everything
+# else runs the suites, including hack/ (mock-unifi is the console the suites
+# run against) and charts/ (the lifecycle suite installs the chart) — a false
+# negative here ships a regression under a green tick, which is far worse than
+# the minutes it saves.
+#
+# Skipping by path means the job does not run at all and reports no status.
+# That is safe today because main has neither branch protection nor a ruleset,
+# so none of these are required checks. If that changes, revisit this: a
+# required check that never runs is reported as passing, and this filter would
+# then let a docs pull request merge with a green Reaction that never executed.
+# The fix in that case is a job that runs and reports success without doing the
+# work, not an absent job.
+#
+# The two lists are identical and have to stay that way; Actions does not
+# support YAML anchors, so they are written out twice.
 on:
   push:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/assets/**'
+      - 'LICENSE'
   pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+      - '.github/assets/**'
+      - 'LICENSE'
 
 permissions: {}
 


### PR DESCRIPTION
Closes #87.

The Reaction and Lifecycle suites each build a Kind cluster and cost roughly 13 and 3 minutes. #85 and #86 waited on them twice over for changes that cannot reach the reaction flow.

## What this does

`paths-ignore` on both triggers of the E2E workflow, covering only what provably cannot change behaviour:

- `docs/**`
- `**.md`
- `.github/assets/**`
- `LICENSE`

`Tests` and `Lint` are left alone. `Tests` is cheap, and it also carries the `Check generated docs are committed` job — that job runs `make docs`, which writes into `docs/`, so filtering it on `docs/**` would disable the drift check precisely on the pull requests it exists to guard.

## On the required-check trap

`main` has neither branch protection nor a ruleset — `/branches/main/protection` returns 404 and both `/rules/branches/main` and `/rulesets` return `[]`. Nothing here is a required check, so a job that never runs reports no status rather than a false green, and skipping outright is safe. That is why this is a plain `paths-ignore` and not a filtered job that reports success without doing the work. The workflow comment records the hazard and the alternative in case protection is added later.

## The two cautions

`hack/**` and `charts/**` are deliberately **not** ignored. `hack/mock-unifi` is the console the suites run against, and the lifecycle suite installs the chart, so `hack/gen-reference.sh` and `charts/reactor/README.md` cost a full run. That is the conservative side of the trade: #86 would still run the suites because it touched `hack/docsgen`.

`'**.md'` rather than `'**/*.md'` — GitHub documents `'**.js'` as matching `index.js` at the root as well as `js/index.js`, so this form is the one that reliably catches a root `README.md`.

## Verification

Simulated GitHub's documented matcher against real repository paths:

| Change | Result |
| --- | --- |
| only `README.md` | skipped |
| #85 for real (2 READMEs + 2 banner SVGs) | skipped |
| #86 for real (`docs/**` + `hack/`) | **runs** — `hack/` is not ignored |
| only `internal/` | runs |
| both `README.md` and `internal/` | runs |

Everything in the caution list still triggers a run: `hack/mock-unifi`, `hack/capture-unifi.sh`, `hack/verify-testdata.sh`, `hack/sync-chart-crds.sh`, `charts/reactor/values.yaml`, the chart templates and CRD, `Makefile`, `go.mod`, `testdata/`, `api/`, `test/e2e/` and this workflow file itself.

This pull request touches only `.github/workflows/test-e2e.yml`, which is not in the ignore list, so the suites run on it — the negative case is exercised here.

## Checks

`make lint` clean (0 issues), `make test` passing, `make docs` and `make manifests generate` produce no drift. `actionlint` reports the same single pre-existing shellcheck warning on the kind-install line as it does on `main`, and nothing new.