### PR TITLE
fix(chart): the adopting upgrade leaves the CRD out of the manifest, and now says so

### DIFF
--- a/charts/reactor/README.md
+++ b/charts/reactor/README.md
@@ -48,7 +48,15 @@ Those versions installed the CRD through `crds/`, which Helm applies without rec
 
 It is rendered only when there is something to adopt, so a fresh install and every later upgrade carry no Job and no cluster-scoped permission. A CRD belonging to a *different* release is never adopted: that upgrade stops, naming the release that owns it.
 
-Set `crds.adopt=false` to hand the CRD over yourself instead; [the troubleshooting guide](https://reactor.robbeverhelst.com/troubleshooting/rbac-and-crd/#upgrading-from-chart-030-or-earlier) has the two `kubectl` commands, which are also the fallback if the hook ever fails.
+Set `crds.adopt=false` to hand the CRD over yourself instead; [the troubleshooting guide](https://reactor.robbeverhelst.com/troubleshooting/rbac-and-crd/#upgrading-from-chart-030-or-earlier) has the two `kubectl` commands, which are also the fallback if the hook ever fails. Until somebody runs them the CRD still belongs to no release, so the upgrade stops there too — with the same two commands in the message.
+
+#### `helm get manifest` shows no CRD after that upgrade
+
+Expected, on that one revision, and only that one.
+
+Helm checks whether it owns an object while it *prepares* an upgrade, before it runs a single hook — so an upgrade that renders a CRD nobody owns fails before the hook that would establish ownership could exist. The chart therefore leaves the CRD out of the release on the adopting upgrade and lets the hook apply the schema instead. `helm get manifest` for that revision lists `serviceaccount.yaml`, `rbac.yaml` and `deployment.yaml` and no `CustomResourceDefinition`, while `helm template` — which has no cluster to look in, so it cannot tell the CRD is unowned — renders one. Both are correct.
+
+The next `helm upgrade` finds the CRD owned, renders it as an ordinary part of the release, and it stays there. Nothing has to be done to make that happen, and nothing is different about a release deployed through Pulumi, Argo CD or Flux: the decision is a `lookup` made at render time, by whichever Helm does the rendering.
 
 ### Managing the CRD outside the release
 

--- a/charts/reactor/templates/_helpers.tpl
+++ b/charts/reactor/templates/_helpers.tpl
@@ -66,6 +66,11 @@ A CRD owned by a different release is never adopted. That is somebody else's
 object, and taking it would leave the release that owns it unable to update its
 own; the upgrade stops here instead, naming what it found.
 
+crds.adopt=false on a CRD nobody owns stops here too. Helm would refuse that
+upgrade anyway — an unowned object is one it will not update — but it refuses
+it with a generic ownership error that says nothing about which value turned
+adoption off or what to run instead. Failing here says both.
+
 `helm template` and a client-side `--dry-run` have no cluster to look in, so
 both render the CRD — the state every install is in once this has happened once.
 */}}
@@ -77,7 +82,19 @@ both render the CRD — the state every install is in once this has happened onc
 {{- $owner := default "" (index $annotations "meta.helm.sh/release-name") -}}
 {{- $ownerNamespace := default "" (index $annotations "meta.helm.sh/release-namespace") -}}
 {{- if eq $owner "" -}}
-{{- if .Values.crds.adopt -}}adopt{{- end -}}
+{{- if .Values.crds.adopt -}}adopt
+{{- else -}}
+{{- fail (printf (join "" (list
+  "the CustomResourceDefinition %s belongs to no Helm release — the state chart 0.3.0 and earlier left "
+  "behind by shipping it under crds/ — and crds.adopt=false turned off the hook that would have handed "
+  "it over. Helm will not update an object it does not own, so this upgrade cannot proceed. Adopt it by "
+  "hand and upgrade again:\n\n"
+  "  kubectl label crd %s app.kubernetes.io/managed-by=Helm --overwrite\n"
+  "  kubectl annotate crd %s meta.helm.sh/release-name=%s meta.helm.sh/release-namespace=%s --overwrite\n\n"
+  "Or upgrade with --set crds.install=false to leave the CRD out of this release entirely."))
+  (include "reactor.crdName" .) (include "reactor.crdName" .) (include "reactor.crdName" .)
+  .Release.Name .Release.Namespace) -}}
+{{- end -}}
 {{- else if or (ne $owner .Release.Name) (ne $ownerNamespace .Release.Namespace) -}}
 {{- fail (printf (join "" (list
   "the CustomResourceDefinition %s belongs to the Helm release %q in namespace %q, not to %q in namespace %q. "

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -19,10 +19,20 @@ crds:
   # only in that case, and cleans itself up when it succeeds. A CRD owned by
   # another release is never adopted; that upgrade stops and says whose it is.
   #
+  # On that one upgrade the chart deliberately leaves the CRD out of the
+  # release, because Helm checks ownership before it runs any hook, and the hook
+  # puts the schema live in the same patch that takes ownership. So `helm get
+  # manifest` for that revision carries no CustomResourceDefinition while `helm
+  # template` renders one; the next upgrade puts it back for good. The chart
+  # README explains it under "helm get manifest shows no CRD after that
+  # upgrade".
+  #
   # Set to false to do it by hand instead
   # (https://reactor.robbeverhelst.com/troubleshooting/ has the two kubectl
-  # commands). Ignored when install is false, which already says the CRD is
-  # somebody else's to manage.
+  # commands). That is a promise to run them: until somebody does, the CRD
+  # belongs to no release and Helm will not update it, so the upgrade stops and
+  # repeats the commands back to you. Ignored when install is false, which
+  # already says the CRD is somebody else's to manage.
   adopt: true
 
 image:

--- a/docs/src/content/docs/contributing/development.md
+++ b/docs/src/content/docs/contributing/development.md
@@ -57,6 +57,16 @@ Each target creates its Kind cluster, runs the suite, and deletes the cluster wh
 
 The suites reach the mock over a fixed node port mapped to the host by `test/e2e/kind-config.yaml`, which is why they create their own clusters rather than reusing one you already have.
 
+### When cluster creation fails on the node port
+
+```text
+ERROR: failed to create cluster: ... Bind for 127.0.0.1:30943 failed: port is already allocated
+```
+
+That node port is fixed, so only one of these suites can exist at a time — and a suite whose cleanup never ran leaves a cluster holding it. `kind get clusters` finds the orphan; deleting it frees the port. The same message also appears for a few seconds after a cluster is deleted, while Docker still holds the reservation, so a rerun that fails immediately after a teardown is worth trying once more before hunting for a cause.
+
+A suite takes a few minutes and is worth capturing to a file. If your shell sets `noclobber` — zsh does under many dotfile setups — `> run.log` **refuses to overwrite an existing file** and the run never starts, while the previous run's log sits there looking like a fresh failure. Use `>|`, or delete the file first.
+
 `make manifests` also regenerates `charts/reactor/templates/crds.yaml` via `hack/sync-chart-crds.sh`. The CRD is a chart *template* deliberately: Helm installs a chart's `crds/` directory on first install only and never upgrades it, so every later schema change would ship silently broken. Don't hand-edit the chart's copy — the tests in `test/chart/` fail when it drifts from `config/crd/bases`, and they need `helm` on your PATH to run at all.
 
 ## Running against a cluster

--- a/docs/src/content/docs/reference/values.md
+++ b/docs/src/content/docs/reference/values.md
@@ -43,10 +43,20 @@ ClusterRole granting get and patch on that single CRD name — is rendered
 only in that case, and cleans itself up when it succeeds. A CRD owned by
 another release is never adopted; that upgrade stops and says whose it is.
 
+On that one upgrade the chart deliberately leaves the CRD out of the
+release, because Helm checks ownership before it runs any hook, and the hook
+puts the schema live in the same patch that takes ownership. So `helm get
+manifest` for that revision carries no CustomResourceDefinition while `helm
+template` renders one; the next upgrade puts it back for good. The chart
+README explains it under "helm get manifest shows no CRD after that
+upgrade".
+
 Set to false to do it by hand instead
 (https://reactor.robbeverhelst.com/troubleshooting/ has the two kubectl
-commands). Ignored when install is false, which already says the CRD is
-somebody else's to manage.
+commands). That is a promise to run them: until somebody does, the CRD
+belongs to no release and Helm will not update it, so the upgrade stops and
+repeats the commands back to you. Ignored when install is false, which
+already says the CRD is somebody else's to manage.
 
 ## `image`
 

--- a/docs/src/content/docs/troubleshooting/rbac-and-crd.md
+++ b/docs/src/content/docs/troubleshooting/rbac-and-crd.md
@@ -70,16 +70,16 @@ What it does, so that nothing about it is a surprise:
 
 A CRD that belongs to a **different** Helm release is never adopted. That upgrade stops before it changes anything, naming the release that owns it — take it from there deliberately, or upgrade with `--set crds.install=false` and leave the CRD to whoever manages it.
 
-**Doing it by hand instead.** With `--set crds.adopt=false` the chart renders no hook, and the upgrade fails the way it used to:
+**Doing it by hand instead.** With `--set crds.adopt=false` the chart renders no hook — and stops the upgrade, because nothing is then left that could put the schema live and Helm will not update a CRD it does not own:
 
 ```text
-Error: UPGRADE FAILED: rendered manifests contain a resource that already
-exists. Unable to continue with update: CustomResourceDefinition
-"automations.reactor.robbeverhelst.com" ... invalid ownership metadata;
-label validation error: missing key "app.kubernetes.io/managed-by" ...
+Error: UPGRADE FAILED: execution error at (reactor/templates/crds.yaml:...):
+the CustomResourceDefinition automations.reactor.robbeverhelst.com belongs to
+no Helm release ... and crds.adopt=false turned off the hook that would have
+handed it over.
 ```
 
-The fix is the pair of commands the hook runs for you — use your own release name and namespace, then upgrade again:
+It stops before anything is applied, and repeats the pair of commands the hook runs for you — use your own release name and namespace, then upgrade again:
 
 ```sh
 kubectl label crd automations.reactor.robbeverhelst.com \
@@ -90,6 +90,32 @@ kubectl annotate crd automations.reactor.robbeverhelst.com \
 ```
 
 The same commands are the fallback if the hook itself fails — its logs say why, and adopting by hand needs no more than this. Once adopted, by either route, it never recurs.
+
+### `helm get manifest` shows no CRD after that upgrade
+
+Expected, on that one revision, and only that one. The CRD is live, owned by your release, and serving the schema the chart shipped — it simply is not part of the manifest Helm recorded for that revision.
+
+Helm checks whether it owns an object while it *prepares* an upgrade, before it runs a single hook. An upgrade that rendered a CRD nobody owns would therefore fail before the hook that establishes ownership could exist. So the chart leaves the CRD out of the release on the adopting upgrade, and the hook applies the schema in the same patch that takes ownership.
+
+That is why the two views disagree, and why both are right:
+
+```sh
+helm template reactor oci://ghcr.io/robbeverhelst/charts/reactor   # renders the CRD
+helm get manifest reactor -n reactor-system                        # does not
+```
+
+`helm template` has no cluster to look in, so it cannot tell the CRD is unowned and renders the ordinary case. The release was rendered against your cluster, where the CRD was unowned, so it rendered the adopting case.
+
+The next `helm upgrade` finds the CRD owned, carries it in the release like any other resource, and it stays there. Nothing is different about a release deployed through Pulumi, Argo CD or Flux — the decision is a `lookup` at render time, made by whichever Helm does the rendering.
+
+To check where you are:
+
+```sh
+kubectl get crd automations.reactor.robbeverhelst.com \
+  -o jsonpath='{.metadata.annotations.meta\.helm\.sh/release-name}{"\n"}'
+```
+
+A release name means the CRD is adopted and the next upgrade will carry it. Empty means adoption has not happened yet.
 
 ### A valid Automation is rejected, or a field is silently dropped
 

--- a/internal/adopt/crd.go
+++ b/internal/adopt/crd.go
@@ -35,6 +35,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -80,7 +81,8 @@ type Options struct {
 	Namespace string
 
 	// ManifestPath is the chart's own copy of the CRD, mounted alongside this
-	// hook, and its spec is applied in the same patch that takes ownership.
+	// hook. Its spec and its annotations — helm.sh/resource-policy: keep among
+	// them — are applied in the same patch that takes ownership.
 	//
 	// It has to be, and that is the part worth explaining. Helm checks
 	// ownership while it prepares the upgrade — before it runs a single hook —
@@ -158,41 +160,61 @@ func CRD(ctx context.Context, c client.Client, opts Options) error {
 }
 
 // adoptionPatch builds the single merge patch that takes ownership and, when
-// the chart's copy of the CRD was mounted, puts its schema live.
+// the chart's copy of the CRD was mounted, puts its schema and its annotations
+// live.
 //
 // One patch rather than two: either the CRD ends up owned by the release and
 // serving the schema that release ships, or nothing about it changed.
 func adoptionPatch(opts Options) ([]byte, error) {
-	metadata := map[string]any{
-		"labels": map[string]any{managedByLabel: managedByHelm},
-		"annotations": map[string]any{
-			releaseNameAnnotation:      opts.Release,
-			releaseNamespaceAnnotation: opts.Namespace,
-		},
-	}
-	patch := map[string]any{"metadata": metadata}
+	annotations := map[string]any{}
+	patch := map[string]any{"metadata": map[string]any{
+		"labels":      map[string]any{managedByLabel: managedByHelm},
+		"annotations": annotations,
+	}}
 
 	if opts.ManifestPath != "" {
-		spec, err := chartSpec(opts.ManifestPath, opts.Name)
+		document, err := chartDocument(opts.ManifestPath, opts.Name)
 		if err != nil {
 			return nil, err
 		}
 		// A merge patch replaces spec.versions wholesale — it is a list, and
 		// JSON merge semantics do not merge those — which is what makes this
 		// the same schema change a normal `helm upgrade` applies.
-		patch["spec"] = spec
+		patch["spec"] = document["spec"]
+		// The chart's annotations along with it, so an adopted CRD carries
+		// helm.sh/resource-policy: keep from the moment it is adopted rather
+		// than from the next upgrade, which is the first time Helm applies the
+		// template itself. Annotations merge, so anything else on the live
+		// object survives.
+		maps.Copy(annotations, chartAnnotations(document))
 	}
+
+	// Last, so ownership is never something the chart's own manifest could
+	// overwrite: it is the half of this patch that has to be exact.
+	annotations[releaseNameAnnotation] = opts.Release
+	annotations[releaseNamespaceAnnotation] = opts.Namespace
 	return json.Marshal(patch)
 }
 
-// chartSpec reads the CRD the chart would have applied and returns its spec.
+// chartAnnotations reads metadata.annotations off a decoded document, without
+// assuming either is present.
+func chartAnnotations(document map[string]any) map[string]any {
+	metadata, ok := document["metadata"].(map[string]any)
+	if !ok {
+		return nil
+	}
+	annotations, _ := metadata["annotations"].(map[string]any)
+	return annotations
+}
+
+// chartDocument reads the CRD the chart would have applied and returns it.
 //
 // The file is the chart's own rendered template, so this is strict about what
 // it accepts: exactly one CustomResourceDefinition, carrying the name being
 // adopted. Anything else means the hook was handed a manifest for a different
 // object, and patching a CRD's schema from one of those is not a mistake worth
 // recovering from.
-func chartSpec(path, name string) (map[string]any, error) {
+func chartDocument(path, name string) (map[string]any, error) {
 	raw, err := os.ReadFile(path) // #nosec G304 -- the path is the chart's own mounted manifest
 	if err != nil {
 		return nil, fmt.Errorf("reading the chart's CRD at %s: %w", path, err)
@@ -220,11 +242,10 @@ func chartSpec(path, name string) (map[string]any, error) {
 		if found != nil {
 			return nil, fmt.Errorf("the chart's CRD at %s holds more than one document", path)
 		}
-		spec, ok := document["spec"].(map[string]any)
-		if !ok {
+		if _, ok := document["spec"].(map[string]any); !ok {
 			return nil, fmt.Errorf("the chart's CRD at %s has no spec", path)
 		}
-		found = spec
+		found = document
 	}
 	if found == nil {
 		return nil, fmt.Errorf("the chart's CRD at %s holds no CustomResourceDefinition", path)

--- a/internal/adopt/crd_test.go
+++ b/internal/adopt/crd_test.go
@@ -254,6 +254,37 @@ func TestAdoptsOwnershipWithoutAManifest(t *testing.T) {
 	}
 }
 
+// TestAdoptionCarriesTheChartsAnnotations covers the half of the patch that is
+// not the schema. On the adopting upgrade the chart deliberately leaves the CRD
+// out of the release, so the template — and helm.sh/resource-policy: keep with
+// it — is not applied until the NEXT upgrade. Carrying the chart's annotations
+// here closes that gap, so a CRD is never owned by a release without the policy
+// that says an uninstall must leave it, and every Automation stored under it,
+// alone.
+//
+// Ownership is written last and is not something the mounted manifest can
+// influence: a chart whose CRD carried a meta.helm.sh annotation of its own
+// would otherwise point the live object at a release that does not exist.
+func TestAdoptionCarriesTheChartsAnnotations(t *testing.T) {
+	misleading := strings.Replace(chartCRD, "helm.sh/resource-policy: keep",
+		"helm.sh/resource-policy: keep\n    "+releaseNameAnnotation+": somebody-else", 1)
+	c := fake.NewClientBuilder().WithScheme(scheme()).WithObjects(liveCRD(nil)).Build()
+
+	if err := CRD(context.Background(), c, options(manifest(t, misleading))); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	annotations := readBack(t, c).GetAnnotations()
+	if got := annotations["helm.sh/resource-policy"]; got != "keep" {
+		t.Errorf("helm.sh/resource-policy = %q, want %q: an uninstall before the next upgrade "+
+			"would have nothing telling Helm to leave the CRD alone", got, "keep")
+	}
+	if got := annotations[releaseNameAnnotation]; got != release {
+		t.Errorf("%s = %q, want %q: the mounted manifest overwrote the release taking ownership",
+			releaseNameAnnotation, got, release)
+	}
+}
+
 // TestRejectsAManifestForSomethingElse guards the input that would be worst to
 // act on: patching one CRD's schema from another object's spec.
 func TestRejectsAManifestForSomethingElse(t *testing.T) {

--- a/test/e2e/lifecycle/upgrade_test.go
+++ b/test/e2e/lifecycle/upgrade_test.go
@@ -220,6 +220,25 @@ var _ = Describe("Upgrading from a chart that shipped the CRD under crds/", Orde
 		Expect(err).NotTo(HaveOccurred())
 		Expect(annotations).To(ContainSubstring(`"meta.helm.sh/release-name":"` + release + `"`))
 		Expect(annotations).To(ContainSubstring(`"meta.helm.sh/release-namespace":"` + namespace + `"`))
+
+		// #84: someone reading `helm get manifest` after this upgrade finds no
+		// CRD in it and reasonably concludes their deployment tool dropped one.
+		// It did not — the chart left it out, because Helm checks ownership
+		// before it runs the hook that establishes ownership. This is the one
+		// revision where the release does not carry the CRD, and it is pinned
+		// here so it stays deliberate rather than becoming a thing to rediscover.
+		By("with the CRD deliberately outside the release on this one revision")
+		manifest, err := cluster.Helm("get", "manifest", release, "--namespace", namespace)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(manifest).NotTo(ContainSubstring("kind: CustomResourceDefinition"),
+			"the adopting upgrade rendered the CRD, which Helm would have refused before the hook could run")
+
+		// And the keep policy live anyway, applied by the hook rather than by
+		// the template that is not part of this revision. Without it there is a
+		// window — this revision — where a Helm-owned CRD holding every
+		// Automation in the cluster carries nothing saying to leave it alone.
+		By("and the keep policy live regardless, because the hook carries it too")
+		Expect(annotations).To(ContainSubstring(`"helm.sh/resource-policy":"keep"`))
 	})
 
 	// A hook that succeeds takes its own permissions with it. The grant it
@@ -286,6 +305,51 @@ var _ = Describe("Upgrading from a chart that shipped the CRD under crds/", Orde
 		Expect(err).NotTo(HaveOccurred())
 		Expect(manifest).To(ContainSubstring("kind: CustomResourceDefinition"),
 			"the CRD never rejoined the release, so a later schema change would not reach the cluster")
+	})
+})
+
+// crds.adopt=false says "I will hand the CRD over myself". Until somebody does,
+// the CRD belongs to no release and Helm will not update it — so the upgrade
+// cannot proceed, and the only question is whether it says why. Helm's own
+// refusal names neither the value that turned adoption off nor the two commands
+// that finish the job, so the chart refuses first and names both.
+var _ = Describe("Declining to adopt a CRD that belongs to no release", Ordered, func() {
+	const namespace = "reactor-no-adopt"
+
+	BeforeAll(func() {
+		removeCRD()
+		_, _ = cluster.Kubectl("create", "namespace", namespace)
+
+		By("leaving the CRD as the crds/ packaging did: applied, owned by nobody")
+		Expect(cluster.Apply(legacyCRD)).To(Succeed())
+	})
+
+	AfterAll(func() {
+		_, _ = cluster.Helm("uninstall", release, "--namespace", namespace, "--ignore-not-found")
+		removeCRD()
+		_, _ = cluster.Kubectl("delete", "namespace", namespace, "--wait=false")
+	})
+
+	It("stops, naming the commands that finish the job", func() {
+		out, err := cluster.Helm("install", release, "charts/reactor", "--namespace", namespace,
+			set, "crds.adopt=false",
+			set, "image.repository="+managerRepository,
+			set, "image.tag="+managerTag,
+			set, "image.pullPolicy=Never",
+			"--timeout=180s")
+		Expect(err).To(HaveOccurred(),
+			"an install that can neither adopt the CRD nor update it reported success")
+		Expect(out).To(ContainSubstring("crds.adopt=false"),
+			"the failure does not say which value declined the adoption")
+		Expect(out).To(ContainSubstring("kubectl label crd " + crdName))
+		Expect(out).To(ContainSubstring("kubectl annotate crd " + crdName))
+	})
+
+	It("leaves the CRD untouched", func() {
+		labels, err := cluster.Kubectl("get", "crd", crdName, "-o", "jsonpath={.metadata.labels}")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(labels).NotTo(ContainSubstring("app.kubernetes.io/managed-by"),
+			"a refused install adopted the CRD anyway")
 	})
 })
 


### PR DESCRIPTION
Closes #84.

## The issue's premise is wrong, and the title should change

#84 is titled *"the CRD template is not in the release manifest under Pulumi"*. Pulumi has nothing to do with it. **This is the chart's own behaviour, it is deliberate, it lasts exactly one revision, and it happens identically under the plain `helm` CLI.** Anyone upgrading from chart 0.3.0 or earlier sees it, whatever they deploy with.

Suggested retitle: **"the adopting upgrade leaves the CRD out of the release manifest, and nothing says so"**.

Nothing here is broken and nothing needs action on a running cluster — see [What a v1.2 user has to change](#what-a-v12-user-has-to-change). What was wrong is that the behaviour was undocumented, that `helm.sh/resource-policy: keep` did not reach the live object during that revision, and that `crds.adopt=false` failed with a message that explained nothing.

## What the one-revision behaviour is

Verifiable from the code alone, no cluster required.

`charts/reactor/templates/_helpers.tpl` defines `reactor.crdAdoption`. It performs a **`lookup` at render time** against the live cluster:

```
{{- $live := lookup "apiextensions.k8s.io/v1" "CustomResourceDefinition" "" (include "reactor.crdName" .) -}}
```

and returns `adopt` when that CRD exists and carries no `meta.helm.sh/release-name` — the state chart 0.3.0 and earlier left behind by shipping the CRD under `crds/`, which Helm applies but never records as part of a release.

`charts/reactor/templates/crds.yaml` is then gated on that value:

```
{{- if and .Values.crds.install (ne (include "reactor.crdAdoption" .) "adopt") }}
```

So when the helper says `adopt`, **the CRD renders nothing**, and `charts/reactor/templates/crd-adoption-hook.yaml` — gated on the opposite condition — renders instead.

Why it has to work this way: Helm checks whether it owns an object while it *prepares* an upgrade, **before it runs a single hook**. An upgrade that rendered a CRD nobody owns would fail with `invalid ownership metadata` before the hook that establishes ownership could exist. The chart therefore leaves the CRD out of the release on that one upgrade, and `adoptionPatch` in `internal/adopt/crd.go` takes ownership *and* replaces `spec` in a single merge patch — so the schema goes live regardless of whether Helm is tracking the object.

Three consequences, all of them correct:

| | |
|---|---|
| `helm get manifest` on the adopting revision | ServiceAccount, RBAC ×4, Deployment — **no CustomResourceDefinition** |
| `helm template` against the same chart | renders the CRD, because it has no cluster to look in and cannot tell the CRD is unowned |
| the next `helm upgrade` | finds the CRD owned, renders it, and it stays in the manifest for good |

The RBAC appearing four times is `rbac.yaml` rendering ClusterRole, ClusterRoleBinding, Role and RoleBinding — an exact match to what #84 observed.

## Why Pulumi looked responsible, and why it isn't

The reported cluster went 0.2.0 → 1.2.0, which *is* the adopting upgrade. It landed on the one revision where this is true, and `skipCrds` was never involved.

The outcome is itself the proof that `lookup` worked under Pulumi rather than being bypassed: had it returned empty — a client-side render — the CRD *would* have rendered, and the upgrade would have failed with `invalid ownership metadata` instead of succeeding. That is exactly what happens when you force the path, and it is now covered by an e2e spec.

I confirmed both branches on a throwaway kind cluster with the plain `helm` CLI, using `--dry-run=server` (which performs `lookup` without applying anything or running a hook):

| live CRD | rendered |
|---|---|
| unowned | adoption hook + ServiceAccount + RBAC ×4 + Deployment, **no CRD** |
| owned by this release | **CRD**, no adoption hook |

The lifecycle e2e suite has been exercising this whole path against the Helm CLI since #72 and passing — it just never asserted the manifest was empty of the CRD, which is precisely why nobody noticed.

## What changed

**`charts/reactor/templates/_helpers.tpl`** — `crds.adopt=false` against an unowned CRD is a promise to hand it over by hand. Until somebody does, Helm refuses the upgrade anyway, with a generic ownership error naming neither the value that declined the adoption nor the commands that finish the job. The chart now stops first and prints both. It does **not** silently freeze the schema — that concern from #84 does not reproduce; it always failed, just unhelpfully.

**`internal/adopt/crd.go`** — the adoption patch now applies the chart manifest's annotations alongside its spec, so an adopted CRD carries `helm.sh/resource-policy: keep` from the moment of adoption rather than from the next upgrade. The ownership pair is written *last*, so a mounted manifest can never redirect the live object at a release that does not exist. This is defence in depth, not a live hole: Helm deletes what is in the release manifest, and on that revision the CRD deliberately is not there.

**`test/e2e/lifecycle/upgrade_test.go`** — pins the two facts #84 was filed about (no CRD in the manifest on the adopting revision; `keep` live anyway because the hook carries it), plus two new specs for the `crds.adopt=false` refusal.

**Docs** — `charts/reactor/README.md` gains a section named after the symptom, `values.yaml` documents what `crds.adopt=false` actually does, and the troubleshooting guide's quoted error was stale and is corrected.

## What a v1.2 user has to change

**Nothing. No action is needed, and this PR does not change what a subsequent upgrade does on an already-adopted cluster.**

For a cluster sitting where the reported one is — v1.2.0, CRD owned by the release, serving the current schema, no `keep`:

- `reactor.crdAdoption` finds `meta.helm.sh/release-name` set and matching, so it returns empty. Neither changed branch is reachable: the `crds.adopt=false` failure requires an *unowned* CRD, and the adoption patch requires the hook, which does not render.
- The next upgrade renders `crds.yaml`, Helm applies it against a CRD it already owns, and `helm.sh/resource-policy: keep` arrives with it. That was already true before this PR — the fix only moves *when* `keep` arrives for clusters that have **not yet** adopted.

I verified that transition end to end on the probe cluster: an owned CRD with no `keep`, plus one release applying the template, ends with `keep` on the live object and the CRD back in the manifest.

The one thing worth knowing while a cluster is on that revision: do not set `crds.adopt=false` expecting it to be a no-op. On an already-adopted cluster it is one. On a cluster that has not adopted yet, it stops the upgrade — which is the honest outcome, and now says so.

## Verification

- `make test` ✅ · `make lint` ✅ (0 issues) · `make manifests docs` ✅ no drift
- `make test-lifecycle` ✅ **22 of 22 specs passed**, in its own kind cluster, torn down after

Every `helm` and `kubectl` invocation was context-pinned; the harness refuses any context that is not a local kind one. No production cluster was touched at any point.

## Environment notes for the next person

Both cost real time here and are now in [contributing/development.md](docs/src/content/docs/contributing/development.md):

- **The e2e node port is fixed** (`test/e2e/kind-config.yaml`), so only one suite cluster can exist at a time. An orphaned cluster from a run whose cleanup never happened makes every later run fail at creation with `Bind for 127.0.0.1:30943 failed: port is already allocated`. I found and removed one such orphan — empty, 18 hours old, no releases or non-default namespaces, residue from a `make test-e2e`. Docker also holds the reservation for a few seconds after a teardown, so the first retry can fail for a reason that has already gone.
- **`noclobber`** turns `> run.log` into a refusal rather than an overwrite. The run never starts and the *previous* run's log stays on disk, which is indistinguishable from a run that failed identically several times over. Use `>|`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CRD adoption to preserve chart annotations while correctly applying Helm ownership metadata.
  * Added clear upgrade failures and manual recovery instructions when adoption is disabled or incomplete.
  * Ensured unowned CRDs remain unchanged when adoption is disabled.

* **Documentation**
  * Clarified CRD adoption behavior, including differences between `helm get manifest` and `helm template`.
  * Added troubleshooting guidance for Kind node-port conflicts and existing test log files.

* **Tests**
  * Expanded coverage for CRD annotations, adoption failures, and upgrade manifest behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->