### PR TITLE
fix: derive the refused-action startup lines from the lists dispatch uses

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -468,7 +468,7 @@ func main() {
 	}
 	if destinations.Empty() {
 		setupLog.Info("Outbound actions disabled (no allowed destinations configured); " +
-			"http.request and notification.* actions will be refused")
+			strings.Join(actions.OutboundTypes(), ", ") + " actions will be refused")
 	}
 
 	if dryRun {
@@ -614,7 +614,7 @@ func setupUniFi(
 	switch {
 	case !writer.Enabled():
 		setupLog.Info("UniFi console actions disabled (nothing is allowlisted); " +
-			"unifi.wlan.* and unifi.poe.cycle actions will be refused")
+			strings.Join(actions.ConsoleTypes(), ", ") + " actions will be refused")
 	case !writer.Credentialed():
 		// Not fatal, on the same rule the webhook fast path follows: this is not
 		// the mechanism of record, and an operator whose poller works should not
@@ -625,7 +625,8 @@ func setupUniFi(
 	default:
 		setupLog.Info("UniFi console actions enabled",
 			"allowedWlans", len(cfg.Actions.AllowedWLANs),
-			"allowedPoePorts", len(cfg.Actions.AllowedPoEPorts))
+			"allowedPoePorts", len(cfg.Actions.AllowedPoEPorts),
+			"allowedOutlets", len(cfg.Actions.AllowedOutlets))
 	}
 	return writer, nil
 }

--- a/internal/actions/client.go
+++ b/internal/actions/client.go
@@ -25,6 +25,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"slices"
 	"time"
 )
 
@@ -54,15 +55,23 @@ const (
 	TypeQBittorrentResume = "qbittorrent.resume"
 )
 
+// outboundTypes is the one list of outbound action types, read by dispatch and
+// by the startup line naming what an empty destination policy refuses, for the
+// reason consoleTypes gives.
+var outboundTypes = []string{
+	TypeHTTPRequest, TypeNtfy, TypeDiscord, TypeSlack, TypeHomeAssistant,
+	TypeQBittorrentPause, TypeQBittorrentResume,
+}
+
 // IsOutbound reports whether an action type leaves the cluster, and so whether
 // it is one this package sends.
 func IsOutbound(actionType string) bool {
-	switch actionType {
-	case TypeHTTPRequest, TypeNtfy, TypeDiscord, TypeSlack, TypeHomeAssistant,
-		TypeQBittorrentPause, TypeQBittorrentResume:
-		return true
-	}
-	return false
+	return slices.Contains(outboundTypes, actionType)
+}
+
+// OutboundTypes returns every outbound action type, in declaration order.
+func OutboundTypes() []string {
+	return slices.Clone(outboundTypes)
 }
 
 const (

--- a/internal/actions/console.go
+++ b/internal/actions/console.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package actions
 
+import "slices"
+
 // The console action types: the edge actions that write to the console a
 // provider observes, rather than to an address an Automation named.
 //
@@ -84,14 +86,24 @@ const (
 	TypeUniFiOutletRestore = "unifi.outlet.restore"
 )
 
+// consoleTypes is the one list of console action types. Dispatch and the
+// startup line that names what an empty allowlist refuses both read it, so a
+// type added here is refused-by-name at startup without anyone remembering —
+// the outlet actions added in v1.3.0 were refused without the startup line
+// naming them (#99).
+var consoleTypes = []string{
+	TypeUniFiWLANEnable, TypeUniFiWLANDisable, TypeUniFiPoECycle,
+	TypeUniFiOutletCut, TypeUniFiOutletRestore,
+}
+
 // IsConsole reports whether an action type writes to a provider's own console,
 // and so whether it is executed by that provider rather than by this package's
 // outbound client.
 func IsConsole(actionType string) bool {
-	switch actionType {
-	case TypeUniFiWLANEnable, TypeUniFiWLANDisable, TypeUniFiPoECycle,
-		TypeUniFiOutletCut, TypeUniFiOutletRestore:
-		return true
-	}
-	return false
+	return slices.Contains(consoleTypes, actionType)
+}
+
+// ConsoleTypes returns every console action type, in declaration order.
+func ConsoleTypes() []string {
+	return slices.Clone(consoleTypes)
 }


### PR DESCRIPTION
Closes #99.

## Which fix, and why

The issue offered two routes: derive the list from where the action types are registered, or stop enumerating. I took the derive route, because it turned out to cost almost nothing: the registration point is effectively the `IsConsole` switch in `internal/actions`, and turning that switch into a slice that both dispatch and the startup line read is a handful of lines. The list is now data — `IsConsole`/`IsOutbound` are `slices.Contains` over it, and `cmd/main.go` joins it into the message — so the next console action shows up in the startup line by construction. A type added to the constants but not the slice would not dispatch at all, which is a much louder failure than a quiet omission from a log line.

The disabled line now reads:

```
UniFi console actions disabled (nothing is allowlisted); unifi.wlan.enable,
unifi.wlan.disable, unifi.poe.cycle, unifi.outlet.cut, unifi.outlet.restore
actions will be refused
```

## Sibling drift, as the issue asked

- The **outbound** line had drifted the same way: it named `http.request` and `notification.*` but not `homeassistant.service` or `qbittorrent.pause`/`resume`, which the empty destination policy also refuses. It now derives from the same list `IsOutbound` uses.
- The **"UniFi console actions enabled"** line logged `allowedWlans` and `allowedPoePorts` counts but not the outlet allowlist. It now logs `allowedOutlets` too.
- Nothing else in `cmd/main.go` hand-enumerates action or state types; the state vocabulary already comes from `unifi.StateVocabulary()`.

No CRD changes, no registry refactor beyond the switch→slice conversion above.

## Verification

- `make test` passes (it runs `go fmt`, `go vet`, `./hack/verify-testdata.sh`, and the full suite).
- `./hack/verify-testdata.sh` also run standalone: captures are sanitized.
- `make lint` reports four pre-existing findings, all in `api/v1alpha1/zz_generated.deepcopy.go` (generated) or a stale cache path outside the repo; none in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Action-disabled log messages now display the specific action that was refused.
  - UniFi console startup logs now include the number of allowed outlets.
  - Action type reporting is more consistent across outbound and console actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->