### PR TITLE
fix(unifi): name the uptime cross-check's believed uplink by its resolved index

### DIFF
--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -379,10 +379,11 @@ func (c *Client) Observe(ctx context.Context) (map[string]string, error) {
 	state := map[string]string{}
 
 	var devices deviceStatResponse
+	var wanIndex int
 	deviceErr := c.get(ctx, "stat/device", &devices)
 	if deviceErr == nil {
 		var fromDevices map[string]string
-		fromDevices, deviceErr = c.stateFromDevices(ctx, devices)
+		fromDevices, wanIndex, deviceErr = c.stateFromDevices(ctx, devices)
 		maps.Copy(state, fromDevices)
 	}
 
@@ -394,7 +395,7 @@ func (c *Client) Observe(ctx context.Context) (map[string]string, error) {
 	var health healthResponse
 	healthErr := c.get(ctx, "stat/health", &health)
 	if healthErr == nil {
-		c.mergeHealth(ctx, state, health, state[stateKeyWAN])
+		c.mergeHealth(ctx, state, health, state[stateKeyWAN], wanIndex)
 	}
 
 	if len(state) == 0 {
@@ -445,9 +446,15 @@ func (c *Client) get(ctx context.Context, endpoint string, out any) error {
 // The two halves are independent on purpose: a site with no UPS still reports
 // wan, and a site whose gateway reports nothing recognisable still reports the
 // UPS keys. Only observing nothing at all is an error.
-func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse) (map[string]string, error) {
+//
+// The resolved WAN index rides alongside the map because the map cannot carry
+// it: wan is published as primary or backup by design, and the health
+// cross-check needs to know which uplink that answer collapsed from (#107).
+// Zero when wan is absent or was guessed rather than resolved.
+func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse) (map[string]string, int, error) {
 	state := map[string]string{}
 	gatewaySeen := false
+	wanIndex := 0
 	// One tally per fleet-wide key, each holding whatever operator configuration
 	// it needs, so that publishing takes nothing but the state map.
 	fleet := newDeviceTally(c.PerDeviceKeys)
@@ -473,7 +480,8 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 		}
 		if !gatewaySeen && len(d.WANs) > 0 {
 			gatewaySeen = true
-			if wan := c.wanFrom(ctx, d); wan != "" {
+			var wan string
+			if wan, wanIndex = c.wanFrom(ctx, d); wan != "" {
 				state[stateKeyWAN] = wan
 			}
 			state[stateKeyISP] = ispFrom(d)
@@ -504,7 +512,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	c.reportOutlets(ctx, outlets.publish(ctx, state))
 
 	if len(state) == 0 {
-		return nil, fmt.Errorf(
+		return nil, 0, fmt.Errorf(
 			"no gateway reporting WAN ports, no UPS, and no adopted device reporting a state "+
 				"were found in the device list; "+
 				"the fields this provider reads were verified on UniFi Network %s (%s), "+
@@ -512,13 +520,18 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 				"— see the compatibility matrix in the README",
 			VerifiedNetworkVersion, VerifiedConsoleModel)
 	}
-	return state, nil
+	return state, wanIndex, nil
 }
 
 // wanSignal is one field's answer to which uplink is live.
 type wanSignal struct {
 	// value is wanPrimary, wanBackup, or empty when the field says nothing.
 	value string
+	// index is the WAN index value collapsed from. value is a two-value key by
+	// design, so it cannot say WHICH backup on a gateway with more than one —
+	// and the health cross-check needs to know exactly that (#107). Zero when
+	// value is empty or the claim was ambiguous.
+	index int
 	// ambiguous records that the field claimed both uplinks at once. That is
 	// itself information — it means the field does not mean what this provider
 	// takes it to mean — so it is kept apart from "said nothing".
@@ -569,9 +582,9 @@ func resolveSignal(claims []int) wanSignal {
 		return wanSignal{}
 	case 1:
 		if claims[0] == wanPrimaryIndex {
-			return wanSignal{value: wanPrimary}
+			return wanSignal{value: wanPrimary, index: claims[0]}
 		}
-		return wanSignal{value: wanBackup}
+		return wanSignal{value: wanBackup, index: claims[0]}
 	}
 	return wanSignal{ambiguous: true}
 }
@@ -591,42 +604,49 @@ func resolveSignal(claims []int) wanSignal {
 // failover takes. The cellular entry carries no is_uplink key at all, so
 // is_uplink names nobody and the uplink interface — which the gateway points
 // at the cellular tunnel — is what resolves the key to backup (#104).
-func (c *Client) wanFrom(ctx context.Context, d deviceRecord) string {
+//
+// The uplink's index is returned alongside the value because the value cannot
+// carry it: wan is a two-value key by design, so "backup" cannot say which
+// backup, and the health cross-check needs exactly that to name the uplink it
+// believes in (#107). Zero when the value itself is a guess — the ambiguous
+// path — or when nothing is published at all.
+func (c *Client) wanFrom(ctx context.Context, d deviceRecord) (string, int) {
 	log := logf.FromContext(ctx).WithName("unifi-wan")
 	claimed, named := d.byIsUplink(), d.byUplinkName()
 
-	var wan string
+	var wan wanSignal
 	switch {
 	case claimed.value != "" && named.value != "" && claimed.value != named.value:
 		metrics.SignalsDisagreed(ProviderName, signalWANUplinkDisagrees)
 		log.Info("The gateway's WAN signals disagree about which uplink is live; "+
 			"trusting is_uplink, which is the signal this mapping has always used",
 			"byIsUplink", claimed.value, "byUplinkName", named.value, "uplink", d.Uplink.Name)
-		wan = claimed.value
+		wan = claimed
 	case claimed.value != "":
-		wan = claimed.value
+		wan = claimed
 	case named.value != "":
 		metrics.SignalsDisagreed(ProviderName, signalWANUplinkUnclaimed)
 		log.Info("is_uplink does not name a single live WAN port; "+
 			"deriving the live uplink from the gateway's uplink interface instead",
 			"byUplinkName", named.value, "uplink", d.Uplink.Name, "bothPortsClaimedUplink", claimed.ambiguous)
-		wan = named.value
+		wan = named
 	case claimed.ambiguous:
 		// Both ports claim the uplink and nothing resolves it. Reporting the
 		// backup is what this provider has always done here; it is a guess,
-		// and saying so is the only honest thing available.
+		// and saying so is the only honest thing available. The index stays
+		// zero: which uplink the guess would even mean is what is unknown.
 		metrics.SignalsDisagreed(ProviderName, signalWANUplinkAmbiguous)
 		log.Info("Both WAN ports report is_uplink and nothing resolves which is live; "+
 			"reporting the backup uplink, which may be wrong",
 			"wan", wanBackup)
-		wan = wanBackup
+		wan = wanSignal{value: wanBackup}
 	default:
 		log.V(1).Info("No WAN port reports is_uplink and the gateway names no uplink interface; wan will not be published")
-		return ""
+		return "", 0
 	}
 
-	c.checkLastWANStatus(ctx, d, wan)
-	return wan
+	c.checkLastWANStatus(ctx, d, wan.value)
+	return wan.value, wan.index
 }
 
 // checkLastWANStatus compares the derived uplink against the gateway's own

--- a/internal/providers/unifi/client_test.go
+++ b/internal/providers/unifi/client_test.go
@@ -165,7 +165,7 @@ func TestObserveWithoutAGatewayStillReportsTheUPS(t *testing.T) {
 
 func TestWANBackupWhenWAN2IsUplink(t *testing.T) {
 	c := NewClient("", nil, "", false)
-	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{
+	state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{
 		Model: gatewayModel,
 		WANs: []wanEntry{
 			{Index: 1, wanPort: wanPort{IsUplink: false, Up: false}},
@@ -203,7 +203,7 @@ func TestUPSStateTransitions(t *testing.T) {
 			vbms.IsBatteryMode = tc.batteryMode
 			vbms.BattPool.BatteryLevel = tc.level
 
-			state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{Model: "USWDA26", VBMS: &vbms}}})
+			state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{Model: "USWDA26", VBMS: &vbms}}})
 			if err != nil {
 				t.Fatalf("stateFromDevices: %v", err)
 			}
@@ -226,7 +226,7 @@ func TestUPSStaysOnBatteryAcrossBatteryLevels(t *testing.T) {
 		vbms.IsBatteryMode = true
 		vbms.BattPool.BatteryLevel = level
 
-		state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
+		state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
 		if err != nil {
 			t.Fatalf("stateFromDevices: %v", err)
 		}
@@ -258,7 +258,7 @@ func TestUPSRuntimeLevels(t *testing.T) {
 			var vbms vbmsTable
 			vbms.BattPool.TimeToRemain = tc.seconds
 
-			state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
+			state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
 			if err != nil {
 				t.Fatalf("stateFromDevices: %v", err)
 			}
@@ -279,7 +279,7 @@ func TestUnknownRuntimeOmitsTheKey(t *testing.T) {
 		var vbms vbmsTable
 		vbms.BattPool.TimeToRemain = seconds
 
-		state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
+		state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
 		if err != nil {
 			t.Fatalf("stateFromDevices: %v", err)
 		}
@@ -316,7 +316,7 @@ func TestUPSLoadLevels(t *testing.T) {
 			var vbms vbmsTable
 			vbms.BattPool.TotalPowerOutput, vbms.BattPool.TotalPowerBudget = tc.output, tc.budget
 
-			state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
+			state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
 			if err != nil {
 				t.Fatalf("stateFromDevices: %v", err)
 			}
@@ -347,7 +347,7 @@ func TestUPSKeysAreIndependentAxes(t *testing.T) {
 			vbms.BattPool.TimeToRemain = 120
 			vbms.BattPool.TotalPowerOutput, vbms.BattPool.TotalPowerBudget = watts(output), watts(1000)
 
-			state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
+			state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
 			if err != nil {
 				t.Fatalf("stateFromDevices: %v", err)
 			}
@@ -373,7 +373,7 @@ func TestCustomUPSRuntimeAndLoadThresholds(t *testing.T) {
 	output, budget := 310.0, 1000.0
 	vbms.BattPool.TotalPowerOutput, vbms.BattPool.TotalPowerBudget = &output, &budget
 
-	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
+	state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -396,7 +396,7 @@ func TestCustomBatteryThresholds(t *testing.T) {
 	vbms.IsBatteryMode = true
 	vbms.BattPool.BatteryLevel = 50
 
-	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
+	state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{{VBMS: &vbms}}})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -407,7 +407,7 @@ func TestCustomBatteryThresholds(t *testing.T) {
 
 func TestErrorsWhenNothingObservable(t *testing.T) {
 	c := NewClient("", nil, "", false)
-	if _, err := c.stateFromDevices(context.Background(), deviceStatResponse{}); err == nil {
+	if _, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{}); err == nil {
 		t.Fatal("expected error for empty device list")
 	}
 }

--- a/internal/providers/unifi/devices_test.go
+++ b/internal/providers/unifi/devices_test.go
@@ -47,7 +47,7 @@ func fleetState(t *testing.T, perDeviceKeys bool, devices ...deviceRecord) map[s
 	t.Helper()
 	c := NewClient("", nil, "", false)
 	c.PerDeviceKeys = perDeviceKeys
-	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -216,7 +216,7 @@ func TestAListWithNothingAdoptedObservesNothing(t *testing.T) {
 	pending.Adopted = nil
 
 	c := NewClient("", nil, "", false)
-	if _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{pending}}); err == nil {
+	if _, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: []deviceRecord{pending}}); err == nil {
 		t.Fatal("a list holding nothing observable should be an error, not an empty observation")
 	}
 }

--- a/internal/providers/unifi/firmware_test.go
+++ b/internal/providers/unifi/firmware_test.go
@@ -139,7 +139,7 @@ func TestFirmwareDecodesTheDocumentedShape(t *testing.T) {
 	}
 
 	c := NewClient("", nil, "", false)
-	state, err := c.stateFromDevices(context.Background(), parsed)
+	state, _, err := c.stateFromDevices(context.Background(), parsed)
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}

--- a/internal/providers/unifi/health.go
+++ b/internal/providers/unifi/health.go
@@ -18,6 +18,7 @@ package unifi
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -117,7 +118,13 @@ type healthMonitor struct {
 // lives in the device response. When wan says nothing, neither does
 // wan.quality: guessing an uplink would publish another uplink's numbers under
 // this one's name.
-func (c *Client) mergeHealth(ctx context.Context, state map[string]string, health healthResponse, wan string) {
+//
+// wanIndex is the uplink wan resolved to, and it comes along because wan alone
+// is not enough to name one: it is a two-value key by design, and on a gateway
+// with more than one backup "backup" does not say which (#107). Zero means wan
+// was guessed rather than resolved, and the per-uplink work is skipped for the
+// same reason it is when wan is empty.
+func (c *Client) mergeHealth(ctx context.Context, state map[string]string, health healthResponse, wan string, wanIndex int) {
 	log := logf.FromContext(ctx).WithName("unifi-health")
 
 	for _, subsystem := range health.Data {
@@ -140,11 +147,16 @@ func (c *Client) mergeHealth(ctx context.Context, state map[string]string, healt
 				state[stateKeyWiFi] = wifi
 			}
 		case healthSubsystemWAN:
-			c.crossCheckUplinkHealth(ctx, wan, subsystem.UptimeStats)
+			c.crossCheckUplinkHealth(ctx, wan, wanIndex, subsystem.UptimeStats)
 			if wan == "" {
 				continue
 			}
-			entry, present := subsystem.UptimeStats[uptimeStatsKey(wan)]
+			if wanIndex < wanPrimaryIndex {
+				log.V(1).Info("wan was guessed rather than resolved to a single uplink; "+
+					"wan.quality will not be published", "wan", wan)
+				continue
+			}
+			entry, present := subsystem.UptimeStats[uptimeStatsKey(wanIndex)]
 			if !present {
 				log.V(1).Info("The health response carries no uptime stats for the live uplink; "+
 					"wan.quality will not be published", "wan", wan)
@@ -157,13 +169,17 @@ func (c *Client) mergeHealth(ctx context.Context, state map[string]string, healt
 	}
 }
 
-// uptimeStatsKey maps a derived uplink onto the key stat/health files it
-// under. Both captured endpoints agree on WAN and WAN2.
-func uptimeStatsKey(wan string) string {
-	if wan == wanBackup {
-		return wanStatusKeyBackup
+// uptimeStatsKey maps a resolved uplink index onto the key stat/health files
+// it under. The primary is WAN with no digit — both captures agree — and every
+// index above it is WAN<N>, which is what the captures show for the second and
+// what live hardware reports for the third (#107). It takes the index rather
+// than wan's value because the value cannot name a backup: deriving the key
+// from it assumed the only backup is the second uplink.
+func uptimeStatsKey(index int) string {
+	if index == wanPrimaryIndex {
+		return wanStatusKeyPrimary
 	}
-	return wanStatusKeyPrimary
+	return fmt.Sprintf("WAN%d", index)
 }
 
 // internetFrom translates the www subsystem's status. An empty result means
@@ -276,11 +292,19 @@ func meanOf(monitors, alerting []healthMonitor, field func(healthMonitor) *float
 // and the one believed live is not among them — the shape of "the mapping is
 // pointing at the wrong port", not the shape of "this link is having a bad
 // day", which wan.quality is the key for.
-func (c *Client) crossCheckUplinkHealth(ctx context.Context, wan string, stats map[string]uplinkHealth) {
-	if wan == "" || len(stats) == 0 {
+//
+// The believed uplink is named by its resolved index, not by wan's value.
+// Deriving the key from the value assumed the only possible backup is the
+// second uplink, and on a gateway whose live backup is the third that reported
+// the mapping as broken — once per poll, for the whole outage — at the exact
+// moment it was right (#107). When no single index was resolved there is
+// nothing precise enough to check, and nothing fires; wan itself was flagged
+// as a guess on that path.
+func (c *Client) crossCheckUplinkHealth(ctx context.Context, wan string, wanIndex int, stats map[string]uplinkHealth) {
+	if wan == "" || wanIndex < wanPrimaryIndex || len(stats) == 0 {
 		return
 	}
-	believed := uptimeStatsKey(wan)
+	believed := uptimeStatsKey(wanIndex)
 	var withUptime []string
 	for key, entry := range stats {
 		if entry.Uptime != nil && *entry.Uptime > 0 {

--- a/internal/providers/unifi/health_test.go
+++ b/internal/providers/unifi/health_test.go
@@ -24,6 +24,15 @@ import (
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+// The uplink indices behind the capture's uptime_stats keys: WAN is the
+// primary, WAN2 the wired backup, WAN3 the cellular one. The tests thread them
+// explicitly because that is the point of #107 — the wan value alone cannot
+// name a backup, so every believed uplink is named by its index.
+const (
+	wiredBackupIndex    = 2
+	cellularBackupIndex = 3
+)
+
 // disagreements reads reactor_provider_signal_disagreements_total for one
 // signal. It gathers from the registry rather than reaching into the metrics
 // package, because the counter is deliberately unexported: what a test may
@@ -74,17 +83,20 @@ func subsystem(t *testing.T, health *healthResponse, name string) *healthSubsyst
 	return nil
 }
 
-func mergedHealth(t *testing.T, c *Client, health healthResponse, wan string) map[string]string {
+// mergedHealth runs mergeHealth as Observe would: with the wan value and the
+// uplink index it resolved from, which are two separate facts — "backup" alone
+// cannot say which backup (#107).
+func mergedHealth(t *testing.T, c *Client, health healthResponse, wan string, wanIndex int) map[string]string {
 	t.Helper()
 	state := map[string]string{}
-	c.mergeHealth(context.Background(), state, health, wan)
+	c.mergeHealth(context.Background(), state, health, wan, wanIndex)
 	return state
 }
 
 // The capture was taken with the internet up and WAN1 at 100% availability,
 // 16 ms average. Both keys should read the healthy value from it unedited.
 func TestHealthAgainstTheCapture(t *testing.T) {
-	state := mergedHealth(t, NewClient("", nil, "", false), capturedHealth(t), wanPrimary)
+	state := mergedHealth(t, NewClient("", nil, "", false), capturedHealth(t), wanPrimary, wanPrimaryIndex)
 
 	for key, want := range map[string]string{
 		stateKeyInternet:   internetOK,
@@ -111,7 +123,7 @@ func TestInternetFromTheWWWSubsystem(t *testing.T) {
 			health := capturedHealth(t)
 			subsystem(t, &health, healthSubsystemWWW).Status = tc.status
 
-			if got := mergedHealth(t, c, health, wanPrimary)[stateKeyInternet]; got != tc.want {
+			if got := mergedHealth(t, c, health, wanPrimary, wanPrimaryIndex)[stateKeyInternet]; got != tc.want {
 				t.Errorf("state[internet] = %q, want %q", got, tc.want)
 			}
 		})
@@ -128,7 +140,7 @@ func TestUnrecognisedInternetStatusOmitsTheKey(t *testing.T) {
 		health := capturedHealth(t)
 		subsystem(t, &health, healthSubsystemWWW).Status = status
 
-		if got, present := mergedHealth(t, c, health, wanPrimary)[stateKeyInternet]; present {
+		if got, present := mergedHealth(t, c, health, wanPrimary, wanPrimaryIndex)[stateKeyInternet]; present {
 			t.Errorf("status %q should publish no internet key, got %q", status, got)
 		}
 	}
@@ -143,7 +155,7 @@ func TestHealthKeysDegradeIndependently(t *testing.T) {
 		health := capturedHealth(t)
 		health.Data = without(health.Data, healthSubsystemWWW)
 
-		state := mergedHealth(t, c, health, wanPrimary)
+		state := mergedHealth(t, c, health, wanPrimary, wanPrimaryIndex)
 		if _, present := state[stateKeyInternet]; present {
 			t.Error("internet should be absent when the console reports no www subsystem")
 		}
@@ -156,7 +168,7 @@ func TestHealthKeysDegradeIndependently(t *testing.T) {
 		health := capturedHealth(t)
 		health.Data = without(health.Data, healthSubsystemWAN)
 
-		state := mergedHealth(t, c, health, wanPrimary)
+		state := mergedHealth(t, c, health, wanPrimary, wanPrimaryIndex)
 		if state[stateKeyInternet] != internetOK {
 			t.Errorf("state[internet] = %q, want %q", state[stateKeyInternet], internetOK)
 		}
@@ -183,13 +195,19 @@ func without(data []healthSubsystem, name string) []healthSubsystem {
 func TestWANQualityNeedsToKnowWhichUplinkIsLive(t *testing.T) {
 	c := NewClient("", nil, "", false)
 
-	if got, present := mergedHealth(t, c, capturedHealth(t), "")[stateKeyWANQuality]; present {
+	if got, present := mergedHealth(t, c, capturedHealth(t), "", 0)[stateKeyWANQuality]; present {
 		t.Errorf("wan.quality should be absent when wan is not derivable, got %q", got)
 	}
 	// The same capture read as if the backup were live: WAN2 has been down for
 	// the whole window, and its monitors say so.
-	if got := mergedHealth(t, c, capturedHealth(t), wanBackup)[stateKeyWANQuality]; got != wanQualityDegraded {
+	if got := mergedHealth(t, c, capturedHealth(t), wanBackup, wiredBackupIndex)[stateKeyWANQuality]; got != wanQualityDegraded {
 		t.Errorf("state[wan.quality] on the dead backup = %q, want %q", got, wanQualityDegraded)
+	}
+	// A wan that was guessed rather than resolved — the ambiguous-claim path —
+	// names no uplink either. Publishing WAN2's numbers there would be the
+	// same two-WAN assumption #107 removed from the cross-check.
+	if got, present := mergedHealth(t, c, capturedHealth(t), wanBackup, 0)[stateKeyWANQuality]; present {
+		t.Errorf("wan.quality should be absent when wan was guessed rather than resolved, got %q", got)
 	}
 }
 
@@ -221,7 +239,7 @@ func TestWANQualityThresholds(t *testing.T) {
 			entry.Monitors, entry.AlertingMonitors = nil, nil
 			subsystem(t, &health, healthSubsystemWAN).UptimeStats[wanStatusKeyPrimary] = entry
 
-			if got := mergedHealth(t, c, health, wanPrimary)[stateKeyWANQuality]; got != tc.want {
+			if got := mergedHealth(t, c, health, wanPrimary, wanPrimaryIndex)[stateKeyWANQuality]; got != tc.want {
 				t.Errorf("state[wan.quality] = %q, want %q", got, tc.want)
 			}
 		})
@@ -240,7 +258,7 @@ func TestMissingAvailabilityIsNotZeroAvailability(t *testing.T) {
 	entry.Monitors, entry.AlertingMonitors = nil, nil
 	subsystem(t, &health, healthSubsystemWAN).UptimeStats[wanStatusKeyPrimary] = entry
 
-	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary, wanPrimaryIndex)
 	if got, present := state[stateKeyWANQuality]; present {
 		t.Fatalf("an entry reporting no availability must publish no wan.quality, got %q", got)
 	}
@@ -257,13 +275,13 @@ func TestAvailabilityFallsBackToTheMonitors(t *testing.T) {
 	wanSubsystem.UptimeStats[wanStatusKeyPrimary] = entry
 
 	// The capture's WAN monitors all read 100%, so it stays good...
-	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary, wanPrimaryIndex)
 	if state[stateKeyWANQuality] != wanQualityGood {
 		t.Errorf("state[wan.quality] = %q, want %q", state[stateKeyWANQuality], wanQualityGood)
 	}
 	// ...and the captured WAN2 entry, which has no uplink-level fields at all,
 	// still reads degraded off its monitors alone.
-	if got := mergedHealth(t, NewClient("", nil, "", false), health, wanBackup)[stateKeyWANQuality]; got != wanQualityDegraded {
+	if got := mergedHealth(t, NewClient("", nil, "", false), health, wanBackup, wiredBackupIndex)[stateKeyWANQuality]; got != wanQualityDegraded {
 		t.Errorf("state[wan.quality] from monitors alone = %q, want %q", got, wanQualityDegraded)
 	}
 }
@@ -277,14 +295,16 @@ func TestUplinkHealthCrossCheck(t *testing.T) {
 	tests := []struct {
 		name          string
 		wan           string
+		wanIndex      int
 		uptime        map[string]*int
 		wantDisagrees bool
 	}{
-		{"the capture, believed correctly", wanPrimary, nil, false},
-		{"believed to be on the backup while the primary has the uptime", wanBackup, nil, true},
+		{"the capture, believed correctly", wanPrimary, wanPrimaryIndex, nil, false},
+		{"believed to be on the backup while the primary has the uptime", wanBackup, wiredBackupIndex, nil, true},
 		{
-			name: "believed to be on the primary while the backup has the uptime",
-			wan:  wanPrimary,
+			name:     "believed to be on the primary while the backup has the uptime",
+			wan:      wanPrimary,
+			wanIndex: wanPrimaryIndex,
 			uptime: map[string]*int{
 				wanStatusKeyPrimary: nil,
 				wanStatusKeyBackup:  seconds(98787),
@@ -295,8 +315,9 @@ func TestUplinkHealthCrossCheck(t *testing.T) {
 			// Mid-switchover: nothing has uptime yet. There is no evidence
 			// either way, so this must stay quiet rather than cry wolf on
 			// every failover.
-			name: "no uplink has uptime",
-			wan:  wanPrimary,
+			name:     "no uplink has uptime",
+			wan:      wanPrimary,
+			wanIndex: wanPrimaryIndex,
 			uptime: map[string]*int{
 				wanStatusKeyPrimary: nil,
 				wanStatusKeyBackup:  nil,
@@ -304,12 +325,45 @@ func TestUplinkHealthCrossCheck(t *testing.T) {
 		},
 		{
 			// Both up: the believed uplink is among them, so nothing is wrong.
-			name: "both uplinks have uptime",
-			wan:  wanBackup,
+			name:     "both uplinks have uptime",
+			wan:      wanBackup,
+			wanIndex: wiredBackupIndex,
 			uptime: map[string]*int{
 				wanStatusKeyPrimary: seconds(98787),
 				wanStatusKeyBackup:  seconds(4200),
 			},
+		},
+		{
+			// The false positive #107 is about, as it fired live: wan resolved
+			// to backup FROM THE THIRD UPLINK, and the health endpoint agrees —
+			// the uptime sits under WAN3. Deriving the believed key from the
+			// value compared WAN2 against {WAN3} and reported the mapping as
+			// broken at the exact moment it was right, once per poll.
+			name:     "the live backup is the third uplink and health agrees",
+			wan:      wanBackup,
+			wanIndex: cellularBackupIndex,
+			uptime: map[string]*int{
+				wanStatusKeyPrimary: nil,
+				"WAN3":              seconds(75),
+			},
+		},
+		{
+			// The disagreement worth keeping — the one the fix must not weaken
+			// away: wan names the third uplink while only the primary has
+			// uptime. "Any backup with uptime counts" would stay quiet here,
+			// and here is precisely a mapping pointing at the wrong backup.
+			name:          "believed to be on the third uplink while the primary has the uptime",
+			wan:           wanBackup,
+			wanIndex:      cellularBackupIndex,
+			wantDisagrees: true,
+		},
+		{
+			// wan was guessed off an ambiguous claim, so no index resolved.
+			// There is no believed uplink precise enough to check against, and
+			// the guess was already reported where it was made.
+			name:     "wan was guessed and no index resolved",
+			wan:      wanBackup,
+			wanIndex: 0,
 		},
 	}
 	for _, tc := range tests {
@@ -323,7 +377,7 @@ func TestUplinkHealthCrossCheck(t *testing.T) {
 			}
 
 			before := disagreements(t, signalWANHealthDisagrees)
-			mergedHealth(t, NewClient("", nil, "", false), health, tc.wan)
+			mergedHealth(t, NewClient("", nil, "", false), health, tc.wan, tc.wanIndex)
 			after := disagreements(t, signalWANHealthDisagrees)
 
 			if got := after > before; got != tc.wantDisagrees {

--- a/internal/providers/unifi/outlets_test.go
+++ b/internal/providers/unifi/outlets_test.go
@@ -60,7 +60,7 @@ func capturedGrouping() []outletRecord {
 func outletState(t *testing.T, devices ...deviceRecord) map[string]string {
 	t.Helper()
 	c := NewClient("", nil, "", false)
-	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -323,7 +323,7 @@ func TestBothRelayHypothesesAreObservable(t *testing.T) {
 			c := NewClient("", nil, "", false)
 			ctx := context.Background()
 
-			if _, err := c.stateFromDevices(ctx, deviceStatResponse{
+			if _, _, err := c.stateFromDevices(ctx, deviceStatResponse{
 				Data: []deviceRecord{upsWithOutlets("UPS 2U", capturedGrouping()...)},
 			}); err != nil {
 				t.Fatalf("first observation: %v", err)
@@ -340,7 +340,7 @@ func TestBothRelayHypothesesAreObservable(t *testing.T) {
 				}
 				second = append(second, o)
 			}
-			state, err := c.stateFromDevices(ctx, deviceStatResponse{
+			state, _, err := c.stateFromDevices(ctx, deviceStatResponse{
 				Data: []deviceRecord{upsWithOutlets("UPS 2U", second...)},
 			})
 			if err != nil {
@@ -386,7 +386,7 @@ func TestOutletChangeIsReportedWithItsRelayGroup(t *testing.T) {
 			}, funcr.Options{}))
 			c := NewClient("", nil, "", false)
 
-			if _, err := c.stateFromDevices(ctx, deviceStatResponse{
+			if _, _, err := c.stateFromDevices(ctx, deviceStatResponse{
 				Data: []deviceRecord{upsWithOutlets("UPS 2U", capturedGrouping()...)},
 			}); err != nil {
 				t.Fatalf("first observation: %v", err)
@@ -409,7 +409,7 @@ func TestOutletChangeIsReportedWithItsRelayGroup(t *testing.T) {
 				}
 				second = append(second, o)
 			}
-			if _, err := c.stateFromDevices(ctx, deviceStatResponse{
+			if _, _, err := c.stateFromDevices(ctx, deviceStatResponse{
 				Data: []deviceRecord{upsWithOutlets("UPS 2U", second...)},
 			}); err != nil {
 				t.Fatalf("second observation: %v", err)

--- a/internal/providers/unifi/poe_test.go
+++ b/internal/providers/unifi/poe_test.go
@@ -58,7 +58,7 @@ func poeState(t *testing.T, threshold float64, devices ...deviceRecord) map[stri
 	t.Helper()
 	c := NewClient("", nil, "", false)
 	c.MaxPoEUtilizationPercent = threshold
-	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -261,7 +261,7 @@ func TestPoEDecodesTheDocumentedShape(t *testing.T) {
 	}
 
 	c := NewClient("", nil, "", false)
-	state, err := c.stateFromDevices(context.Background(), parsed)
+	state, _, err := c.stateFromDevices(context.Background(), parsed)
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -85,8 +85,13 @@ const (
 	wanStatusOnline = "online"
 
 	// The keys last_wan_status and the health subsystem's uptime_stats use for
-	// each uplink. Both captures agree on WAN for the first and WAN2 for the
-	// second, and neither has been observed while the second was live.
+	// the first two uplinks. Both captures agree on WAN for the first and WAN2
+	// for the second, and the second has still never been observed live. A
+	// THIRD has: during a real cellular failover the health endpoint
+	// accumulated the live uplink's uptime under WAN3, so these two constants
+	// are not the whole key space — which is why uptimeStatsKey derives WAN<N>
+	// from the resolved uplink index instead of assuming every backup is the
+	// second (#107).
 	wanStatusKeyPrimary = "WAN"
 	wanStatusKeyBackup  = "WAN2"
 

--- a/internal/providers/unifi/temperature_test.go
+++ b/internal/providers/unifi/temperature_test.go
@@ -45,7 +45,7 @@ func heatState(t *testing.T, threshold float64, devices ...deviceRecord) map[str
 	t.Helper()
 	c := NewClient("", nil, "", false)
 	c.HighTemperatureCelsius = threshold
-	state, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
+	state, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{Data: devices})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -232,7 +232,7 @@ func TestTemperatureDecodesTheDocumentedShape(t *testing.T) {
 	}
 
 	c := NewClient("", nil, "", false)
-	state, err := c.stateFromDevices(context.Background(), parsed)
+	state, _, err := c.stateFromDevices(context.Background(), parsed)
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}

--- a/internal/providers/unifi/version_test.go
+++ b/internal/providers/unifi/version_test.go
@@ -168,7 +168,7 @@ func TestVersionGuardGivesUpQuietlyOnAnUnreachableConsole(t *testing.T) {
 // because that is what it usually means once the credentials are right.
 func TestNothingObservableNamesTheTestedVersion(t *testing.T) {
 	c := NewClient("", nil, "", false)
-	_, err := c.stateFromDevices(context.Background(), deviceStatResponse{})
+	_, _, err := c.stateFromDevices(context.Background(), deviceStatResponse{})
 	if err == nil {
 		t.Fatal("expected an error for an empty device list")
 	}

--- a/internal/providers/unifi/wan_test.go
+++ b/internal/providers/unifi/wan_test.go
@@ -151,7 +151,7 @@ func TestCapturedGatewayHasEverySignalAgreeing(t *testing.T) {
 	ctx, logs := logged(t)
 	c := NewClient("", nil, "", false)
 
-	state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, nil))
+	state, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, nil))
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestFailoverHypotheses(t *testing.T) {
 			ctx, logs := logged(t)
 			c := NewClient("", nil, "", false)
 
-			state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, tc.apply))
+			state, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, tc.apply))
 			if err != nil {
 				t.Fatalf("stateFromDevices: %v", err)
 			}
@@ -345,7 +345,7 @@ func TestCellularFailoverReportsBackup(t *testing.T) {
 	ctx, logs := logged(t)
 	c := NewClient("", nil, "", false)
 
-	state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, func(d *deviceRecord) {
+	state, wanIndex, err := c.stateFromDevices(ctx, gatewayFromCapture(t, func(d *deviceRecord) {
 		withCellularBackup(d)
 		wan(d, 1).IsUplink, wan(d, 1).Up = false, false
 		d.Uplink.Name = cellularIfName
@@ -359,6 +359,12 @@ func TestCellularFailoverReportsBackup(t *testing.T) {
 	}
 	if value != wanBackup {
 		t.Fatalf("state[wan] = %q, want %q", value, wanBackup)
+	}
+	// backup alone cannot say WHICH backup, and on this failover it is the
+	// third uplink — the fact the health cross-check needs, and the one whose
+	// loss made it fire falsely on every poll of the real outage (#107).
+	if wanIndex != 3 {
+		t.Errorf("resolved wan index = %d, want 3 — the cross-check would look for the wrong uptime_stats key", wanIndex)
 	}
 	// The path taken must be the documented one: is_uplink resolves nothing,
 	// the uplink interface decides.
@@ -374,7 +380,7 @@ func TestACellularBackupAtRestChangesNothing(t *testing.T) {
 	ctx, logs := logged(t)
 	c := NewClient("", nil, "", false)
 
-	state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, withCellularBackup))
+	state, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, withCellularBackup))
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -456,13 +462,13 @@ func TestISPAndWANDisagreementAcrossObservations(t *testing.T) {
 
 			// First observation: the capture, unmodified. Nothing to compare
 			// against yet, so nothing may be reported.
-			if _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, nil)); err != nil {
+			if _, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, nil)); err != nil {
 				t.Fatalf("first observation: %v", err)
 			}
 			if strings.Contains(logs(), "ISP") {
 				t.Errorf("the first observation has nothing to disagree with:\n%s", logs())
 			}
-			if _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, tc.then)); err != nil {
+			if _, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, tc.then)); err != nil {
 				t.Fatalf("second observation: %v", err)
 			}
 			if !strings.Contains(logs(), tc.wantLogged) {
@@ -478,10 +484,10 @@ func TestNoDisagreementWhenBothSignalsMoveTogether(t *testing.T) {
 	ctx, logs := logged(t)
 	c := NewClient("", nil, "", false)
 
-	if _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, nil)); err != nil {
+	if _, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, nil)); err != nil {
 		t.Fatalf("first observation: %v", err)
 	}
-	state, err := c.stateFromDevices(ctx, gatewayFromCapture(t, func(d *deviceRecord) {
+	state, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, func(d *deviceRecord) {
 		wan(d, 1).IsUplink, wan(d, 1).Up = false, false
 		wan(d, 2).IsUplink, wan(d, 2).Up = true, true
 		d.Uplink.Name = wan(d, 2).IfName
@@ -512,7 +518,7 @@ func TestAnUnknownCarrierIsNotACarrierChange(t *testing.T) {
 		func(d *deviceRecord) { d.ISP = "" },
 		nil,
 	} {
-		if _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, apply)); err != nil {
+		if _, _, err := c.stateFromDevices(ctx, gatewayFromCapture(t, apply)); err != nil {
 			t.Fatalf("stateFromDevices: %v", err)
 		}
 	}

--- a/internal/providers/unifi/wifi_test.go
+++ b/internal/providers/unifi/wifi_test.go
@@ -50,7 +50,7 @@ func TestWiFiAgainstTheCapture(t *testing.T) {
 	}
 
 	before := disagreements(t, signalWiFiStatusDisagrees)
-	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary, wanPrimaryIndex)
 
 	if state[stateKeyWiFi] != wifiWarning {
 		t.Errorf("state[wifi] = %q, want %q", state[stateKeyWiFi], wifiWarning)
@@ -82,7 +82,7 @@ func TestWiFiFromTheAPCounts(t *testing.T) {
 			// about the derivation rather than about the cross-check.
 			subsystem(t, &health, healthSubsystemWLAN).Status = ""
 
-			if got := mergedHealth(t, c, health, wanPrimary)[stateKeyWiFi]; got != tc.want {
+			if got := mergedHealth(t, c, health, wanPrimary, wanPrimaryIndex)[stateKeyWiFi]; got != tc.want {
 				t.Errorf("state[wifi] = %q with %d adopted and %d disconnected, want %q",
 					got, tc.adopted, tc.disconnected, tc.want)
 			}
@@ -96,7 +96,7 @@ func TestNoAccessPointsPublishesNoWiFiKey(t *testing.T) {
 	health := capturedHealth(t)
 	counts(t, &health, 0, 0, 0)
 
-	if got, present := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)[stateKeyWiFi]; present {
+	if got, present := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary, wanPrimaryIndex)[stateKeyWiFi]; present {
 		t.Errorf("a site with no adopted AP should publish no wifi key, got %q", got)
 	}
 }
@@ -124,7 +124,7 @@ func TestMissingAPCountsPublishNoWiFiKey(t *testing.T) {
 				wlan.NumDisconnected = nil
 			}
 
-			if got, present := mergedHealth(t, c, health, wanPrimary)[stateKeyWiFi]; present {
+			if got, present := mergedHealth(t, c, health, wanPrimary, wanPrimaryIndex)[stateKeyWiFi]; present {
 				t.Errorf("missing counts should publish no wifi key, got %q", got)
 			}
 		})
@@ -144,7 +144,7 @@ func TestWiFiDegradesWithoutTakingTheOtherHealthKeys(t *testing.T) {
 	}
 	health.Data = kept
 
-	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary, wanPrimaryIndex)
 	if got, present := state[stateKeyWiFi]; present {
 		t.Errorf("wifi should be absent when the wlan subsystem is, got %q", got)
 	}
@@ -169,7 +169,7 @@ func TestTheConsolesOwnStatusIsCrossCheckedRatherThanTrusted(t *testing.T) {
 	counts(t, &health, 3, 0, 3)
 	subsystem(t, &health, healthSubsystemWLAN).Status = healthStatusWarning
 
-	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)
+	state := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary, wanPrimaryIndex)
 	if state[stateKeyWiFi] != wifiOK {
 		t.Errorf("state[wifi] = %q, want %q: every adopted AP is connected", state[stateKeyWiFi], wifiOK)
 	}
@@ -187,7 +187,7 @@ func TestAnUnfamiliarWiFiStatusIsNotADisagreement(t *testing.T) {
 	counts(t, &health, 2, 0, 2)
 	subsystem(t, &health, healthSubsystemWLAN).Status = "degraded-somehow"
 
-	if got := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary)[stateKeyWiFi]; got != wifiOK {
+	if got := mergedHealth(t, NewClient("", nil, "", false), health, wanPrimary, wanPrimaryIndex)[stateKeyWiFi]; got != wifiOK {
 		t.Errorf("state[wifi] = %q, want %q", got, wifiOK)
 	}
 	if after := disagreements(t, signalWiFiStatusDisagrees); after != before {


### PR DESCRIPTION
Closes #107.

## What was wrong

`crossCheckUplinkHealth` derived its uptime-stats key from the `wan` **value** via `uptimeStatsKey(wan)`, which mapped `backup` to the constant `WAN2`. `wan` is a two-value key by design, so it cannot say *which* backup — the mapping assumed the only possible backup is the second uplink, the same fixed two-WAN assumption #104 removed from the decode path.

On a gateway whose live backup is the third uplink, the check compared `WAN2` against a set containing only `WAN3`, concluded they disagreed, and reported the wan mapping as broken at the exact moment it was right — once per poll for the whole outage, each firing incrementing `SignalsDisagreed`, the metric that exists precisely so an operator can alert on the mapping being untrustworthy.

## The fix

Exactly the shape the issue suggests:

- `resolveSignal` already computed the winning WAN index to produce its value and threw it away; the index now rides on `wanSignal` and is threaded through `wanFrom` → `stateFromDevices` → `Observe` → `mergeHealth` → `crossCheckUplinkHealth`.
- `uptimeStatsKey` now takes the resolved index: `wanPrimaryIndex` is `WAN` with no digit (both committed captures agree), and every index above it is `WAN<N>` — matching the captures for the second uplink and what live hardware reports for the third.
- The check keeps its narrowness: it fires only when some uplink has uptime **and** the believed one is not among them. It is deliberately **not** weakened to "any non-primary uplink with uptime counts as agreement when wan is backup" — that would discard the check's actual value, catching a mapping that points at the *wrong* backup on a gateway with more than one. A test pins that case down.
- The comment on `wanStatusKeyPrimary` / `wanStatusKeyBackup` now records what has actually been observed: the second uplink still never live, a third observed live accumulating uptime under `WAN3`.

Two consequential details:

- On the ambiguous-claim path (`both ports claim the uplink and nothing breaks the tie`) `wan` is a guess and no index resolves. The cross-check now stays out of it — there is no believed uplink precise enough to check — and `wan.quality` is no longer published off `WAN2`'s numbers there, which was the same two-WAN assumption in a second place. Guessing an uplink would publish another uplink's numbers under this one's name, which is the rule `mergeHealth` already documented.
- `checkLastWANStatus` still uses the two constants against `last_wan_status`; a missing key there returns silently, so it cannot fire falsely. Left as is to keep this change scoped to the check that did.

## Tests

- The case that fired live: `wan` resolved to backup from the **third** uplink, uptime present only under `WAN3` — the check stays silent.
- The disagreement worth keeping: `wan` names the third uplink while only the primary has uptime — the check still fires.
- The guessed-wan path checks nothing and publishes no `wan.quality`.
- `TestCellularFailoverReportsBackup` now also asserts the resolved index is 3, the fact the cross-check depends on.

All records are built in the tests from the committed captures; no fixtures added. `make test` (which runs `hack/verify-testdata.sh`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved UniFi WAN detection during failover, including cellular and additional backup uplinks.
  - Health and uptime metrics now associate data with the correct uplink.
  - WAN quality is no longer reported when the active uplink cannot be identified confidently.
  - Added support for uptime statistics such as `WAN3` and higher-numbered uplinks.

- **Tests**
  - Expanded coverage for cellular failover, backup uplinks, and health-data matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->