### PR TITLE
fix(testdata): file the ISP fields and the counts in the replace-the-value tier

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ So, concretely:
 
 - **Never paste a raw API response into a test, a fixture, or an issue.** Not "just this once", not with a couple of fields blanked out.
 - **Never hand-edit a committed capture** to look sanitized. Fix the allowlist and capture again.
-- `hack/verify-testdata.sh` runs as part of `make test` and rejects unredacted secret fields, routable IPs, and real MACs. It is the safety net, not the mechanism — passing it is not evidence that a hand-made fixture is safe.
+- `hack/verify-testdata.sh` runs as part of `make test` and rejects unredacted secret fields, routable IPs, real MACs, and carrier fields that are not the placeholder. It is the safety net, not the mechanism — passing it is not evidence that a hand-made fixture is safe.
 - Webhook captures follow the same discipline. `hack/webhook-logger.mjs` writes deliveries verbatim to a gitignored directory; allowlist them before committing anything.
 
 [`testdata/unifi/README.md`](testdata/unifi/README.md) documents what each fixture contains and which mappings are inferred rather than observed.

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Each key is published only when the matching hardware is adopted by your control
 | --- | --- | --- |
 | `wan` | `primary`, `backup` | which uplink the gateway is currently using |
 | `wan.quality` | `good`, `degraded` | how well that uplink has been performing, against the configured thresholds |
-| `isp` | a slug, e.g. `telenet`, or `unknown` | the carrier behind the live uplink |
+| `isp` | a slug, e.g. `example-telecom`, or `unknown` | the carrier behind the live uplink |
 | `internet` | `ok`, `degraded`, `down` | whether the outside world is reachable at all |
 | `ups` | `online`, `on-battery` | whether a UniFi UPS is on mains or running on battery |
 | `ups.battery` | `normal`, `low`, `critical` | remaining charge against the configured thresholds |
@@ -194,7 +194,7 @@ Each key is published only when the matching hardware is adopted by your control
 
 ```sh
 kubectl -n reactor-system logs deploy/reactor | grep 'key=isp'
-# INFO state transition provider=unifi key=isp from= to=telenet
+# INFO state transition provider=unifi key=isp from= to=example-telecom
 ```
 
 A key that stops being reported is **held**, not treated as a condition that ended — losing sight of the hardware must not scale workloads back up mid-outage.

--- a/docs/src/content/docs/contributing/adding-a-provider.md
+++ b/docs/src/content/docs/contributing/adding-a-provider.md
@@ -313,7 +313,7 @@ Parsers are written against real captured responses, never against assumed forma
 
 For a new provider, add a `hack/capture-<provider>.sh` in the same shape as `hack/capture-unifi.sh`: fetch, project down to the allowlisted fields with `jq`, replace the few remaining identifying values with placeholders (documentation-range IPs, fixed dummy MACs and IDs), write into `testdata/<provider>/`. Supporting a new field in your parser means adding it to that allowlist deliberately, one at a time.
 
-**Extend the safety net.** `hack/verify-testdata.sh` runs as part of `make test` and rejects unredacted secret fields, routable IPs, and real MACs. Add your provider's secret-bearing field names to it. The script is the net; the capture script is the mechanism. Never hand-edit a captured response into "safe" — capture it again with the allowlist fixed.
+**Extend the safety net.** `hack/verify-testdata.sh` runs as part of `make test` and rejects unredacted secret fields, routable IPs, real MACs, and carrier fields that are not the placeholder. Add your provider's secret-bearing field names to it. The script is the net; the capture script is the mechanism. Never hand-edit a captured response into "safe" — capture it again with the allowlist fixed.
 
 **Write a `testdata/<provider>/README.md`** recording what hardware and what software version produced the captures, which fields each file documents, and which mappings are *inferred* rather than observed. The UniFi one flags that the `wan` mapping has never seen a real failover, and that honesty is worth more than the fixture.
 

--- a/docs/src/content/docs/contributing/development.md
+++ b/docs/src/content/docs/contributing/development.md
@@ -256,7 +256,7 @@ The script **keeps an explicit allowlist of fields and discards everything else*
 
 This is allowlist rather than denylist for a reason: `stat/device` returns whole device records containing management keys, syslog keys, and adoption identifiers, and the parser needs a dozen fields out of hundreds. An earlier version of these fixtures stripped the sensitive fields someone thought of instead of keeping only the needed ones, and a live credential reached this repository's history as a result.
 
-`make test` runs `hack/verify-testdata.sh`, which rejects unredacted secret fields, routable IPs, and real MACs. That is the safety net; the capture script is the mechanism.
+`make test` runs `hack/verify-testdata.sh`, which rejects unredacted secret fields, routable IPs, real MACs, and carrier fields that are not the placeholder. That is the safety net; the capture script is the mechanism.
 
 `hack/webhook-logger.mjs` dumps incoming webhook deliveries verbatim to `testdata/unifi/webhooks/raw/` (gitignored) when capturing from a real Alarm Manager. Apply the same allowlist discipline before committing any of it.
 

--- a/docs/src/content/docs/design/spec.md
+++ b/docs/src/content/docs/design/spec.md
@@ -38,7 +38,7 @@ A homelab often needs to react to those events.
 For example:
 
 ```text
-Telenet WAN fails
+Primary WAN fails
         ↓
 UDM switches to U5G backup
         ↓
@@ -51,7 +51,7 @@ large downloads stop
 backup jobs stop
 bandwidth-heavy workloads scale down
         ↓
-Telenet returns
+primary WAN returns
         ↓
 Reactor receives recovery event
         ↓

--- a/docs/src/content/docs/guides/pause-downloads-on-a-metered-connection.md
+++ b/docs/src/content/docs/guides/pause-downloads-on-a-metered-connection.md
@@ -172,7 +172,7 @@ non-alphanumeric turned into a hyphen. Look yours up before matching on it:
 
 ```sh
 kubectl -n reactor-system logs deploy/reactor | grep 'key=isp'
-# INFO state transition provider=unifi key=isp from= to=telenet
+# INFO state transition provider=unifi key=isp from= to=example-telecom
 ```
 
 It is debounced at 2 samples, because a geolocation lookup on a freshly assigned

--- a/docs/src/content/docs/state-keys/index.md
+++ b/docs/src/content/docs/state-keys/index.md
@@ -11,7 +11,7 @@ Each key is published only when the matching hardware is adopted by your control
 | --- | --- | --- |
 | `wan` | `primary`, `backup` | which uplink the gateway is currently using |
 | `wan.quality` | `good`, `degraded` | how well that uplink has been performing, against the configured thresholds |
-| `isp` | a slug, e.g. `telenet`, or `unknown` | the carrier behind the live uplink |
+| `isp` | a slug, e.g. `example-telecom`, or `unknown` | the carrier behind the live uplink |
 | `internet` | `ok`, `degraded`, `down` | whether the outside world is reachable at all |
 | `ups` | `online`, `on-battery` | whether a UniFi UPS is on mains or running on battery |
 | `ups.battery` | `normal`, `low`, `critical` | remaining charge against the configured thresholds |
@@ -29,7 +29,7 @@ Each key is published only when the matching hardware is adopted by your control
 
 ```sh
 kubectl -n reactor-system logs deploy/reactor | grep 'key=isp'
-# INFO state transition provider=unifi key=isp from= to=telenet
+# INFO state transition provider=unifi key=isp from= to=example-telecom
 ```
 
 — and use it when *who* is carrying your traffic is what matters rather than which port it leaves by, which is usually the case for anything metered:

--- a/docs/src/content/docs/troubleshooting/state-keys.md
+++ b/docs/src/content/docs/troubleshooting/state-keys.md
@@ -145,7 +145,7 @@ the `wlan` subsystem's AP counts rather than from its `status` string, so:
 | --- | --- |
 | `The wlan subsystem reports no AP counts` (debug) | `num_adopted` or `num_disconnected` is missing. Neither is read as zero, so the key is withheld |
 | `No access point is adopted` (debug) | Zero adopted APs — there is no WiFi here to be healthy. Not the same as `ok` |
-| `wifi: warning` you cannot explain | The debug line names the numbers: `wifi wifi=warning adopted=3 disconnected=1 connected=2`. One of your APs is out of contact — `devices` and the per-device keys say which |
+| `wifi: warning` you cannot explain | The debug line names the numbers: `wifi wifi=warning adopted=4 disconnected=1 connected=3`. One of your APs is out of contact — `devices` and the per-device keys say which |
 | `The console's own wlan status and the value derived from its AP counts disagree` | UniFi's own wording and the counts have parted company. The counts are what `wifi` reports. If this fires steadily, UniFi's `warning` means something the counts do not — worth reporting on [#9](https://github.com/robbeverhelst/unifi-reactor/issues/9) |
 
 The same granularity applies to the UPS keys. `ups.runtime` is published only

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -24,11 +24,42 @@ api() {
   curl -sk --fail -m 20 -H "X-API-KEY: $UNIFI_API_KEY" "$UNIFI_URL/proxy/network/api/s/$SITE/$1"
 }
 
-# Placeholders. Real values never reach disk.
+# --- the two tiers ----------------------------------------------------------
+# Everything that survives the allowlist below is in exactly one of two tiers,
+# and adding a field means filing it in one of them on purpose:
+#
+#   1. kept as captured — the value is API shape. Subsystem names, statuses,
+#      firmware versions, relay states, battery telemetry. A reader learns
+#      something about UniFi from it and nothing about whose console it is.
+#   2. kept in shape, value replaced — the field is API shape but its value
+#      describes this particular household. Public IPs, MACs, device _ids,
+#      device and port and outlet names, the carrier, and the counts.
+#
+# Tier 2 is not "the sensitive fields": none of it is a credential. It is "the
+# fields whose value is about the owner rather than about the API". isp_name
+# and isp_organization sat in tier 1 through two releases because nobody put
+# that question to them — they are real fields a parser reads, so being in the
+# allowlist at all looked like the deliberate decision. See #94. Being read is
+# what earns a field a place here; it is not what earns its value one.
+
+# Tier 2 placeholders. Real values never reach disk.
 PUB_IP='203.0.113.10'   # TEST-NET-3
 GW_IP='203.0.113.1'
 MAC='aa:bb:cc:00:11:22'
 DEVICE_ID='000000000000000000000042'   # the outlet write PUTs to rest/device/<_id>
+# Two words, so a fixture still exercises the slugifier's space rule, and
+# unmistakably not a carrier anybody buys service from.
+ISP='Example Telecom'
+ISP_ORG='Example Telecom NV'
+# One placeholder site for every count. A stat/health response counts the
+# household — the people, their phones, the access points on their walls — and
+# none of that is API shape. Only three counts are read by anything
+# (num_adopted, num_disconnected and num_ap on the wlan subsystem) and they are
+# read as none/some/all rather than as numbers, so scaling every count onto
+# this site costs no fidelity and keeps num_ap + num_disconnected == num_adopted.
+CLIENTS=10    # any non-zero number of clients or stations
+DEVICES=4     # adopted devices, and adopted access points
+GATEWAYS=1    # a site has one gateway: that is shape, not inventory
 
 # --- allowlists -------------------------------------------------------------
 # A WAN port: only what the uplink decision and the docs need.
@@ -55,6 +86,10 @@ WAN='{is_uplink, up, ifname, name, speed, ip: (if .ip then "'"$PUB_IP"'" else nu
 # reports, so a fixture carrying it is not pretending — it is the state every
 # console starts in, and the one Reactor refuses to switch.
 #
+# The carrier is replaced for the reason the public IP is. `isp` is a real
+# state key, so a fixture has to carry *a* carrier — it never had to carry the
+# true one, and the true one says which company bills this address.
+#
 # outlet_caps and outlet_overrides are here because the write path reads the
 # first and modifies the second. Both were confirmed present on real hardware on
 # 2026-08-15; the fixture committed before that date predates this projection
@@ -76,7 +111,7 @@ DEVICE='{
   wan2: (if .wan2 then (.wan2 | '"$WAN"') else null end),
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),
   last_wan_status,
-  isp: (.active_geo_info.WAN.isp_name // null),
+  isp: (if .active_geo_info.WAN.isp_name then "'"$ISP"'" else null end),
   vbms_table,
   outlet_table: (if .outlet_table then [.outlet_table[] | {
     index, relay_state, relay_group, outlet_caps,
@@ -129,12 +164,36 @@ for pair in "switch:/tmp/cap-switch.json" "ap:/tmp/cap-ap.json"; do
   echo "  wrote stat-device-$kind.json"
 done
 
+# Every count here is scaled onto the placeholder site declared above. An
+# absent count stays absent and a zero stays zero — the parsers branch on both,
+# and "no guests" and "no access points adopted" are shapes rather than numbers
+# — while the AP triple keeps the only relation anything reads out of it:
+# whether none, some, or all of the adopted access points are disconnected.
 echo "capturing stat/health"
-api stat/health | jq '{meta: {rc: "ok"}, data: [.data[] | {
-  subsystem, status, num_user, num_guest, num_ap, num_adopted, num_disconnected, num_pending, num_gw, num_sta,
+api stat/health | jq '
+def scaled(n): if . == null then null elif . == 0 then 0 else n end;
+{meta: {rc: "ok"}, data: [.data[]
+  | . as $s
+  # The wan subsystem counts gateways; the others count devices and access
+  # points. Two placeholders, so num_adopted and num_gw cannot contradict.
+  | (if $s.subsystem == "wan" then '"$GATEWAYS"' else '"$DEVICES"' end) as $adopted
+  | (if ($s.num_disconnected // 0) == 0 then 0
+     elif ($s.num_disconnected // 0) >= ($s.num_adopted // 0) then $adopted
+     else 1 end) as $down
+  | {
+  subsystem, status,
+  num_user: (.num_user | scaled('"$CLIENTS"')),
+  num_guest: (.num_guest | scaled('"$CLIENTS"')),
+  num_ap: (if .num_ap == null then null else $adopted - $down end),
+  num_adopted: (.num_adopted | scaled($adopted)),
+  num_disconnected: (if .num_disconnected == null then null else $down end),
+  num_pending: (.num_pending | scaled(1)),
+  num_gw: (.num_gw | scaled('"$GATEWAYS"')),
+  num_sta: (.num_sta | scaled('"$CLIENTS"')),
   wan_ip: (if .wan_ip then "'"$PUB_IP"'" else null end),
   gateways: (if .gateways then ["'"$GW_IP"'"] else null end),
-  isp_name, isp_organization,
+  isp_name: (if .isp_name then "'"$ISP"'" else null end),
+  isp_organization: (if .isp_organization then "'"$ISP_ORG"'" else null end),
   uptime_stats
 } | with_entries(select(.value != null))]}' > "$OUT/stat-health.json"
 

--- a/hack/mock-unifi/main.go
+++ b/hack/mock-unifi/main.go
@@ -1019,7 +1019,7 @@ func (m *mock) rewriteUptimeStats(subsystem map[string]any) {
 }
 
 // rewriteWLAN applies the AP-count overrides, keeping num_ap consistent with
-// them: the capture has 2 connected alongside 3 adopted and 1 disconnected, and
+// them: the capture has 3 connected alongside 4 adopted and 1 disconnected, and
 // a mock that broke that arithmetic would be rehearsing a console nobody has.
 func (m *mock) rewriteWLAN(subsystem map[string]any) {
 	if m.apAdopted != nil {

--- a/hack/verify-testdata.sh
+++ b/hack/verify-testdata.sh
@@ -7,11 +7,50 @@
 # credential in a public repository.
 set -euo pipefail
 
-cd "$(dirname "$0")/.."
+# Resolved before the cd below, because the expected placeholders are a fact
+# about this repository's capture script rather than about the tree being
+# scanned.
+HACK_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# An optional root exists so the guards below can be exercised against a
+# throwaway tree of fixtures. With no argument this is the repository, which is
+# how make test and hack/capture-unifi.sh both run it.
+cd "${1:-$HACK_DIR/..}"
 failed=0
 
 # Fields that must never carry a real value.
 SECRET_FIELDS='x_authkey|syslog_key|serial|anon_id|device_id|hash_id|external_id|setup_id'
+
+# Fields whose value must be the placeholder the capture script writes, and
+# nothing else.
+#
+# The tempting guard here is a list of carrier names never to publish, and it
+# is the wrong way round: such a list has to contain the real value as a
+# literal, in this file, in a public repository — which is the thing being
+# removed, moved from a fixture to a script and labelled. It would also only
+# ever catch the one carrier somebody thought to add.
+#
+# Required-to-equal catches every carrier instead, names none of them, and is
+# the same move the MAC guard below already makes: the rule there is "inside
+# the aa:bb:cc prefix", not "not one of these MACs".
+#
+# The placeholders are read out of hack/capture-unifi.sh rather than repeated
+# here, so the value the capture writes and the value this requires cannot
+# drift apart.
+ISP_FIELDS='isp|isp_name|isp_organization'
+placeholder() { sed -n "s/^$1='\(.*\)'\$/\1/p" "$HACK_DIR/capture-unifi.sh"; }
+ISP_PLACEHOLDER="$(placeholder ISP)"
+ISP_ORG_PLACEHOLDER="$(placeholder ISP_ORG)"
+if [ -z "$ISP_PLACEHOLDER" ] || [ -z "$ISP_ORG_PLACEHOLDER" ]; then
+  echo "hack/capture-unifi.sh no longer declares ISP and ISP_ORG, so the carrier"
+  echo "guard below would accept anything. Fix that before trusting this script."
+  exit 1
+fi
+
+# The counts are deliberately not guarded. There is no positive rule to write —
+# every small integer is a plausible count — and enumerating forbidden ones
+# would be the same inverted mistake as a carrier denylist. The capture script
+# scaling them onto a placeholder site is the whole of the fix there.
 
 for file in testdata/unifi/api/*.json testdata/unifi/webhooks/*.json; do
   [ -e "$file" ] || continue
@@ -39,6 +78,23 @@ for file in testdata/unifi/api/*.json testdata/unifi/webhooks/*.json; do
       *) echo "$file: routable IP address: $hit"; failed=1 ;;
     esac
   done < <(grep -oE '\b([0-9]{1,3}\.){3}[0-9]{1,3}\b' "$file" | sort -u || true)
+
+  # A carrier field carrying anything but the placeholder. The offending value
+  # is deliberately not echoed: it is a real carrier by definition, and CI logs
+  # are as public as the fixture would have been.
+  while IFS= read -r hit; do
+    value="$(printf '%s' "$hit" | sed 's/.*: *"\(.*\)"$/\1/')"
+    case "$value" in
+      "$ISP_PLACEHOLDER"|"$ISP_ORG_PLACEHOLDER") continue ;;
+    esac
+    field="$(printf '%s' "$hit" | sed 's/^"\([a-z_]*\)".*/\1/')"
+    echo "$file: $field is not the placeholder carrier."
+    echo "  This capture was taken with the ISP fields in the tier that keeps the"
+    echo "  captured value. Move them to the replaced-value tier in"
+    echo "  hack/capture-unifi.sh, then re-derive the fixture by hand from the"
+    echo "  committed one — do not edit this value in place and do not re-capture."
+    failed=1
+  done < <(grep -oE "\"($ISP_FIELDS)\" *: *\"[^\"]*\"" "$file" | sort -u || true)
 
   # MACs must be inside the aa:bb:cc documentation-ish prefix used by the captures.
   while IFS= read -r hit; do

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -601,7 +601,7 @@ func ispFrom(d deviceRecord) string {
 }
 
 // slugify lowercases and collapses every run of non-alphanumeric characters
-// into a single hyphen, so "Telenet BV" becomes "telenet-bv".
+// into a single hyphen, so "Example Telecom NV" becomes "example-telecom-nv".
 func slugify(name string) string {
 	var b strings.Builder
 	b.Grow(len(name))

--- a/internal/providers/unifi/client_test.go
+++ b/internal/providers/unifi/client_test.go
@@ -95,7 +95,7 @@ func TestObserveAgainstCapturedGatewayAndUPS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Observe: %v", err)
 	}
-	// The captures were taken with WAN1 active, Telenet as the carrier, the
+	// The captures were taken with WAN1 active, a placeholder carrier, the
 	// UPS on mains at 97%, the www subsystem reporting ok, and WAN1 at 100%
 	// availability and 16 ms average latency.
 	for key, want := range map[string]string{

--- a/internal/providers/unifi/health.go
+++ b/internal/providers/unifi/health.go
@@ -63,9 +63,11 @@ type healthSubsystem struct {
 	// no counts is not a subsystem with zero APs, and zero adopted APs is a
 	// site with no WiFi rather than a site whose WiFi is fine.
 	//
-	// The capture carries all three — 2, 3 and 1 — and they are internally
-	// consistent: 2 connected plus 1 disconnected is the 3 that are adopted,
-	// which is what says NumAdopted is the denominator wifi should use.
+	// The capture carries all three — 3, 4 and 1 — and they are internally
+	// consistent: 3 connected plus 1 disconnected is the 4 that are adopted,
+	// which is what says NumAdopted is the denominator wifi should use. The
+	// counts are scaled onto a placeholder site by hack/capture-unifi.sh; that
+	// arithmetic is the part of them a capture is for.
 	NumAP           *int `json:"num_ap"`
 	NumAdopted      *int `json:"num_adopted"`
 	NumDisconnected *int `json:"num_disconnected"`

--- a/internal/providers/unifi/verify_testdata_test.go
+++ b/internal/providers/unifi/verify_testdata_test.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// hack/verify-testdata.sh requires the carrier fields in a capture to equal the
+// placeholder the capture script writes, rather than forbidding the carriers it
+// has seen. Required-to-equal is what makes the guard worth having: it catches
+// every carrier from every future capture, and it never has to name one, where
+// a list of forbidden names would have to carry the real value in a public file
+// to protect it (#94).
+//
+// A guard nothing exercises is a guard that can quietly stop matching — move
+// the check out of the loop, rename the variable it reads, and every capture
+// still passes. So these tests drive the script itself, in all three
+// directions: a real-looking carrier is rejected, the placeholder is accepted,
+// and the committed captures pass every guard in the file.
+//
+// The placeholders are read out of hack/capture-unifi.sh, which is where the
+// script under test reads them from too, so no test here has to repeat a value
+// that would then drift.
+
+const (
+	verifyTestdataScript = "verify-testdata.sh"
+	captureScript        = "capture-unifi.sh"
+)
+
+func hackScript(t *testing.T, name string) string {
+	t.Helper()
+	path := filepath.Join("..", "..", "..", "hack", name)
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("hack/%s is not reachable from here: %v", name, err)
+	}
+	return path
+}
+
+// runVerifyTestdata runs the script against root, or against the repository
+// when root is empty, and returns its combined output.
+func runVerifyTestdata(t *testing.T, root string) (string, error) {
+	t.Helper()
+	args := []string{hackScript(t, verifyTestdataScript)}
+	if root != "" {
+		args = append(args, root)
+	}
+	out, err := exec.Command("bash", args...).CombinedOutput()
+	return string(out), err
+}
+
+// placeholderCarrier reads one of the ISP placeholders out of the capture
+// script, the same way the guard under test does.
+func placeholderCarrier(t *testing.T, name string) string {
+	t.Helper()
+	script, err := os.ReadFile(hackScript(t, captureScript))
+	if err != nil {
+		t.Fatalf("reading hack/%s: %v", captureScript, err)
+	}
+	match := regexp.MustCompile(`(?m)^` + name + `='([^']*)'`).FindSubmatch(script)
+	if match == nil || len(match[1]) == 0 {
+		t.Fatalf("hack/%s no longer declares %s; the carrier guard has nothing to require", captureScript, name)
+	}
+	return string(match[1])
+}
+
+// captureWithCarrier writes a throwaway tree holding one capture whose only
+// interesting content is its carrier fields. Everything else about it passes
+// every other guard in the script: no secret fields, no routable addresses, no
+// real MACs.
+func captureWithCarrier(t *testing.T, name, organization string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "testdata", "unifi", "api")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("building a throwaway capture tree: %v", err)
+	}
+	fixture := fmt.Sprintf(
+		`{"meta":{"rc":"ok"},"data":[{"subsystem":"wan","status":"ok",`+
+			`"wan_ip":"203.0.113.10","isp_name":%q,"isp_organization":%q}]}`, name, organization)
+	if err := os.WriteFile(filepath.Join(dir, "stat-health.json"), []byte(fixture), 0o644); err != nil {
+		t.Fatalf("writing the throwaway capture: %v", err)
+	}
+	return root
+}
+
+// The carrier here is invented, and that is the point: the guard is not
+// checking against a list of known carriers, so any name that is not the
+// placeholder has to trip it.
+func TestACarrierThatIsNotThePlaceholderIsRejected(t *testing.T) {
+	root := captureWithCarrier(t, "Northwind Broadband", "Northwind Broadband PLC")
+
+	out, err := runVerifyTestdata(t, root)
+	if err == nil {
+		t.Fatalf("verify-testdata.sh accepted a capture carrying a real-looking carrier:\n%s", out)
+	}
+	for _, want := range []string{"isp_name", "isp_organization", "stat-health.json", "capture-unifi.sh"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("the failure should mention %q, so it says what is wrong and what to do; got:\n%s", want, out)
+		}
+	}
+	// Naming the offending value would put a real carrier in the CI log of a
+	// public repository, which is the thing this guard exists to prevent.
+	if strings.Contains(out, "Northwind") {
+		t.Errorf("the failure echoed the carrier it caught, got:\n%s", out)
+	}
+}
+
+func TestThePlaceholderCarrierIsAccepted(t *testing.T) {
+	root := captureWithCarrier(t,
+		placeholderCarrier(t, "ISP"), placeholderCarrier(t, "ISP_ORG"))
+
+	if out, err := runVerifyTestdata(t, root); err != nil {
+		t.Fatalf("verify-testdata.sh rejected the placeholder its own capture script writes:\n%s", out)
+	}
+}
+
+func TestTheCommittedCapturesPassEveryGuard(t *testing.T) {
+	if out, err := runVerifyTestdata(t, ""); err != nil {
+		t.Fatalf("the committed captures do not pass hack/verify-testdata.sh:\n%s", out)
+	}
+}

--- a/internal/providers/unifi/wan_test.go
+++ b/internal/providers/unifi/wan_test.go
@@ -46,8 +46,11 @@ import (
 const (
 	gatewayCapture = "stat-device-gateway.json"
 
-	// capturedISP is the carrier in the committed capture, and its slug.
-	capturedISP = "telenet"
+	// capturedISP is the slug of the carrier in the committed capture. The
+	// capture carries a placeholder name rather than the console's real one —
+	// the isp key is a real feature, so a fixture has to carry *a* carrier, and
+	// never had to carry the true one. See hack/capture-unifi.sh.
+	capturedISP = "example-telecom"
 
 	// backupCarrier is an obviously synthetic ISP name. The real backup carrier
 	// is unknown — the 5G uplink has never carried traffic — so inventing a
@@ -358,13 +361,13 @@ func TestAnUnknownCarrierIsNotACarrierChange(t *testing.T) {
 
 func TestISPNormalization(t *testing.T) {
 	for input, want := range map[string]string{
-		"Telenet":            capturedISP,
-		"Telenet BV":         "telenet-bv",
+		"Example Telecom":    capturedISP,
+		"Example Telecom NV": "example-telecom-nv",
 		"  Proximus  NV  ":   "proximus-nv",
 		"AT&T":               "at-t",
 		"Orange (Belgium)":   "orange-belgium",
 		"KPN B.V.":           "kpn-b-v",
-		"telenet":            "telenet",
+		"example telecom":    capturedISP,
 		"3 Ireland":          "3-ireland",
 		"":                   "",
 		"!!!":                "",

--- a/internal/providers/unifi/wifi.go
+++ b/internal/providers/unifi/wifi.go
@@ -36,7 +36,7 @@ import (
 //   - error becomes derivable. No capture has ever shown any subsystem saying
 //     "error", so mapping it through would be inference; "every adopted AP is
 //     disconnected" is an observation, and it is what error means here.
-//   - The two agree in the only capture there is — status "warning" with 1 of 3
+//   - The two agree in the only capture there is — status "warning" with 1 of 4
 //     adopted APs disconnected — so this is a sharpening of the console's
 //     verdict rather than a disagreement with it.
 //
@@ -73,8 +73,8 @@ func wifiFrom(ctx context.Context, subsystem healthSubsystem) string {
 		wifi = wifiWarning
 	}
 
-	// num_ap is the count of APs actually connected: in the capture it is 2
-	// alongside 3 adopted and 1 disconnected, which is the arithmetic that says
+	// num_ap is the count of APs actually connected: in the capture it is 3
+	// alongside 4 adopted and 1 disconnected, which is the arithmetic that says
 	// num_adopted is the right denominator. It is logged rather than derived
 	// from, so that a firmware where it stops adding up is visible here first.
 	log.V(1).Info("wifi", "wifi", wifi, "adopted", *adopted, "disconnected", *disconnected,

--- a/internal/providers/unifi/wifi_test.go
+++ b/internal/providers/unifi/wifi_test.go
@@ -27,10 +27,15 @@ func counts(t *testing.T, health *healthResponse, adopted, disconnected, connect
 	wlan.NumAdopted, wlan.NumDisconnected, wlan.NumAP = &adopted, &disconnected, &connected
 }
 
-// The capture was taken with 3 APs adopted, 1 disconnected and 2 connected, and
-// the console calling the subsystem "warning". Both signals agree on that
-// reading, which is the whole reason the counts are trusted as the sharper of
-// the two rather than as a contradiction of it.
+// The capture carries 4 APs adopted, 1 disconnected and 3 connected, with the
+// console calling the subsystem "warning". Both signals agree on that reading,
+// which is the whole reason the counts are trusted as the sharper of the two
+// rather than as a contradiction of it.
+//
+// The numbers themselves are a placeholder site — hack/capture-unifi.sh scales
+// every count in a capture, because how many access points somebody owns is
+// not API shape. What survives the scaling is what this test is about: the
+// arithmetic, and that none/some/all still lands where it did.
 func TestWiFiAgainstTheCapture(t *testing.T) {
 	health := capturedHealth(t)
 	wlan := subsystem(t, &health, healthSubsystemWLAN)
@@ -38,10 +43,10 @@ func TestWiFiAgainstTheCapture(t *testing.T) {
 		t.Fatalf("the capture's wlan status is %q, expected %q — this test is written against it",
 			wlan.Status, healthStatusWarning)
 	}
-	if wlan.NumAdopted == nil || *wlan.NumAdopted != 3 ||
+	if wlan.NumAdopted == nil || *wlan.NumAdopted != 4 ||
 		wlan.NumDisconnected == nil || *wlan.NumDisconnected != 1 ||
-		wlan.NumAP == nil || *wlan.NumAP != 2 {
-		t.Fatalf("the capture's wlan counts are not the 3/1/2 this test is written against: %+v", wlan)
+		wlan.NumAP == nil || *wlan.NumAP != 3 {
+		t.Fatalf("the capture's wlan counts are not the 4/1/3 this test is written against: %+v", wlan)
 	}
 
 	before := disagreements(t, signalWiFiStatusDisagrees)

--- a/test/e2e/reaction/fleet_test.go
+++ b/test/e2e/reaction/fleet_test.go
@@ -73,11 +73,11 @@ var _ = Describe("Reacting to the fleet, firmware, thermals, WiFi and PoE", Orde
 
 	BeforeAll(func() {
 		resetConsole()
-		// The capture itself has one of three access points disconnected, so
+		// The capture itself has one of four access points disconnected, so
 		// the console's own baseline is wifi: warning. This block starts from a
 		// healthy one and breaks it deliberately, rather than beginning
 		// half-broken.
-		Expect(mock.WiFi("adopted=3&disconnected=0")).To(Succeed())
+		Expect(mock.WiFi("adopted=4&disconnected=0")).To(Succeed())
 		for _, policy := range policies {
 			Expect(cluster.Apply(workload(policy.target, baseline))).To(Succeed())
 			Expect(cluster.Apply(scaleAutomation(policy.name, policy.when, policy.target, 0))).To(Succeed())
@@ -95,7 +95,7 @@ var _ = Describe("Reacting to the fleet, firmware, thermals, WiFi and PoE", Orde
 	// instead of releasing it. That is the behaviour half this file exists to
 	// prove, and it would hang the teardown of the other half.
 	AfterAll(func() {
-		Expect(mock.WiFi("adopted=3&disconnected=0")).To(Succeed())
+		Expect(mock.WiFi("adopted=4&disconnected=0")).To(Succeed())
 		Expect(mock.Temperature("celsius=45")).To(Succeed())
 		Expect(mock.PoE("watts=12&budget=60&silent=false")).To(Succeed())
 		Expect(mock.Firmware("upgradable=false")).To(Succeed())
@@ -142,7 +142,7 @@ var _ = Describe("Reacting to the fleet, firmware, thermals, WiFi and PoE", Orde
 		}).Should(Succeed())
 	})
 
-	// The capture's own wlan subsystem is the first half of this: 1 of 3 adopted
+	// The capture's own wlan subsystem is the first half of this: 1 of 4 adopted
 	// access points disconnected, which is what a real console was reporting
 	// when it was captured.
 	//
@@ -151,7 +151,7 @@ var _ = Describe("Reacting to the fleet, firmware, thermals, WiFi and PoE", Orde
 	// `warning` stops matching at `error`, because those are different values of
 	// one key rather than steps of a ladder. Match the value you mean.
 	It("sheds while access points are missing, and reports all of them gone as a different value", func() {
-		By("restoring the capture: 1 of 3 access points disconnected")
+		By("restoring the capture: 1 of 4 access points disconnected")
 		Expect(mock.WiFi("reset=true")).To(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(automationOf(g, wifiPolicy).Status.ObservedState).To(HaveKeyWithValue(keyWiFi, wifiWarning))
@@ -159,7 +159,7 @@ var _ = Describe("Reacting to the fleet, firmware, thermals, WiFi and PoE", Orde
 		}).Should(Succeed())
 
 		By("losing all of them, which is error rather than a worse warning")
-		Expect(mock.WiFi("adopted=3&disconnected=3")).To(Succeed())
+		Expect(mock.WiFi("adopted=4&disconnected=4")).To(Succeed())
 		Eventually(func(g Gomega) {
 			g.Expect(automationOf(g, wifiPolicy).Status.ObservedState).To(HaveKeyWithValue(keyWiFi, wifiError))
 			// An Automation matching `warning` no longer matches, so its claim

--- a/test/e2e/reaction/suite_test.go
+++ b/test/e2e/reaction/suite_test.go
@@ -290,7 +290,7 @@ var consoleAtRest = map[string]string{
 	keyUPSLoad:    upsLoadNormal,
 	keyInternet:   internetOK,
 	keyDevices:    devicesAllOnline,
-	// warning, not ok: the capture has one of three access points
+	// warning, not ok: the capture has one of four access points
 	// disconnected, so a console put back to it is half-broken by construction.
 	// The fleet specs start by fixing that; a reset does not.
 	keyWiFi:   wifiWarning,

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -8,11 +8,28 @@ Real responses from a UDM Pro (UniFi Network **10.5.67**, gateway firmware 5.1.2
 UNIFI_URL=https://192.168.1.1 UNIFI_API_KEY=<key> ./hack/capture-unifi.sh
 ```
 
-That script is the policy. **It keeps an explicit allowlist of fields and discards everything else**, then replaces the few remaining sensitive values with placeholders (public IPs become TEST-NET-3, MACs and site IDs become fixed dummies). Adding a field to a parser means adding it to the allowlist, deliberately, one at a time.
+That script is the policy. **It keeps an explicit allowlist of fields and discards everything else**, then replaces the value of some of the fields it keeps with a placeholder. Adding a field to a parser means adding it to the allowlist, deliberately, one at a time — and filing it in one of the two tiers below while you are there.
 
 The allowlist matters more than it looks. `stat/device` returns entire device records — roughly 8 KB each, containing device management keys (`x_authkey`), syslog keys, adoption identifiers, and full topology tables. The parser needs about a dozen fields. An earlier version of these fixtures was produced by *removing* the sensitive fields someone thought of rather than *keeping* only the needed ones, and a live credential reached this repository's history as a result. Allowlist, not denylist.
 
-`hack/verify-testdata.sh` runs as part of `make test` and rejects unredacted secret fields, routable IPs outside documentation ranges, and MACs outside the placeholder prefix. It is the safety net, not the mechanism.
+### The two tiers
+
+Surviving the allowlist is not one decision but two, and until [#94](https://github.com/robbeverhelst/unifi-reactor/issues/94) the second one was never written down. Every field that reaches a fixture is in exactly one of these:
+
+1. **Kept as captured** — the value *is* API shape. Subsystem names, statuses, firmware versions, relay states, battery telemetry. A reader learns something about UniFi from it and nothing about whose console it is.
+2. **Kept in shape, value replaced** — the field is API shape, but its value describes this particular household. Public IPs (TEST-NET-3), MACs and device `_id`s (fixed dummies), device, port and outlet names, the carrier, and every client and device count.
+
+Tier 2 is not "the sensitive fields": none of it is a credential. It is *the fields whose value is about the owner rather than about the API*, and that is the distinction which is easy to lose. `isp_name` and `isp_organization` sat in tier 1 through two releases carrying a real carrier, because being read by a parser is what puts a field in the allowlist and was mistaken for what keeps its value. Being read earns a field its place; it does not earn its value one.
+
+The counts are tier 2 for the same reason. `num_user`, `num_sta`, `num_ap`, `num_adopted` and the rest are an inventory — how many people are here and what they own — and only three of them are read by anything, as none/some/all rather than as numbers. So the script scales every count onto one placeholder site, keeping everything a parser can see: an absent count stays absent, a zero stays zero, and `num_ap + num_disconnected` still equals `num_adopted`.
+
+`hack/verify-testdata.sh` runs as part of `make test` and rejects unredacted secret fields, routable IPs outside documentation ranges, MACs outside the placeholder prefix, and carrier fields that are not the placeholder. It is the safety net, not the mechanism.
+
+That last check is required-to-equal rather than forbidden-to-be, and the direction is the whole of its value. A list of carrier names never to publish would have to hold the real one as a literal, in a public file, which is the thing being removed rather than a guard against it — and it would only ever catch the carriers somebody thought to add. Requiring `isp`, `isp_name` and `isp_organization` to equal what `hack/capture-unifi.sh` writes catches *every* carrier from every future capture and names none of them. It is also how the MAC guard already reasons: the rule there is "inside the `aa:bb:cc` prefix", not "not one of these MACs".
+
+The placeholders are read out of the capture script, so the value a capture writes and the value the guard requires cannot drift apart.
+
+The counts are deliberately unguarded. There is no positive rule to write — every small integer is a plausible count — and enumerating forbidden ones would be the same inverted mistake. The capture script scaling them is the whole of the fix there.
 
 ## Files
 
@@ -34,7 +51,7 @@ Captured with WAN1 (ethernet) active and WAN2 (SFP+) enabled but down. Four fiel
 | --- | --- | --- |
 | `wan1.is_uplink` / `wan2.is_uplink` | `true` / `false` | derives `wan: primary \| backup`. **The signal of record**, and the unverified one |
 | `uplink.name` | `eth8`, matching `wan1.ifname` | independent second opinion, matched against each port's `ifname`. Used when `is_uplink` names no single live port; otherwise only to report disagreement |
-| `isp` | `Telenet` | published as the `isp` state key, slugified. Compared with `wan` across observations: if one moves and the other does not, that is logged |
+| `isp` | `Example Telecom` — a placeholder, see [below](#the-two-tiers) | published as the `isp` state key, slugified. Compared with `wan` across observations: if one moves and the other does not, that is logged |
 | `last_wan_status` | `{"WAN": "online"}` | never derived from — only `online` has ever been seen, so the failed value is unknown. Used only to notice the live uplink not calling itself online |
 
 > ⚠️ **The mapping is inferred, not observed.** No real failover has been captured, so which of these fields actually moves during one is unconfirmed — including whether `is_uplink` means "is carrying traffic" or "is configured as the uplink". See issue #34, and the runbook below for how to settle it.
@@ -105,14 +122,14 @@ The third key from this capture, and the only one in the `device.<name>`/
 
 | Field | In the capture | What the provider does with it |
 | --- | --- | --- |
-| `num_adopted` | `3` | the denominator: how many APs this site owns |
+| `num_adopted` | `4` | the denominator: how many APs this site owns |
 | `num_disconnected` | `1` | some → `warning`, all → `error`, none → `ok` |
-| `num_ap` | `2` | never derived from — logged, because `2 + 1 = 3` is the arithmetic that says `num_adopted` is the right denominator |
+| `num_ap` | `3` | never derived from — logged, because `3 + 1 = 4` is the arithmetic that says `num_adopted` is the right denominator |
 | `status` | `warning` | never derived from either. Cross-checked against the counts, and a mismatch is counted as `wifi-status-disagrees` |
 
 `wifi` comes from the counts rather than from `status`, and issue
 [#9](https://github.com/robbeverhelst/unifi-reactor/issues/9) asked for that to be
-documented rather than left mysterious. The counts can be explained — "1 of 3
+documented rather than left mysterious. The counts can be explained — "1 of 4
 access points is disconnected" — and they make `error` *derivable*, where mapping
 the vendor string through would have been inference: no capture has ever shown
 any subsystem saying `error`, on any subsystem. Here the two agree exactly, which

--- a/testdata/unifi/api/stat-device-gateway.json
+++ b/testdata/unifi/api/stat-device-gateway.json
@@ -34,7 +34,7 @@
       "last_wan_status": {
         "WAN": "online"
       },
-      "isp": "Telenet",
+      "isp": "Example Telecom",
       "outlet_table": []
     }
   ]

--- a/testdata/unifi/api/stat-health.json
+++ b/testdata/unifi/api/stat-health.json
@@ -6,10 +6,10 @@
     {
       "subsystem": "wlan",
       "status": "warning",
-      "num_user": 9,
+      "num_user": 10,
       "num_guest": 0,
-      "num_ap": 2,
-      "num_adopted": 3,
+      "num_ap": 3,
+      "num_adopted": 4,
       "num_disconnected": 1,
       "num_pending": 0
     },
@@ -20,13 +20,13 @@
       "num_disconnected": 0,
       "num_pending": 0,
       "num_gw": 1,
-      "num_sta": 23,
+      "num_sta": 10,
       "wan_ip": "203.0.113.10",
       "gateways": [
         "203.0.113.1"
       ],
-      "isp_name": "Telenet",
-      "isp_organization": "Telenet BV",
+      "isp_name": "Example Telecom",
+      "isp_organization": "Example Telecom NV",
       "uptime_stats": {
         "WAN": {
           "alerting_monitors": [
@@ -130,7 +130,7 @@
     {
       "subsystem": "lan",
       "status": "ok",
-      "num_user": 14,
+      "num_user": 10,
       "num_guest": 0,
       "num_adopted": 4,
       "num_disconnected": 0,


### PR DESCRIPTION
Closes #94.

`hack/capture-unifi.sh` has always had two tiers, and only the first was ever written down:

1. **kept as captured** — the value *is* API shape (subsystem names, statuses, firmware versions, relay states, battery telemetry)
2. **kept in shape, value replaced** — the field is API shape but its value describes one particular household (the public IP, MACs, the device `_id`, device and port and outlet names)

`isp_name`, `isp_organization` and the gateway's `isp` were filed in tier 1, so the committed captures carried the console owner's real carrier — along with the client and device counts, which are the same class of detail. Nothing here is a credential and nothing is exploitable; it is a violation of the project rule that nothing personal lives in the repository, and that is the reason to fix it.

The failure is worth naming precisely: **being read by a parser is what earns a field a place in the allowlist, and that was mistaken for what earns its value one.** A field in the wrong tier is invisible to review, because the allowlist is the thing reviewers read and everything in it looks deliberate.

## What changed

- **Both tiers are named in the capture script**, so the next field added has to be filed on purpose.
- **The carrier is a placeholder** (`Example Telecom` / `Example Telecom NV`), two words so a fixture still exercises the slugifier's space-to-hyphen rule.
- **Every client and device count is scaled onto one placeholder site.** Only three counts are read by anything — `num_adopted`, `num_disconnected`, `num_ap` on the `wlan` subsystem — and they are read as none/some/all rather than as numbers. So the scaling keeps everything a parser can see: an absent count stays absent, a zero stays zero, and `num_ap + num_disconnected` still equals `num_adopted`. `num_pending` went with them; it is the same kind of number and splitting it off would have left the tiering incoherent.
- **The carrier guard in `hack/verify-testdata.sh` is required-to-equal, not forbidden-to-be.** `isp`, `isp_name` and `isp_organization` in any committed capture must equal the placeholder the capture script writes, and the placeholders are read out of `capture-unifi.sh` so the two cannot drift.
- **Counts are deliberately unguarded.** There is no positive rule to write — every small integer is a plausible count — and enumerating forbidden numbers would be the same inverted mistake. The scaling in the capture script is the whole of the fix there.
- **Tests drive the guard in all three directions**: an invented carrier is rejected, the placeholder is accepted, and the committed captures pass every guard in the file. The rejection test also asserts the script does *not* echo the offending value, since a real carrier in a public CI log is the thing being prevented.
- Docs and comments that named a carrier as the example `isp` value are updated — `testdata/unifi/README.md`, the root `README.md`, `design/spec.md`, `state-keys/index.md`, the metered-connection guide, `client.go` and the two test files.

## Why the guard is positive rather than a list of names

A list of carrier names never to publish has to contain the real value as a literal, in a public file, under a variable name advertising what it is. That moves the value from a fixture to a script and labels it; it does not remove it. It also only ever catches the carriers somebody thought to add.

Requiring equality with the placeholder catches **every** carrier from **every** future capture and names none of them. It is the same move the MAC guard in the same file already makes: the rule there is "inside the `aa:bb:cc` prefix", not "not one of these MACs".

## The fixtures were hand-edited, not re-captured

Deliberately. A re-capture needs a live console and reintroduces exactly the risk this issue is about — the capture path put a live credential in this repository's history once already.

The two edited files are a **fixed point of the new projection**: replaying the script's own `stat/health` filter over the edited fixture reproduces it exactly, key order included. That is the strongest check available without touching hardware, and it is what says the hand edit and the script agree about what a capture of this shape looks like.

## Verification

- `make test` — green, including `hack/verify-testdata.sh`
- `./hack/verify-testdata.sh` — passes on the scrubbed tree; fails on a tree whose capture names any other carrier
- `go vet -tags=e2e ./test/e2e/...` and `shellcheck` on both scripts — clean
- `git grep -i` for the old value over this branch's tree — no matches

## Not in scope

Rewriting history. The value is in the published history from the root commit onward, and a force-push over the whole of `main` is the repository owner's call, recorded on #94.