### PR TITLE
fix(unifi): collect every wanN so a cellular failover reads backup

### DIFF
--- a/docs/src/content/docs/state-keys/wan-and-internet.md
+++ b/docs/src/content/docs/state-keys/wan-and-internet.md
@@ -3,6 +3,19 @@ title: "WAN and internet state keys"
 description: "wan says which uplink is selected, internet says whether the outside world is reachable at all, and wan.quality says whether the link has been any good. Three different questions."
 ---
 
+## `wan` covers every uplink the gateway reports
+
+`wan` is derived from every `wanN` block in the gateway's device record — `wan1`, `wan2`, `wan3`, however many the console reports. The numbering carries exactly one meaning: `wan1` is the **primary**, and every uplink above it is a **backup**. The vocabulary stays two values no matter how many uplinks exist, so a gateway with a wired secondary *and* a cellular tertiary reads `backup` for either of them — `wan` says the primary is not carrying the traffic, not which link is or what it costs. Whether a cellular backup should be distinguishable from a wired one is tracked as [#105](https://github.com/robbeverhelst/unifi-reactor/issues/105).
+
+A cellular backup is not a physical WAN port. The gateway reports it as a tunnel interface (`gre1` on the hardware this was verified against) whose `wanN` entry carries **no `is_uplink` field at all** — absent, not `false`. So on a failover to cellular the `is_uplink` signal names nobody, and the second signal is what resolves the key: the gateway names its own uplink interface, that name matches the cellular entry's `ifname`, and `wan` reads `backup`. The log line `is_uplink does not name a single live WAN port` accompanies this, and on cellular hardware it is the expected path rather than a fallback misfiring — see [the troubleshooting entry](/troubleshooting/state-keys/#10-wan-and-isp-disagree-about-a-failover).
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      wan: backup      # the primary uplink is not the one carrying traffic
+```
+
 ## `internet` is the one `wan` cannot express
 
 `wan` says which uplink is *selected*. It stays `primary` when the link is up, the uplink is unchanged, and there is no internet — the failure your gateway's own failover may never act on, because from the gateway's point of view nothing is wrong. `internet` is the key for that case, and it comes from a different place: the console's own `www` health subsystem, which is its judgement about reachability rather than about link state.

--- a/docs/src/content/docs/troubleshooting/state-keys.md
+++ b/docs/src/content/docs/troubleshooting/state-keys.md
@@ -93,8 +93,8 @@ kubectl -n reactor-system logs deploy/reactor | grep unifi-wan
 | `The ISP behind the uplink changed but the gateway still reports the same uplink` | Your traffic moved to a different carrier while `wan` did not move. If that was a failover, `wan` missed it. | Same — this is the observation issue #34 is open for |
 | `The gateway changed uplink but the ISP behind it did not change` | `wan` moved without your carrier changing. Normal if both uplinks are with the same ISP; suspicious otherwise. | Nothing, unless your two uplinks are with different carriers |
 | `The uplink believed to be live does not report itself as online` | The port Reactor thinks is carrying traffic reports something other than `online` in `last_wan_status`. | Note the exact status value on [#34](https://github.com/robbeverhelst/unifi-reactor/issues/34) — only `online` has ever been observed, and the failed value is unknown |
-| `is_uplink does not name a single live WAN port` | No port claimed the uplink, or both did. Reactor fell back to the gateway's uplink interface. | Nothing; this is the fallback working. Worth reporting if it persists rather than appearing for one poll during a switchover |
-| `The health endpoint accumulated uptime on an uplink other than the one wan names` | A **third** signal, from a different endpoint, disagrees — and the strongest one, because uptime is traffic the console watched pass rather than a statement about configuration. | This is the most useful thing you can report on [#34](https://github.com/robbeverhelst/unifi-reactor/issues/34). Post the `uptime_stats` block alongside the `wan1`/`wan2` fields |
+| `is_uplink does not name a single live WAN port` | No port claimed the uplink, or more than one did. Reactor fell back to the gateway's uplink interface. | Nothing; this is the fallback working. On a failover to a **cellular** backup it is the expected path for as long as cellular carries the traffic — a cellular uplink never reports `is_uplink` at all, so the uplink interface is the signal that resolves it ([#104](https://github.com/robbeverhelst/unifi-reactor/issues/104)). On all-wired gateways it is worth reporting if it persists rather than appearing for one poll during a switchover |
+| `The health endpoint accumulated uptime on an uplink other than the one wan names` | A **third** signal, from a different endpoint, disagrees — and the strongest one, because uptime is traffic the console watched pass rather than a statement about configuration. | This is the most useful thing you can report on [#34](https://github.com/robbeverhelst/unifi-reactor/issues/34). Post the `uptime_stats` block alongside every `wanN` block's fields |
 
 None of these stops anything: state is still published and Automations still run. They exist
 because the `wan` mapping has never been checked against a real failover, and a wrong mapping
@@ -316,6 +316,37 @@ Outlet state changed. If you are running the relay-group experiment on issue #60
 relay group is the switching unit. Either way, post it on
 [#60](https://github.com/robbeverhelst/unifi-reactor/issues/60) — that one line
 is what unblocks #23.
+
+---
+
+## 10g. `wan` disappeared during a failover
+
+The symptom: `wan` read `primary`, the gateway failed over, and instead of
+`backup` the key *vanished* — `StateKeyUnavailable` on every Automation
+matching it, and a `when: {wan: backup}` Automation that never fired. A
+missing key holds the last decision (see
+[§2](#2-statekeyunavailable-and-held-state)), so the automation written for
+exactly this failover stayed quiet through it: the last thing it observed was
+"not matching, the primary is fine".
+
+On releases carrying the fix for
+[#104](https://github.com/robbeverhelst/unifi-reactor/issues/104) the known
+cause is gone: a gateway with a cellular backup reports it as a **third** WAN
+(`wan3`), Reactor used to decode exactly two, and on failover the live uplink
+matched nothing it had decoded. Every `wanN` the gateway reports is now
+collected, so that failover reads `backup`.
+
+If the key still disappears on a current release, the gateway is uplinked
+through an interface that matches no `wanN` entry at all — a combination this
+mapping has not seen. Confirm, then report it:
+
+```sh
+kubectl -n reactor-system logs deploy/reactor | grep "wan will not be published"
+```
+
+Post the gateway's `uplink.name` and the `ifname` of every `wanN` block on
+[#104](https://github.com/robbeverhelst/unifi-reactor/issues/104), with
+addresses removed.
 
 ---
 

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -107,8 +107,6 @@ DEVICE='{
     port_idx, poe_enable, poe_power, poe_class, is_uplink, port_poe,
     name: ("port-" + (.port_idx | tostring))
   }] else null end),
-  wan1: (if .wan1 then (.wan1 | '"$WAN"') else null end),
-  wan2: (if .wan2 then (.wan2 | '"$WAN"') else null end),
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),
   last_wan_status,
   isp: (if .active_geo_info.WAN.isp_name then "'"$ISP"'" else null end),
@@ -121,7 +119,16 @@ DEVICE='{
     index, relay_state, cycle_enabled,
     name: ("Outlet " + (.index | tostring))
   }] else null end)
-} | with_entries(select(.value != null))'
+}
+# Every wanN the console reports, through the WAN projection above. This used
+# to name wan1 and wan2, which is how a gateway with a cellular backup — which
+# reports it as wan3 — could never produce a fixture reproducing #104. The wanN
+# fields themselves stay in the allowlist one at a time exactly as before; what
+# is dynamic is only which N exist. mbb is deliberately NOT projected: nothing
+# reads it, and it carries a cell_id and a modem MAC, which under the #94 rule
+# would put it in the replace-the-value tier before it could ever be committed.
++ (with_entries(select((.key | test("^wan[0-9]+$")) and .value != null)) | map_values('"$WAN"'))
+| with_entries(select(.value != null))'
 
 echo "capturing stat/device -> gateway + UPS"
 api stat/device > /tmp/cap-device.json

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -25,6 +25,7 @@ import (
 	"maps"
 	"net/http"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -189,11 +190,17 @@ type deviceStatResponse struct {
 }
 
 type deviceRecord struct {
-	Model  string     `json:"model"`
-	Type   string     `json:"type"`
-	Name   string     `json:"name"`
-	WAN1   *wanPort   `json:"wan1"`
-	WAN2   *wanPort   `json:"wan2"`
+	Model string `json:"model"`
+	Type  string `json:"type"`
+	Name  string `json:"name"`
+	// WANs is every wanN block the record carries, in index order, collected by
+	// UnmarshalJSON below. It is deliberately not a fixed set of named fields:
+	// this struct once declared wan1 and wan2 because that is what the author's
+	// gateway had, and a gateway with a cellular backup reports the cellular
+	// uplink as wan3 — which was then silently never decoded, and the wan key
+	// vanished on the exact failover it exists to report (#104). How many wanN
+	// a gateway can carry is unknown, so the only safe list is "all of them".
+	WANs   []wanEntry `json:"-"`
 	Uplink *uplinkRef `json:"uplink"`
 	// ISP is the capture's name for active_geo_info.WAN.isp_name — the carrier
 	// the console geolocated the current public address to.
@@ -216,6 +223,12 @@ type deviceRecord struct {
 }
 
 type wanPort struct {
+	// IsUplink is a plain bool, so a record with no is_uplink key at all
+	// decodes to false — and the cellular entry is exactly that record: the
+	// field is absent, not false (#104). "Absent claims nothing" happens to be
+	// the safe direction, but it is an accident of the decode rather than a
+	// decision, and a *bool would only earn its nil handling once something
+	// needs to tell "absent" from "explicitly not the uplink". Nothing does.
 	IsUplink bool   `json:"is_uplink"`
 	Up       bool   `json:"up"`
 	IfName   string `json:"ifname"`
@@ -223,9 +236,76 @@ type wanPort struct {
 	IP       string `json:"ip"`
 }
 
+// wanEntry is one wanN block together with the N it was keyed by.
+type wanEntry struct {
+	// Index is the N in wanN. Its one meaning is that wanPrimaryIndex is the
+	// primary and everything above it is a backup; the numbering has no other
+	// significance, and it is not dense — a gateway may report wan1 and wan3
+	// with no wan2.
+	Index int
+	wanPort
+}
+
+// wanPrimaryIndex is the one WAN index that means "primary". This is the only
+// place the numbering carries meaning: every other index is a backup.
+const wanPrimaryIndex = 1
+
+// UnmarshalJSON decodes the named fields as usual, then walks the raw object
+// once more to collect every wanN key. The second pass is what a fixed field
+// list cannot do: it decodes uplinks this repository has never seen the name
+// of, instead of silently dropping them (#104).
+func (d *deviceRecord) UnmarshalJSON(data []byte) error {
+	type plain deviceRecord
+	if err := json.Unmarshal(data, (*plain)(d)); err != nil {
+		return err
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for key, value := range raw {
+		index, ok := wanIndexOf(key)
+		if !ok {
+			continue
+		}
+		// Decoded via a pointer so an explicit null — which is how the capture
+		// script writes a WAN the console did not report — is skipped, exactly
+		// as the old *wanPort fields skipped it.
+		var port *wanPort
+		if err := json.Unmarshal(value, &port); err != nil {
+			return err
+		}
+		if port == nil {
+			continue
+		}
+		d.WANs = append(d.WANs, wanEntry{Index: index, wanPort: *port})
+	}
+	// The raw object is a map, so the collection order is random; index order
+	// is the one the rest of this file may rely on.
+	slices.SortFunc(d.WANs, func(a, b wanEntry) int { return a.Index - b.Index })
+	return nil
+}
+
+// wanIndexOf extracts the N from a wanN key. Only "wan" followed entirely by
+// digits qualifies, so wan_ip and friends do not.
+func wanIndexOf(key string) (int, bool) {
+	digits, found := strings.CutPrefix(key, "wan")
+	if !found || digits == "" {
+		return 0, false
+	}
+	index := 0
+	for _, r := range digits {
+		if r < '0' || r > '9' {
+			return 0, false
+		}
+		index = index*10 + int(r-'0')
+	}
+	return index, index >= wanPrimaryIndex
+}
+
 // uplinkRef is the gateway's own statement of which interface it is uplinked
-// through. It is the second, independent answer to the question wan1/wan2
-// is_uplink answers.
+// through. It is the second, independent answer to the question the wanN
+// is_uplink fields answer.
 type uplinkRef struct {
 	Name string `json:"name"`
 	Type string `json:"type"`
@@ -391,7 +471,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 			logf.FromContext(ctx).WithName("unifi-devices").V(1).Info(
 				"Skipping a device that is not adopted", "model", d.Model, "type", d.Type)
 		}
-		if !gatewaySeen && (d.WAN1 != nil || d.WAN2 != nil) {
+		if !gatewaySeen && len(d.WANs) > 0 {
 			gatewaySeen = true
 			if wan := c.wanFrom(ctx, d); wan != "" {
 				state[stateKeyWAN] = wan
@@ -448,11 +528,17 @@ type wanSignal struct {
 // byIsUplink is the signal the wan mapping has always been derived from, and
 // the one issue #34 exists to verify: it has only ever been observed on a
 // gateway with a single live uplink, so "the port with is_uplink set is the
-// live one" is inference, not observation.
+// live one" is inference, not observation. A cellular uplink never appears
+// here at all — its record carries no is_uplink key — so on a cellular
+// failover this signal says nothing and byUplinkName decides.
 func (d deviceRecord) byIsUplink() wanSignal {
-	primary := d.WAN1 != nil && d.WAN1.IsUplink
-	backup := d.WAN2 != nil && d.WAN2.IsUplink
-	return resolveSignal(primary, backup)
+	var claims []int
+	for _, w := range d.WANs {
+		if w.IsUplink {
+			claims = append(claims, w.Index)
+		}
+	}
+	return resolveSignal(claims)
 }
 
 // byUplinkName is the independent second opinion: the gateway names the
@@ -463,19 +549,31 @@ func (d deviceRecord) byUplinkName() wanSignal {
 	if d.Uplink == nil {
 		return wanSignal{}
 	}
-	return resolveSignal(d.WAN1.named(d.Uplink.Name), d.WAN2.named(d.Uplink.Name))
+	var claims []int
+	for _, w := range d.WANs {
+		if w.named(d.Uplink.Name) {
+			claims = append(claims, w.Index)
+		}
+	}
+	return resolveSignal(claims)
 }
 
-func resolveSignal(primary, backup bool) wanSignal {
-	switch {
-	case primary && backup:
-		return wanSignal{ambiguous: true}
-	case backup:
+// resolveSignal turns the WAN indices a field claimed into that field's
+// answer. Exactly one claim answers — wanPrimaryIndex is the primary,
+// anything else a backup. More than one is ambiguous even when every claimant
+// is a backup: the field is contradicting itself, and which backup carries
+// the traffic is exactly what it has failed to say.
+func resolveSignal(claims []int) wanSignal {
+	switch len(claims) {
+	case 0:
+		return wanSignal{}
+	case 1:
+		if claims[0] == wanPrimaryIndex {
+			return wanSignal{value: wanPrimary}
+		}
 		return wanSignal{value: wanBackup}
-	case primary:
-		return wanSignal{value: wanPrimary}
 	}
-	return wanSignal{}
+	return wanSignal{ambiguous: true}
 }
 
 // wanFrom decides which uplink is live, and reports rather than resolves any
@@ -488,6 +586,11 @@ func resolveSignal(primary, backup bool) wanSignal {
 // missing key and a coin flip respectively, so it can only be an improvement.
 // Everything else is a log line, because deciding which signal wins needs a
 // real failover to have been observed, and one has not been (issue #34).
+//
+// The unclaimed path is load-bearing, not defensive: it is the one a cellular
+// failover takes. The cellular entry carries no is_uplink key at all, so
+// is_uplink names nobody and the uplink interface — which the gateway points
+// at the cellular tunnel — is what resolves the key to backup (#104).
 func (c *Client) wanFrom(ctx context.Context, d deviceRecord) string {
 	log := logf.FromContext(ctx).WithName("unifi-wan")
 	claimed, named := d.byIsUplink(), d.byUplinkName()

--- a/internal/providers/unifi/client_test.go
+++ b/internal/providers/unifi/client_test.go
@@ -38,18 +38,23 @@ func captured(t *testing.T, name string) []byte {
 }
 
 // merged builds one device list from several captured responses, the way a
-// real controller returns every device in a single call.
+// real controller returns every device in a single call. The records are kept
+// as raw JSON rather than round-tripped through deviceRecord: the parser only
+// decodes, so a re-serialisation would silently feed the tests its own subset
+// of the capture instead of the capture.
 func merged(t *testing.T, names ...string) []byte {
 	t.Helper()
-	var all deviceStatResponse
+	records := make([]json.RawMessage, 0, len(names))
 	for _, name := range names {
-		var parsed deviceStatResponse
+		var parsed struct {
+			Data []json.RawMessage `json:"data"`
+		}
 		if err := json.Unmarshal(captured(t, name), &parsed); err != nil {
 			t.Fatalf("parsing %s: %v", name, err)
 		}
-		all.Data = append(all.Data, parsed.Data...)
+		records = append(records, parsed.Data...)
 	}
-	b, err := json.Marshal(all)
+	b, err := json.Marshal(map[string]any{"meta": map[string]string{"rc": "ok"}, "data": records})
 	if err != nil {
 		t.Fatalf("marshalling merged payload: %v", err)
 	}
@@ -161,9 +166,11 @@ func TestObserveWithoutAGatewayStillReportsTheUPS(t *testing.T) {
 func TestWANBackupWhenWAN2IsUplink(t *testing.T) {
 	c := NewClient("", nil, "", false)
 	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{
-		Model: "UDMPRO",
-		WAN1:  &wanPort{IsUplink: false, Up: false},
-		WAN2:  &wanPort{IsUplink: true, Up: true},
+		Model: gatewayModel,
+		WANs: []wanEntry{
+			{Index: 1, wanPort: wanPort{IsUplink: false, Up: false}},
+			{Index: 2, wanPort: wanPort{IsUplink: true, Up: true}},
+		},
 	}}})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)

--- a/internal/providers/unifi/devices_test.go
+++ b/internal/providers/unifi/devices_test.go
@@ -296,7 +296,7 @@ func TestFleetAndGatewayKeysDegradeIndependently(t *testing.T) {
 		t.Error("wan should be absent when no gateway is in the list")
 	}
 
-	gateway := deviceRecord{Model: "UDMPRO", WAN1: &wanPort{IsUplink: true, Up: true}}
+	gateway := deviceRecord{Model: gatewayModel, WANs: []wanEntry{{Index: 1, wanPort: wanPort{IsUplink: true, Up: true}}}}
 	withoutFleet := fleetState(t, false, gateway)
 	if withoutFleet[stateKeyWAN] != wanPrimary {
 		t.Errorf("state[wan] = %q, want %q", withoutFleet[stateKeyWAN], wanPrimary)

--- a/internal/providers/unifi/wan_test.go
+++ b/internal/providers/unifi/wan_test.go
@@ -19,6 +19,8 @@ package unifi
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -46,6 +48,10 @@ import (
 const (
 	gatewayCapture = "stat-device-gateway.json"
 
+	// gatewayModel is the console model every capture and hand-built gateway
+	// record in these tests reports.
+	gatewayModel = "UDMPRO"
+
 	// capturedISP is the slug of the carrier in the committed capture. The
 	// capture carries a placeholder name rather than the console's real one —
 	// the isp key is a real feature, so a fixture has to carry *a* carrier, and
@@ -66,7 +72,42 @@ const (
 
 	// loggedDisagreement is the substring every cross-check warning shares.
 	loggedDisagreement = "disagree"
+
+	// loggedUnclaimed is the line the provider logs when is_uplink resolves
+	// nothing and the gateway's uplink interface decides instead — the path a
+	// cellular failover takes, since the cellular entry has no is_uplink key.
+	loggedUnclaimed = "is_uplink does not name a single live WAN port"
+
+	// cellularIfName is the interface the live hardware behind #104 reports
+	// for its cellular uplink: a GRE tunnel, not a physical WAN port.
+	cellularIfName = "gre1"
 )
+
+// wan returns the collected entry for wanN, so a hypothesis edits "wan2"
+// rather than a slice position. Asking for an index the record does not carry
+// is a bug in the test.
+func wan(d *deviceRecord, index int) *wanEntry {
+	for i := range d.WANs {
+		if d.WANs[i].Index == index {
+			return &d.WANs[i]
+		}
+	}
+	panic(fmt.Sprintf("no wan%d in this record", index))
+}
+
+// withCellularBackup appends a third uplink shaped exactly as the gateway
+// behind #104 reports its cellular backup: a GRE tunnel, up and holding an
+// address — and with no is_uplink key at all, which the plain-bool field
+// decodes as false. It goes in as wan3 so the fixture's wired pair stays the
+// observed ground truth.
+func withCellularBackup(d *deviceRecord) {
+	d.WANs = append(d.WANs, wanEntry{Index: 3, wanPort: wanPort{
+		Up:     true,
+		IfName: cellularIfName,
+		Name:   cellularIfName,
+		IP:     "203.0.113.11",
+	}})
+}
 
 // gatewayFromCapture returns the committed gateway record with one
 // transformation applied, so the starting point of every hypothesis is real.
@@ -144,9 +185,9 @@ func TestFailoverHypotheses(t *testing.T) {
 			// like, the current mapping is simply right.
 			name: "every signal moves",
 			apply: func(d *deviceRecord) {
-				d.WAN1.IsUplink, d.WAN1.Up = false, false
-				d.WAN2.IsUplink, d.WAN2.Up = true, true
-				d.Uplink.Name = d.WAN2.IfName
+				wan(d, 1).IsUplink, wan(d, 1).Up = false, false
+				wan(d, 2).IsUplink, wan(d, 2).Up = true, true
+				d.Uplink.Name = wan(d, 2).IfName
 				d.LastWANStatus = map[string]any{wanStatusKeyPrimary: statusFailed, wanStatusKeyBackup: wanStatusOnline}
 				d.ISP = backupCarrier
 			},
@@ -159,8 +200,8 @@ func TestFailoverHypotheses(t *testing.T) {
 			// worth knowing about before trusting either.
 			name: "only is_uplink moves",
 			apply: func(d *deviceRecord) {
-				d.WAN1.IsUplink = false
-				d.WAN2.IsUplink, d.WAN2.Up = true, true
+				wan(d, 1).IsUplink = false
+				wan(d, 2).IsUplink, wan(d, 2).Up = true, true
 			},
 			wantWAN:    wanBackup,
 			wantISP:    capturedISP,
@@ -173,8 +214,8 @@ func TestFailoverHypotheses(t *testing.T) {
 			// a failover — so the only defence is that it says so loudly.
 			name: "is_uplink stays pinned while everything else moves",
 			apply: func(d *deviceRecord) {
-				d.WAN2.Up = true
-				d.Uplink.Name = d.WAN2.IfName
+				wan(d, 2).Up = true
+				d.Uplink.Name = wan(d, 2).IfName
 				d.LastWANStatus = map[string]any{wanStatusKeyPrimary: statusFailed, wanStatusKeyBackup: wanStatusOnline}
 				d.ISP = backupCarrier
 			},
@@ -191,11 +232,11 @@ func TestFailoverHypotheses(t *testing.T) {
 			// for no reason beyond the order of a switch statement.
 			name: "both ports claim the uplink",
 			apply: func(d *deviceRecord) {
-				d.WAN2.IsUplink, d.WAN2.Up = true, true
+				wan(d, 2).IsUplink, wan(d, 2).Up = true, true
 			},
 			wantWAN:    wanPrimary,
 			wantISP:    capturedISP,
-			wantLogged: []string{"is_uplink does not name a single live WAN port", `"bothPortsClaimedUplink"=true`},
+			wantLogged: []string{loggedUnclaimed, `"bothPortsClaimedUplink"=true`},
 		},
 		{
 			// The switchover window: the old uplink has dropped and the new
@@ -204,13 +245,46 @@ func TestFailoverHypotheses(t *testing.T) {
 			// disappeared".
 			name: "neither port claims the uplink mid-switchover",
 			apply: func(d *deviceRecord) {
-				d.WAN1.IsUplink, d.WAN1.Up = false, false
-				d.WAN2.Up = true
-				d.Uplink.Name = d.WAN2.IfName
+				wan(d, 1).IsUplink, wan(d, 1).Up = false, false
+				wan(d, 2).Up = true
+				d.Uplink.Name = wan(d, 2).IfName
 			},
 			wantWAN:    wanBackup,
 			wantISP:    capturedISP,
-			wantLogged: []string{"is_uplink does not name a single live WAN port"},
+			wantLogged: []string{loggedUnclaimed},
+		},
+		{
+			// A gateway reporting wan1 and wan3 with no wan2 — nothing promises
+			// the numbering is dense, so a gap must resolve exactly as the
+			// contiguous record does.
+			name: "a numbering gap still resolves",
+			apply: func(d *deviceRecord) {
+				withCellularBackup(d)
+				d.WANs = slices.DeleteFunc(d.WANs, func(w wanEntry) bool { return w.Index == 2 })
+				wan(d, 1).IsUplink, wan(d, 1).Up = false, false
+				d.Uplink.Name = cellularIfName
+			},
+			wantWAN:    wanBackup,
+			wantISP:    capturedISP,
+			wantLogged: []string{loggedUnclaimed},
+		},
+		{
+			// is_uplink contradicting itself across two backups. Both indices
+			// mean backup, but which one carries the traffic is exactly what
+			// the field failed to say, so it stays ambiguous — and with no
+			// uplink block to break the tie, the provider reports backup and
+			// says it may be wrong, as it always has on an ambiguous claim.
+			name: "two backups both claim the uplink and nothing breaks the tie",
+			apply: func(d *deviceRecord) {
+				withCellularBackup(d)
+				wan(d, 1).IsUplink, wan(d, 1).Up = false, false
+				wan(d, 2).IsUplink, wan(d, 2).Up = true, true
+				wan(d, 3).IsUplink = true
+				d.Uplink = nil
+			},
+			wantWAN:    wanBackup,
+			wantISP:    capturedISP,
+			wantLogged: []string{"Both WAN ports report is_uplink"},
 		},
 		{
 			// Nothing left to go on. The key is omitted rather than guessed,
@@ -218,7 +292,7 @@ func TestFailoverHypotheses(t *testing.T) {
 			// of running onExit actions mid-failover.
 			name: "no signal at all",
 			apply: func(d *deviceRecord) {
-				d.WAN1.IsUplink = false
+				wan(d, 1).IsUplink = false
 				d.Uplink = nil
 			},
 			wantWAN: "",
@@ -260,6 +334,94 @@ func TestFailoverHypotheses(t *testing.T) {
 	}
 }
 
+// The regression #104 is about, asserted the way the bug presented on real
+// hardware: primary down, is_uplink claimed by nobody — the cellular entry
+// carries no is_uplink key at all — and the gateway's uplink interface naming
+// the third WAN's tunnel. The key must be PRESENT and read backup. Before
+// every wanN was collected, this exact record produced no wan key, so a
+// `when: {wan: backup}` Automation held "everything is fine" straight through
+// the failover it was written for.
+func TestCellularFailoverReportsBackup(t *testing.T) {
+	ctx, logs := logged(t)
+	c := NewClient("", nil, "", false)
+
+	state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, func(d *deviceRecord) {
+		withCellularBackup(d)
+		wan(d, 1).IsUplink, wan(d, 1).Up = false, false
+		d.Uplink.Name = cellularIfName
+	}))
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	value, present := state[stateKeyWAN]
+	if !present {
+		t.Fatalf("state carries no wan key at all — the failover to cellular is invisible, which is the bug #104 reported; state = %v", state)
+	}
+	if value != wanBackup {
+		t.Fatalf("state[wan] = %q, want %q", value, wanBackup)
+	}
+	// The path taken must be the documented one: is_uplink resolves nothing,
+	// the uplink interface decides.
+	if !strings.Contains(logs(), loggedUnclaimed) {
+		t.Errorf("expected the provider to report %q, logged:\n%s", loggedUnclaimed, logs())
+	}
+}
+
+// The common case on the same hardware: three WANs visible, wired primary
+// live. Nothing may change, and nothing may be reported as a disagreement —
+// a third uplink at rest is not noise.
+func TestACellularBackupAtRestChangesNothing(t *testing.T) {
+	ctx, logs := logged(t)
+	c := NewClient("", nil, "", false)
+
+	state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, withCellularBackup))
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	if state[stateKeyWAN] != wanPrimary {
+		t.Errorf("state[wan] = %q, want %q", state[stateKeyWAN], wanPrimary)
+	}
+	if strings.Contains(logs(), loggedDisagreement) {
+		t.Errorf("a cellular backup sitting idle is not a disagreement:\n%s", logs())
+	}
+}
+
+// The decode itself: every wanN key is collected, in index order, with the
+// named fields still decoding alongside them. This is JSON-level on purpose —
+// absent-versus-false on is_uplink only exists at the decode boundary.
+func TestEveryWANIsCollected(t *testing.T) {
+	blob := `{
+		"model": "UDMPRO",
+		"wan10": {"up": false, "ifname": "eth10"},
+		"wan1": {"is_uplink": true, "up": true, "ifname": "eth8"},
+		"wan3": {"up": true, "ifname": "gre1"},
+		"wan2": null,
+		"wan_ip": "203.0.113.10"
+	}`
+	var d deviceRecord
+	if err := json.Unmarshal([]byte(blob), &d); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if d.Model != gatewayModel {
+		t.Errorf("Model = %q; the named fields must keep decoding next to the wanN collection", d.Model)
+	}
+	indices := make([]int, 0, len(d.WANs))
+	for _, w := range d.WANs {
+		indices = append(indices, w.Index)
+	}
+	// wan2 is null (a WAN the console did not report), wan_ip is not a WAN,
+	// and wan10 must sort after wan3 numerically rather than lexically.
+	if want := []int{1, 3, 10}; !slices.Equal(indices, want) {
+		t.Fatalf("collected indices %v, want %v", indices, want)
+	}
+	if wan(&d, 3).IsUplink {
+		t.Errorf("wan3 carries no is_uplink key, which must decode as false — absent claims nothing")
+	}
+	if !wan(&d, 1).IsUplink || wan(&d, 1).IfName != "eth8" {
+		t.Errorf("wan1 = %+v, want the values it was given", *wan(&d, 1))
+	}
+}
+
 // The cross-check issue #6 exists for: wan and isp are independent answers to
 // "did the uplink change", and they are only meaningful together across two
 // observations.
@@ -272,9 +434,9 @@ func TestISPAndWANDisagreementAcrossObservations(t *testing.T) {
 		{
 			name: "the uplink changed but the carrier did not",
 			then: func(d *deviceRecord) {
-				d.WAN1.IsUplink = false
-				d.WAN2.IsUplink, d.WAN2.Up = true, true
-				d.Uplink.Name = d.WAN2.IfName
+				wan(d, 1).IsUplink = false
+				wan(d, 2).IsUplink, wan(d, 2).Up = true, true
+				d.Uplink.Name = wan(d, 2).IfName
 			},
 			wantLogged: "changed uplink but the ISP behind it did not change",
 		},
@@ -320,9 +482,9 @@ func TestNoDisagreementWhenBothSignalsMoveTogether(t *testing.T) {
 		t.Fatalf("first observation: %v", err)
 	}
 	state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, func(d *deviceRecord) {
-		d.WAN1.IsUplink, d.WAN1.Up = false, false
-		d.WAN2.IsUplink, d.WAN2.Up = true, true
-		d.Uplink.Name = d.WAN2.IfName
+		wan(d, 1).IsUplink, wan(d, 1).Up = false, false
+		wan(d, 2).IsUplink, wan(d, 2).Up = true, true
+		d.Uplink.Name = wan(d, 2).IfName
 		d.LastWANStatus = map[string]any{wanStatusKeyPrimary: statusFailed, wanStatusKeyBackup: wanStatusOnline}
 		d.ISP = backupCarrier
 	}))

--- a/testdata/unifi/README.md
+++ b/testdata/unifi/README.md
@@ -35,7 +35,7 @@ The counts are deliberately unguarded. There is no positive rule to write — ev
 
 | File | Endpoint | What it documents |
 | --- | --- | --- |
-| `api/stat-device-gateway.json` | `GET /proxy/network/api/s/<site>/stat/device` (gateway) | `wan1`/`wan2` (`is_uplink`, `up`, `ifname`, `speed`), `uplink`, `last_wan_status`, `isp` (allowlisted from `active_geo_info.WAN.isp_name`), `state`/`adopted`/`name` (the `devices` key) |
+| `api/stat-device-gateway.json` | `GET /proxy/network/api/s/<site>/stat/device` (gateway) | every `wanN` (`is_uplink`, `up`, `ifname`, `speed`) — this capture predates the cellular backup, so it carries only `wan1`/`wan2`; a gateway with a cellular backup reports `wan3` (#104) — `uplink`, `last_wan_status`, `isp` (allowlisted from `active_geo_info.WAN.isp_name`), `state`/`adopted`/`name` (the `devices` key) |
 | `api/stat-device-ups.json` | same call, UPS record | `vbms_table` battery state, `outlet_table`, `state`/`adopted`/`name` |
 | `api/stat-health.json` | `GET /proxy/network/api/s/<site>/stat/health` | per-subsystem `status` (the `internet` key), WAN `uptime_stats` monitors (the `wan.quality` key), ISP |
 | `api/integration-info.json` | `GET /proxy/network/integration/v1/info` | controller version, for the compatibility guard |


### PR DESCRIPTION
Closes #104.

## What was wrong

A gateway with a cellular backup reports **three** uplinks, and the cellular one is `wan3` — a GRE tunnel (`gre1`), typed by the modem, carrying an address, with **no `is_uplink` key at all**. `deviceRecord` declared `wan1` and `wan2` and nothing else, so `wan3` was never decoded and both signals failed independently on failover: `byIsUplink` saw no claim, and `byUplinkName` compared `uplink.name` (`gre1`) against the two WANs it had, matching neither. `wanFrom` then correctly produced a **missing key** — and a missing key holds the last matching decision, so a `when: {wan: backup}` Automation stayed at "not matching, the primary is fine" through the exact failover it was written for. The README's headline example did not fire on this hardware.

## What changed

- **`deviceRecord` collects every `wanN`** via a second pass over the raw object in `UnmarshalJSON`, ordered by index. Index 1 is the primary and everything above it is a backup — stated once, as `wanPrimaryIndex`. Gaps in the numbering are allowed; nothing assumes density.
- **The two signals keep their relationship and only widen their candidate set.** `resolveSignal` now takes the claimed indices instead of two booleans; more than one claim stays ambiguous even when every claimant is a backup. The path that resolves a cellular failover is the one `wanFrom` already had for "is_uplink names nobody" — the uplink interface decides — and its comment now says that path is load-bearing, not defensive.
- **`wanPort.IsUplink` stays a plain `bool`**, with a comment recording that "absent decodes to false" is an accident that happens to be the safe direction (absent claims nothing). Not changed to `*bool`; nothing needs to tell absent from explicitly-false.
- **`hack/capture-unifi.sh` projects every `wanN`** through the same per-field `WAN` allowlist instead of naming `wan1`/`wan2`, so a capture from a three-WAN gateway carries the third without another edit. **`mbb` is deliberately not projected** — nothing reads it, and it carries a `cell_id` and a modem MAC, which under the #94 rule would need the replace-the-value tier before it could ever be committed. No capture was run; no fixture changed. The three-WAN case is built in the tests, where the interesting thing is the combination of field values.
- **Tests**: the regression that matters is asserted the way the bug presented — primary down, `is_uplink` claimed by nobody, `uplink.name` matching the third WAN's `ifname` → the `wan` key is **present** and equal to `backup` (`TestCellularFailoverReportsBackup`). Also: three WANs at rest → `primary` with no disagreement logged; a `wan1`+`wan3` numbering gap resolves; two backups both claiming stays ambiguous; a JSON-level decode test covers collection order (`wan10` after `wan3`), null `wanN`, non-WAN keys (`wan_ip`), and absent-`is_uplink`-decodes-false. All two-WAN tests pass unmodified except for the mechanical `d.WAN1` → `wan(d, 1)` rewrite. The `merged` test helper now merges raw JSON instead of round-tripping through `deviceRecord`, which only decodes.
- **Docs**: `state-keys/wan-and-internet.md` now says `wan` covers however many uplinks the gateway reports, that `wan1` is the primary, and that a cellular backup appears as a tunnel with no `is_uplink` so the uplink-name signal resolves it. Troubleshooting gains **§10g "`wan` disappeared during a failover"**, written for the operator meeting the symptom, and the §10 table row for the unclaimed-uplink log line now says it is the *expected* path on a cellular failover. The generated reference regenerated with no drift (this change touches no API types, metrics, events, or chart values).

## Behaviour change on multi-WAN gateways — read before upgrading

On gateways with more than two uplinks, **a state key that previously went missing now reports a value**: on a failover to the third uplink, `wan` becomes `backup` instead of disappearing. **Automations matching `when: {wan: backup}` that have never fired on this hardware will start firing** — including their `onEnter` actions — the first time a failover happens after upgrading. That is the intent of the fix. Two-WAN gateways behave byte-for-byte as before, and the `wan` vocabulary is unchanged (`primary`/`backup`, no new keys, nothing read from `mbb`/`type`/`rat` — that discussion is #105, and #34's live-failover verification should now happen against the cellular uplink, after this lands).

## A known edge left in place, deliberately

`uptimeStatsKey` and `checkLastWANStatus` still map `backup` to the `WAN2` key, so during a *cellular* failover `wan.quality` reads the wired secondary's `uptime_stats` entry rather than the cellular uplink's (`WAN3`, which the committed health capture shows exists). Fixing that needs the live WAN *index* threaded into the health merge plus an observed `wanN` ↔ `WAN`*N* correspondence, which is inference today. `crossCheckUplinkHealth` will log the mismatch when it happens, which is the honest available behaviour; it belongs with #34's observation rather than in this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for detecting and reporting all available WAN uplinks, including additional interfaces such as `wan3`.
  - Improved cellular failover detection and primary/backup WAN mapping.
  - Added handling for sparse WAN numbering and ambiguous uplink states.

- **Documentation**
  - Documented WAN state matching, cellular failover behavior, and troubleshooting guidance.
  - Updated gateway capture documentation to cover additional WAN interfaces.

- **Bug Fixes**
  - Corrected WAN reporting when uplinks disappear or health status conflicts with the selected connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->