### PR TITLE
fix(unifi): recognise the transient device states, and stop the INFO drip

### DIFF
--- a/internal/providers/unifi/devices.go
+++ b/internal/providers/unifi/devices.go
@@ -26,15 +26,25 @@ import (
 	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
 )
 
-// The two values of the console's per-device state field this provider is
-// willing to read. UniFi documents others — provisioning, upgrading, heartbeat
-// missed, adoption pending — and none of them has been captured, so anything
-// else is treated as "this device says nothing" rather than being folded into
-// one of these. Reading an unfamiliar state as offline is how a firmware that
-// added a value would shed a cluster's load.
+// The two values of the console's per-device state field this provider
+// translates into a published value. UniFi's enum is wider: an independent Go
+// client for the same API carries Upgrading = 4, Provisioning = 5 and
+// HeartbeatMissing = 6, and state 5 has now been observed on real hardware
+// (#97) — three device classes entering it within the same second of a config
+// push, one of them re-entering it hours later. Those three are states a
+// healthy device passes through, so they are recognised below but still
+// deliberately not folded into online or offline: a device mid-provision is
+// genuinely neither, and reading an unfamiliar state as offline is how a
+// firmware that added a value would shed a cluster's load. Anything outside
+// this set — adoption pending is documented but has never been captured — is
+// treated as "this device says nothing".
 const (
 	deviceStateOffline = 0
 	deviceStateOnline  = 1
+
+	deviceStateUpgrading        = 4
+	deviceStateProvisioning     = 5
+	deviceStateHeartbeatMissing = 6
 )
 
 // deviceHealthFields are the fields the devices and device.<name> keys are
@@ -118,11 +128,19 @@ func (t *deviceTally) observe(ctx context.Context, d deviceRecord) {
 		value = deviceOnline
 	case deviceStateOffline:
 		value = deviceOffline
+	case deviceStateUpgrading, deviceStateProvisioning, deviceStateHeartbeatMissing:
+		// Not translated into a value: these are states a healthy device
+		// passes through, and reading any of them as offline would report a
+		// firmware update as a fleet outage. V(1) rather than INFO, because a
+		// site that pushes config regularly would otherwise produce a steady
+		// INFO drip that says nothing new after the first line (#97).
+		log.V(1).Info("A device reports a transient state; it counts towards neither devices nor a key of its own",
+			"state", *d.State, "model", d.Model, "type", d.Type)
+		return
 	default:
-		// An unrecognised state is not translated into a value, for the same
-		// reason an unrecognised www status is not: provisioning and upgrading
-		// are states a healthy device passes through, and reading either as
-		// offline would report a firmware update as a fleet outage.
+		// An unrecognised state is not translated into a value either, and it
+		// stays at INFO: a state this provider has never heard of is exactly
+		// what an operator should see and report.
 		log.Info("A device reports a state this provider does not recognise; it counts towards neither "+
 			"devices nor a key of its own. Please report it — the set of states is what this key is derived from",
 			"state", *d.State, "model", d.Model, "type", d.Type)

--- a/internal/providers/unifi/devices_test.go
+++ b/internal/providers/unifi/devices_test.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/go-logr/logr/funcr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // adoptedDevice is a device record in the shape the captures have: adopted,
@@ -140,11 +143,13 @@ func TestMissingStateIsNotAnOfflineDevice(t *testing.T) {
 	}
 }
 
-// Provisioning, upgrading and heartbeat-missed are states UniFi documents and
-// no capture has ever shown. None of them may be folded into offline: a fleet
-// mid-firmware-upgrade is not a fleet outage.
+// Neither the known transient states — upgrading, provisioning, heartbeat
+// missed — nor a value this provider has never heard of may be folded into
+// offline: a fleet mid-firmware-upgrade is not a fleet outage. State 5 is the
+// one real hardware has shown (#97), so it is pinned here by constructing the
+// record directly; no capture carries it.
 func TestUnrecognisedDeviceStateIsNeitherOnlineNorOffline(t *testing.T) {
-	for _, state := range []int{2, 4, 5, 6, 11, -1} {
+	for _, state := range []int{2, deviceStateUpgrading, deviceStateProvisioning, deviceStateHeartbeatMissing, 11, -1} {
 		odd := adoptedDevice("Provisioning", state)
 		got := fleetState(t, true, adoptedDevice("Switch 48", deviceStateOnline), odd)
 
@@ -154,6 +159,31 @@ func TestUnrecognisedDeviceStateIsNeitherOnlineNorOffline(t *testing.T) {
 		if value, present := got[stateKeyDevicePrefix+"provisioning"]; present {
 			t.Errorf("state %d should publish no key of its own, got %q", state, value)
 		}
+	}
+}
+
+// The INFO level is reserved for states this provider has genuinely never
+// heard of, because those are worth an operator's attention. The known
+// transient states are something a healthy site produces every config push,
+// so they must not add an INFO line per device per poll (#97) — they speak at
+// V(1) only, which the verbosity-0 logger here drops.
+func TestKnownTransientStatesDoNotLogAtInfo(t *testing.T) {
+	var sink strings.Builder
+	ctx := logf.IntoContext(context.Background(), funcr.New(func(prefix, args string) {
+		sink.WriteString(prefix + " " + args + "\n")
+	}, funcr.Options{}))
+
+	tally := newDeviceTally(false)
+	for _, state := range []int{deviceStateUpgrading, deviceStateProvisioning, deviceStateHeartbeatMissing} {
+		tally.observe(ctx, adoptedDevice("Core Switch", state))
+	}
+	if got := sink.String(); got != "" {
+		t.Errorf("a known transient state should say nothing at INFO, got %q", got)
+	}
+
+	tally.observe(ctx, adoptedDevice("Core Switch", 11))
+	if got := sink.String(); !strings.Contains(got, "does not recognise") {
+		t.Errorf("a genuinely unknown state should keep the please-report INFO line, got %q", got)
 	}
 }
 


### PR DESCRIPTION
Closes #97.

State 5 is provisioning — observed on real hardware, cross-checked against an independent Go client for the same API, which also carries 4 = upgrading and 6 = heartbeat missing. This PR does the first two of the issue's three points and files the third.

**What stays the same.** All three states remain outside the online/offline tally, exactly as before: a device mid-provision is genuinely neither, and reading an unfamiliar state as offline is how a firmware that added a value would shed a cluster's load. No published key or value changes.

**What changes.**
1. The comment justifying the `default` branch said none of the other states had been captured. That sentence was load-bearing and is now false, so it records what #97 observed instead.
2. The known transient states (4, 5, 6) now log at V(1). A site that pushes config regularly produced a steady per-device-per-poll INFO drip that said nothing new after the first line. Genuinely unknown states keep the please-report INFO line — those really are worth an operator's attention, and #97 itself is that line working.

**What is deliberately not here.** A device stuck in a transient state is still invisible to `devices`. Surfacing it needs either a third `devices` value or a new key, plus a duration threshold and cross-poll memory the tally does not have — API decisions, not implementation. Filed as #101 with the reasoning rather than guessed at here.

**Testing.** No fixture carries state 5 (the capture allowlist cannot produce one), so it is pinned by constructing the record directly: the existing tally test now names the transient states, and a new test asserts the log-level split — a verbosity-0 logger sees nothing for 4/5/6 and still sees the please-report line for a state nobody has heard of. `make test` and `./hack/verify-testdata.sh` pass; the changed package lints clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)