### PR TITLE
feat(unifi): data.usage — the active SIM against its data plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ Each key is published only when the matching hardware is adopted by your control
 | `wan.quality` | `good`, `degraded` | how well that uplink has been performing, against the configured thresholds |
 | `isp` | a slug, e.g. `example-telecom`, or `unknown` | the carrier behind the live uplink |
 | `internet` | `ok`, `degraded`, `down` | whether the outside world is reachable at all |
+| `data.usage` | `under`, `warning`, `over` | the active SIM's traffic against its data plan, as the console judges it. Absent without a cellular uplink |
 | `ups` | `online`, `on-battery` | whether a UniFi UPS is on mains or running on battery |
 | `ups.battery` | `normal`, `low`, `critical` | remaining charge against the configured thresholds |
 | `ups.runtime` | `ample`, `short`, `critical` | how long the UPS says it can carry its current load |

--- a/charts/reactor/values.yaml
+++ b/charts/reactor/values.yaml
@@ -208,6 +208,14 @@ unifi:
     # by a poll, and it is a prefix because outlet keys are named outlet.<index>
     # until somebody names the outlets, and outlet.<name> afterwards.
     #
+    # data.usage is written down at 1 for outlet.*'s reason: there is nothing
+    # here to settle. The console has already done the byte accounting and the
+    # threshold comparison against the SIM's real plan before Reactor ever
+    # sees the flags this key is read from, so an extra sample would be
+    # second-guessing a judgement rather than settling a reading. It matches
+    # wan, not ups.battery — the threshold crossing happened on the console's
+    # side, where the hysteresis belongs.
+    #
     # An entry may end in "*", which matches every key with that prefix. It is
     # how a group whose key names come from your hardware gets settled at all:
     # no list here could name them. Exact keys win over patterns, and the
@@ -227,6 +235,7 @@ unifi:
       wifi: 2
       poe: 3
       outlet.*: 1
+      data.usage: 1
   # Name of an existing Secret containing the key UNIFI_API_KEY.
   # Create it with:
   #   kubectl -n <namespace> create secret generic unifi-reactor-credentials \

--- a/docs/src/content/docs/concepts/settling-a-noisy-signal.md
+++ b/docs/src/content/docs/concepts/settling-a-noisy-signal.md
@@ -25,6 +25,7 @@ unifi:
       wifi: 2           # ...and an AP heartbeat can miss a beat
       poe: 3            # ...and a PoE draw moves when a radio comes up
       outlet.*: 1       # a relay is a switch position; there is nothing to settle
+      data.usage: 1     # the console already settled this against the real plan
 ```
 
 Each extra sample costs one `pollInterval` of reaction time, so the default is `1`: a WAN failover and a power cut both deserve an immediate reaction, and neither flaps. `ups.battery` ships at `2` because it is a threshold crossing — a charge hovering at 30% would otherwise report `low`, `normal`, `low` — and because a battery drains over minutes, so spending one more poll to be sure costs nothing. At the default 30s poll that makes a battery-level escalation react in 60s worst case instead of 30s.

--- a/docs/src/content/docs/reference/values.md
+++ b/docs/src/content/docs/reference/values.md
@@ -280,6 +280,7 @@ temperature: 3
 wifi: 2
 poe: 3
 outlet.*: 1
+data.usage: 1
 ```
 
 Per-key overrides. ups.battery is a threshold crossing, so a charge
@@ -331,6 +332,14 @@ settle. It matches wan and ups, which are debounced at 1 for the same
 reason. Stating it means raising `default` cannot quietly delay an outlet
 by a poll, and it is a prefix because outlet keys are named outlet.&lt;index>
 until somebody names the outlets, and outlet.&lt;name> afterwards.
+
+data.usage is written down at 1 for outlet.*'s reason: there is nothing
+here to settle. The console has already done the byte accounting and the
+threshold comparison against the SIM's real plan before Reactor ever
+sees the flags this key is read from, so an extra sample would be
+second-guessing a judgement rather than settling a reading. It matches
+wan, not ups.battery — the threshold crossing happened on the console's
+side, where the hysteresis belongs.
 
 An entry may end in "*", which matches every key with that prefix. It is
 how a group whose key names come from your hardware gets settled at all:

--- a/docs/src/content/docs/state-keys/index.md
+++ b/docs/src/content/docs/state-keys/index.md
@@ -1,6 +1,6 @@
 ---
 title: "State keys"
-description: "The whole vocabulary the UniFi provider publishes — wan, internet, ups, devices, firmware, temperature, wifi, poe, outlets — with the values each key can hold."
+description: "The whole vocabulary the UniFi provider publishes — wan, internet, data usage, ups, devices, firmware, temperature, wifi, poe, outlets — with the values each key can hold."
 ---
 
 ## State keys
@@ -13,6 +13,7 @@ Each key is published only when the matching hardware is adopted by your control
 | `wan.quality` | `good`, `degraded` | how well that uplink has been performing, against the configured thresholds |
 | `isp` | a slug, e.g. `example-telecom`, or `unknown` | the carrier behind the live uplink |
 | `internet` | `ok`, `degraded`, `down` | whether the outside world is reachable at all |
+| `data.usage` | `under`, `warning`, `over` | the active SIM's traffic against its data plan, as the console judges it. Absent without a cellular uplink — see [WAN and internet](/state-keys/wan-and-internet/#datausage-is-the-allowance-behind-the-cellular-uplink) |
 | `ups` | `online`, `on-battery` | whether a UniFi UPS is on mains or running on battery |
 | `ups.battery` | `normal`, `low`, `critical` | remaining charge against the configured thresholds |
 | `ups.runtime` | `ample`, `short`, `critical` | how long the UPS says it can carry its current load |

--- a/docs/src/content/docs/state-keys/wan-and-internet.md
+++ b/docs/src/content/docs/state-keys/wan-and-internet.md
@@ -1,6 +1,6 @@
 ---
 title: "WAN and internet state keys"
-description: "wan says which uplink is selected, internet says whether the outside world is reachable at all, and wan.quality says whether the link has been any good. Three different questions."
+description: "wan says which uplink is selected, internet says whether the outside world is reachable at all, wan.quality says whether the link has been any good, and data.usage says how much of the cellular allowance is left. Four different questions."
 ---
 
 ## `wan` covers every uplink the gateway reports
@@ -15,6 +15,27 @@ A cellular backup is not a physical WAN port. The gateway reports it as a tunnel
     state:
       wan: backup      # the primary uplink is not the one carrying traffic
 ```
+
+## `data.usage` is the allowance behind the cellular uplink
+
+`wan: backup` says a metered link may be carrying the traffic; `data.usage` says how much of its allowance is left to carry it with. It is derived from the **active** SIM in the gateway's modem record, and the values are the console's own judgement rather than Reactor's arithmetic: the console does the byte accounting and the threshold comparison against whatever the SIM's real plan is, and reports the result as two flags. There is no threshold to configure and nothing counted on Reactor's side.
+
+| Value | Meaning |
+| --- | --- |
+| `under` | there is an allowance and it is not close |
+| `warning` | approaching the plan's limit |
+| `over` | the limit has been reached — which wins when the console sets both flags |
+
+The key is **absent, not `under`**, when there is nothing to be under: no modem, no SIM reporting itself active, no card in the active slot, or a SIM with no data plan. `under` is a claim about headroom, and a site with no cellular uplink has none to claim — an absent key is quiet, a wrong `under` lies. For the same reason, a gateway whose SIMs contradict each other — more than one reporting itself active — publishes nothing and says so in the log, because guessing which slot is live could report the idle SIM's headroom while the live one is over its cap.
+
+```yaml
+  when:
+    provider: unifi
+    state:
+      data.usage: warning   # slow down before the cap, not after it
+```
+
+Match on `warning` rather than `over` when the reaction is throttling: by the time the limit is reached, the SIM is already being shaped or billed. `data.usage` ships at the [default debounce of 1 sample](/concepts/settling-a-noisy-signal/) — the console has already settled these flags against the real plan, so there is no reading left to settle — and it pairs naturally with `wan: backup` in automations like [pausing downloads on a metered connection](/guides/pause-downloads-on-a-metered-connection/).
 
 ## `internet` is the one `wan` cannot express
 

--- a/hack/capture-unifi.sh
+++ b/hack/capture-unifi.sh
@@ -95,6 +95,15 @@ WAN='{is_uplink, up, ifname, name, speed, ip: (if .ip then "'"$PUB_IP"'" else nu
 # 2026-08-15; the fixture committed before that date predates this projection
 # and carries neither, which is why the write path is exercised against
 # hack/mock-unifi rather than against a capture.
+#
+# mbb is the most sensitive block this API has shown so far, and its projection
+# is the six booleans-and-a-slot the data.usage key reads — nothing else. A real
+# SIM entry also carries the SIM's iccid (its serial number), the modem's imei,
+# the PIN/PUK lock state and retry counters, the carrier's name in spn, and
+# mcc/mnc/asn which together identify the country and network operator. None of
+# that is redacted: it is absent, which is the only projection under which it
+# cannot leak. rxbytes and txbytes are counters rather than identifiers, but
+# nothing reads them, and being read is what earns a field a place here.
 DEVICE='{
   model, type, name, state, adopted, version, displayable_version,
   disconnection_reason,
@@ -110,6 +119,9 @@ DEVICE='{
   uplink: (if .uplink then {name: .uplink.name, type: .uplink.type} else null end),
   last_wan_status,
   isp: (if .active_geo_info.WAN.isp_name then "'"$ISP"'" else null end),
+  mbb: (if .mbb.sim then {sim: [.mbb.sim[] | {
+    active, slot, card_present, has_data_plan, data_warning, data_limited
+  }]} else null end),
   vbms_table,
   outlet_table: (if .outlet_table then [.outlet_table[] | {
     index, relay_state, relay_group, outlet_caps,
@@ -124,9 +136,7 @@ DEVICE='{
 # to name wan1 and wan2, which is how a gateway with a cellular backup — which
 # reports it as wan3 — could never produce a fixture reproducing #104. The wanN
 # fields themselves stay in the allowlist one at a time exactly as before; what
-# is dynamic is only which N exist. mbb is deliberately NOT projected: nothing
-# reads it, and it carries a cell_id and a modem MAC, which under the #94 rule
-# would put it in the replace-the-value tier before it could ever be committed.
+# is dynamic is only which N exist.
 + (with_entries(select((.key | test("^wan[0-9]+$")) and .value != null)) | map_values('"$WAN"'))
 | with_entries(select(.value != null))'
 

--- a/hack/verify-testdata.sh
+++ b/hack/verify-testdata.sh
@@ -18,8 +18,12 @@ HACK_DIR="$(cd "$(dirname "$0")" && pwd)"
 cd "${1:-$HACK_DIR/..}"
 failed=0
 
-# Fields that must never carry a real value.
-SECRET_FIELDS='x_authkey|syslog_key|serial|anon_id|device_id|hash_id|external_id|setup_id'
+# Fields that must never carry a real value. The SIM and modem identifiers are
+# here ahead of any fixture that could carry them: an iccid is the SIM's serial
+# number, an imei identifies the modem, and the PIN/PUK state is the lock on
+# somebody's SIM. The capture projection drops all of them rather than
+# redacting them, so for these, appearing at all is the violation.
+SECRET_FIELDS='x_authkey|syslog_key|serial|anon_id|device_id|hash_id|external_id|setup_id|iccid|imei|pin_lock|pin_verified|pin_tries_remaining|puk_tries_remaining'
 
 # Fields whose value must be the placeholder the capture script writes, and
 # nothing else.
@@ -37,7 +41,11 @@ SECRET_FIELDS='x_authkey|syslog_key|serial|anon_id|device_id|hash_id|external_id
 # The placeholders are read out of hack/capture-unifi.sh rather than repeated
 # here, so the value the capture writes and the value this requires cannot
 # drift apart.
-ISP_FIELDS='isp|isp_name|isp_organization'
+# spn is the SIM's own statement of the same fact — the carrier's name, read
+# off the card in the modem block. The capture projection drops it entirely, so
+# the only value that could ever legitimately appear is the placeholder a
+# hand-derived fixture copied from the capture script.
+ISP_FIELDS='isp|isp_name|isp_organization|spn'
 placeholder() { sed -n "s/^$1='\(.*\)'\$/\1/p" "$HACK_DIR/capture-unifi.sh"; }
 ISP_PLACEHOLDER="$(placeholder ISP)"
 ISP_ORG_PLACEHOLDER="$(placeholder ISP_ORG)"
@@ -55,11 +63,15 @@ fi
 for file in testdata/unifi/api/*.json testdata/unifi/webhooks/*.json; do
   [ -e "$file" ] || continue
 
-  # Any of the above with something other than a redaction marker.
+  # Any of the above with something other than a redaction marker. The value
+  # side accepts a quoted string or a bare JSON scalar, because the PIN and PUK
+  # retry counters are numbers and a numeric secret is no less real for having
+  # no quotes; the optional spaces are how jq pretty-prints, which is the shape
+  # every committed capture actually has.
   while IFS= read -r hit; do
     echo "$file: unredacted secret field: $hit"
     failed=1
-  done < <(grep -oE "\"($SECRET_FIELDS)\":\"[^\"]+\"" "$file" | grep -vE '"REDACTED"' || true)
+  done < <(grep -oE "\"($SECRET_FIELDS)\" *: *(\"[^\"]*\"|[^,}[:space:]]+)" "$file" | grep -vE '"REDACTED"$' || true)
 
   # Real-world addresses that should have been replaced with documentation ranges.
   while IFS= read -r hit; do

--- a/internal/providers/unifi/client.go
+++ b/internal/providers/unifi/client.go
@@ -220,6 +220,7 @@ type deviceRecord struct {
 	temperatureFields
 	poeFields
 	outletFields
+	dataUsageFields
 }
 
 type wanPort struct {
@@ -352,6 +353,7 @@ type vbmsTable struct {
 //	wan.quality  good    | degraded    (how well that uplink is performing)
 //	isp          a slug, or unknown    (the carrier behind the live uplink)
 //	internet     ok | degraded | down  (whether the outside world is reachable)
+//	data.usage   under | warning | over  (the active SIM against its data plan)
 //	ups          online  | on-battery  (whether the UPS is running on mains)
 //	ups.battery  normal  | low | critical
 //	ups.runtime  ample   | short | critical
@@ -455,6 +457,7 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 	state := map[string]string{}
 	gatewaySeen := false
 	wanIndex := 0
+	mbbSeen := false
 	// One tally per fleet-wide key, each holding whatever operator configuration
 	// it needs, so that publishing takes nothing but the state map.
 	fleet := newDeviceTally(c.PerDeviceKeys)
@@ -486,6 +489,16 @@ func (c *Client) stateFromDevices(ctx context.Context, parsed deviceStatResponse
 			}
 			state[stateKeyISP] = ispFrom(d)
 			c.crossCheckOverTime(ctx, state[stateKeyWAN], state[stateKeyISP])
+		}
+		// First-modem-wins, like the gateway above: multiple modems per site
+		// are out of scope, and a second record must not fill in a key the
+		// first one deliberately left unpublished — a contradiction between
+		// SIMs is silence, not an invitation for another device to answer.
+		if !mbbSeen && d.MBB != nil {
+			mbbSeen = true
+			if usage := dataUsageFrom(ctx, d); usage != "" {
+				state[stateKeyDataUsage] = usage
+			}
 		}
 		if _, seen := state[stateKeyUPS]; !seen && d.VBMS != nil {
 			state[stateKeyUPS] = upsOnline

--- a/internal/providers/unifi/datausage.go
+++ b/internal/providers/unifi/datausage.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"context"
+	"strconv"
+	"strings"
+
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/robbeverhelst/unifi-reactor/internal/metrics"
+)
+
+// dataUsageFields are the fields the data.usage key is derived from, embedded
+// in deviceRecord so they decode from the same flat object.
+//
+// The console does the accounting: data_warning and data_limited are its own
+// judgement of the SIM's traffic against whatever the plan is, so this key
+// needs no byte counting, no persistence across restarts, and no threshold of
+// its own — the one state key here whose threshold lives on somebody else's
+// hardware.
+type dataUsageFields struct {
+	MBB *mbbBlock `json:"mbb"`
+}
+
+// mbbBlock is the gateway's mobile-broadband record. Only the SIM list is
+// read; the rest of a real block is identifiers (a cell_id, a modem MAC) that
+// nothing here needs and no capture may carry.
+type mbbBlock struct {
+	SIM []simSlot `json:"sim"`
+}
+
+// simSlot is one SIM slot, projected down to the six fields the data.usage
+// key reads. A real entry also carries the SIM's iccid, the modem's imei, the
+// PIN/PUK retry counters, the carrier's name in spn, and mcc/mnc/asn which
+// together identify the country and network operator — the most sensitive
+// block this API has shown so far. None of that may be decoded here: being
+// read is what earns a field a place in the capture allowlist (#94), so a
+// field added to this struct is a field the capture script starts keeping.
+//
+// The booleans are plain rather than pointers, and that is safe by
+// construction rather than by accident: every one of them gates towards
+// absence. An absent active, card_present or has_data_plan decodes to false
+// and drops the key — the direction that publishes fewer keys — and the two
+// flags the value comes from are only read once those gates have passed, so a
+// truncated record cannot be read as headroom.
+type simSlot struct {
+	Active      bool `json:"active"`
+	Slot        int  `json:"slot"`
+	CardPresent bool `json:"card_present"`
+	HasDataPlan bool `json:"has_data_plan"`
+	DataWarning bool `json:"data_warning"`
+	DataLimited bool `json:"data_limited"`
+}
+
+// dataUsageFrom derives data.usage from the active SIM in one modem record.
+// An empty result means the key is not published, and that is the deliberate
+// answer for most of this function: under means "there is an allowance and it
+// is not close", so a slot with no card, a SIM with no plan, or a record with
+// no active SIM has nothing to be under — publishing under there would report
+// plenty of headroom for a site that has none.
+func dataUsageFrom(ctx context.Context, d deviceRecord) string {
+	log := logf.FromContext(ctx).WithName("unifi-data-usage")
+	if d.MBB == nil {
+		return ""
+	}
+
+	var active []simSlot
+	for _, s := range d.MBB.SIM {
+		if s.Active {
+			active = append(active, s)
+		}
+	}
+	switch len(active) {
+	case 0:
+		log.V(1).Info("No SIM reports itself active; data.usage will not be published")
+		return ""
+	case 1:
+	default:
+		// The console is contradicting itself, and which slot carries the
+		// traffic is exactly what it has failed to say. Guessing could pick
+		// the slot whose allowance is fine while the live one is over its cap,
+		// so nothing is published and the contradiction is counted.
+		slots := make([]string, len(active))
+		for i, s := range active {
+			slots[i] = strconv.Itoa(s.Slot)
+		}
+		metrics.SignalsDisagreed(ProviderName, signalSIMMultipleActive)
+		log.Info("More than one SIM reports itself active, so which slot is live is unknown; "+
+			"data.usage will not be published",
+			"slots", strings.Join(slots, ","))
+		return ""
+	}
+
+	sim := active[0]
+	if !sim.CardPresent {
+		log.V(1).Info("The active SIM slot has no card in it; data.usage will not be published",
+			"slot", sim.Slot)
+		return ""
+	}
+	if !sim.HasDataPlan {
+		log.V(1).Info("The active SIM has no data plan; data.usage will not be published",
+			"slot", sim.Slot)
+		return ""
+	}
+
+	// A reached limit wins over a warning about approaching one: when both
+	// flags are set, over is the one that is still true.
+	value := dataUsageUnder
+	switch {
+	case sim.DataLimited:
+		value = dataUsageOver
+	case sim.DataWarning:
+		value = dataUsageWarning
+	}
+	log.V(1).Info("data.usage", "data.usage", value, "slot", sim.Slot,
+		"dataWarning", sim.DataWarning, "dataLimited", sim.DataLimited)
+	return value
+}

--- a/internal/providers/unifi/datausage_test.go
+++ b/internal/providers/unifi/datausage_test.go
@@ -133,7 +133,7 @@ func TestDataUsageThroughTheDeviceList(t *testing.T) {
 
 	warned := planned()
 	warned.DataWarning = true
-	state, err := c.stateFromDevices(ctx, deviceStatResponse{Data: []deviceRecord{modem(warned)}})
+	state, _, err := c.stateFromDevices(ctx, deviceStatResponse{Data: []deviceRecord{modem(warned)}})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}
@@ -146,7 +146,7 @@ func TestDataUsageThroughTheDeviceList(t *testing.T) {
 	noPlan := planned()
 	noPlan.HasDataPlan = false
 	ups := deviceRecord{VBMS: &vbmsTable{}}
-	state, err = c.stateFromDevices(ctx, deviceStatResponse{Data: []deviceRecord{modem(noPlan), ups}})
+	state, _, err = c.stateFromDevices(ctx, deviceStatResponse{Data: []deviceRecord{modem(noPlan), ups}})
 	if err != nil {
 		t.Fatalf("stateFromDevices: %v", err)
 	}

--- a/internal/providers/unifi/datausage_test.go
+++ b/internal/providers/unifi/datausage_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright 2026.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unifi
+
+import (
+	"strings"
+	"testing"
+)
+
+// Every record in this file is built in code rather than committed to
+// testdata/. That is a policy decision, not a shortcut: the interesting cases
+// are combinations of four booleans, not a realistic device, and a real mbb
+// block carries the SIM's iccid, the modem's imei and the PIN retry counters —
+// so every committed fixture carrying one is a standing risk for nothing a
+// hand-built record does not already prove. No committed fixture has an mbb
+// block, and this file is the reason none is needed.
+
+// modem returns a record whose mbb block holds exactly the given SIM slots.
+func modem(sims ...simSlot) deviceRecord {
+	return deviceRecord{
+		Model:           gatewayModel,
+		Type:            "udm",
+		dataUsageFields: dataUsageFields{MBB: &mbbBlock{SIM: sims}},
+	}
+}
+
+// planned is a healthy active SIM: card in the slot, plan on the card. The
+// tests below flip one field at a time off this baseline.
+func planned() simSlot {
+	return simSlot{Active: true, Slot: 1, CardPresent: true, HasDataPlan: true}
+}
+
+func TestDataUsageFromTheActiveSIM(t *testing.T) {
+	warned := planned()
+	warned.DataWarning = true
+	limited := planned()
+	limited.DataLimited = true
+	both := planned()
+	both.DataWarning, both.DataLimited = true, true
+
+	tests := []struct {
+		name string
+		sims []simSlot
+		want string
+	}{
+		{"neither flag set is under", []simSlot{planned()}, dataUsageUnder},
+		{"data_warning is warning", []simSlot{warned}, dataUsageWarning},
+		{"data_limited is over", []simSlot{limited}, dataUsageOver},
+		// A reached limit is not also a warning about approaching one.
+		{"data_limited wins when both are set", []simSlot{both}, dataUsageOver},
+		// A spare SIM's flags must not leak into the answer: the active slot
+		// decides, whatever the other one reports.
+		{"the inactive SIM's flags are ignored", []simSlot{
+			planned(), {Slot: 2, CardPresent: true, HasDataPlan: true, DataLimited: true},
+		}, dataUsageUnder},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := logged(t)
+			if got := dataUsageFrom(ctx, modem(tt.sims...)); got != tt.want {
+				t.Errorf("dataUsageFrom = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// The cases where the key must be absent rather than under. under means
+// "there is an allowance and it is not close", and none of these records has
+// an allowance — publishing under for any of them would report headroom for a
+// site that has none.
+func TestDataUsageIsAbsentWhenThereIsNothingToBeUnder(t *testing.T) {
+	noCard := planned()
+	noCard.CardPresent = false
+	noPlan := planned()
+	noPlan.HasDataPlan = false
+
+	tests := []struct {
+		name string
+		sims []simSlot
+	}{
+		{"no SIM entries at all", nil},
+		{"no SIM is active", []simSlot{{Slot: 1, CardPresent: true, HasDataPlan: true}}},
+		{"the active slot has no card", []simSlot{noCard}},
+		{"the active SIM has no data plan", []simSlot{noPlan}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, _ := logged(t)
+			if got := dataUsageFrom(ctx, modem(tt.sims...)); got != "" {
+				t.Errorf("dataUsageFrom = %q, want the key not to be published", got)
+			}
+		})
+	}
+}
+
+// Two SIMs both claiming to be active is the console contradicting itself,
+// and which slot carries the traffic is exactly what it has failed to say.
+// Guessing could report the idle slot's headroom while the live one is over
+// its cap, so the contradiction is a log line and no key at all.
+func TestTwoActiveSIMsPublishNothingAndSaySo(t *testing.T) {
+	ctx, logs := logged(t)
+	second := planned()
+	second.Slot = 2
+
+	if got := dataUsageFrom(ctx, modem(planned(), second)); got != "" {
+		t.Errorf("dataUsageFrom = %q, want nothing while the SIMs contradict each other", got)
+	}
+	if !strings.Contains(logs(), "More than one SIM") {
+		t.Errorf("a contradiction between SIMs must be reported, not resolved silently; logged:\n%s", logs())
+	}
+}
+
+// Through stateFromDevices: a modem record publishes the key alongside the
+// rest of the observation, and a record with nothing to say costs the
+// observation nothing.
+func TestDataUsageThroughTheDeviceList(t *testing.T) {
+	ctx, _ := logged(t)
+	c := NewClient("", nil, "", false)
+
+	warned := planned()
+	warned.DataWarning = true
+	state, err := c.stateFromDevices(ctx, deviceStatResponse{Data: []deviceRecord{modem(warned)}})
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	if state[stateKeyDataUsage] != dataUsageWarning {
+		t.Errorf("state[data.usage] = %q, want %q", state[stateKeyDataUsage], dataUsageWarning)
+	}
+
+	// A gateway with a modem but no plan on the SIM: the UPS record keeps the
+	// observation non-empty, and data.usage must be absent rather than under.
+	noPlan := planned()
+	noPlan.HasDataPlan = false
+	ups := deviceRecord{VBMS: &vbmsTable{}}
+	state, err = c.stateFromDevices(ctx, deviceStatResponse{Data: []deviceRecord{modem(noPlan), ups}})
+	if err != nil {
+		t.Fatalf("stateFromDevices: %v", err)
+	}
+	if got, present := state[stateKeyDataUsage]; present {
+		t.Errorf("state[data.usage] = %q, want the key to be absent for a SIM with no plan", got)
+	}
+}

--- a/internal/providers/unifi/state.go
+++ b/internal/providers/unifi/state.go
@@ -26,6 +26,7 @@ const (
 	stateKeyWANQuality  = "wan.quality"
 	stateKeyISP         = "isp"
 	stateKeyInternet    = "internet"
+	stateKeyDataUsage   = "data.usage"
 	stateKeyUPS         = "ups"
 	stateKeyUPSBattery  = "ups.battery"
 	stateKeyUPSRuntime  = "ups.runtime"
@@ -110,6 +111,19 @@ const (
 	healthStatusOK      = "ok"
 	healthStatusWarning = "warning"
 	healthStatusError   = "error"
+
+	// data.usage is the active SIM's traffic against its data plan, read
+	// straight from the console's own data_warning and data_limited flags. The
+	// console does the accounting and the threshold comparison against
+	// whatever the plan really is, so unlike wan.quality there is no threshold
+	// to configure here and nothing is counted on this side. under means
+	// "there is an allowance and it is not close" — which is why the key is
+	// absent, never under, when there is no modem, no active SIM, no card or
+	// no plan: publishing under for a site with no allowance reports headroom
+	// it does not have. See datausage.go.
+	dataUsageUnder   = "under"
+	dataUsageWarning = "warning"
+	dataUsageOver    = "over"
 
 	upsOnline    = "online"
 	upsOnBattery = "on-battery"
@@ -200,6 +214,7 @@ const (
 	signalDeviceNameShared    = "device-name-shared"
 	signalWiFiStatusDisagrees = "wifi-status-disagrees"
 	signalOutletNameShared    = "outlet-name-shared"
+	signalSIMMultipleActive   = "sim-multiple-active"
 )
 
 // StateVocabulary is the closed value set of every key this provider publishes
@@ -275,6 +290,7 @@ func StateVocabulary() map[string][]string {
 		stateKeyWAN:         {wanPrimary, wanBackup},
 		stateKeyWANQuality:  {wanQualityGood, wanQualityDegraded},
 		stateKeyInternet:    {internetOK, internetDegraded, internetDown},
+		stateKeyDataUsage:   {dataUsageUnder, dataUsageWarning, dataUsageOver},
 		stateKeyUPS:         {upsOnline, upsOnBattery},
 		stateKeyUPSBattery:  {batteryNormal, batteryLow, batteryCritical},
 		stateKeyUPSRuntime:  {upsRuntimeAmple, upsRuntimeShort, upsRuntimeCritical},

--- a/internal/providers/unifi/verify_testdata_test.go
+++ b/internal/providers/unifi/verify_testdata_test.go
@@ -135,6 +135,85 @@ func TestThePlaceholderCarrierIsAccepted(t *testing.T) {
 	}
 }
 
+// captureWithSIM writes a throwaway tree holding one device capture whose mbb
+// block carries the given extra JSON alongside the six fields the projection
+// keeps. Everything else about it passes every other guard in the script.
+func captureWithSIM(t *testing.T, extra string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "testdata", "unifi", "api")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("building a throwaway capture tree: %v", err)
+	}
+	sim := `"active": true, "slot": 1, "card_present": true, "has_data_plan": true, ` +
+		`"data_warning": false, "data_limited": false`
+	if extra != "" {
+		sim += ", " + extra
+	}
+	fixture := `{"meta": {"rc": "ok"}, "data": [{"model": "UDMPRO", "mbb": {"sim": [{` + sim + `}]}}]}`
+	if err := os.WriteFile(filepath.Join(dir, "stat-device-gateway.json"), []byte(fixture), 0o644); err != nil {
+		t.Fatalf("writing the throwaway capture: %v", err)
+	}
+	return root
+}
+
+// The projection the capture script applies to mbb — the six fields and
+// nothing else — has to pass, or no capture with a cellular uplink could ever
+// be committed at all.
+func TestTheProjectedSIMBlockIsAccepted(t *testing.T) {
+	root := captureWithSIM(t, "")
+	if out, err := runVerifyTestdata(t, root); err != nil {
+		t.Fatalf("verify-testdata.sh rejected the exact projection the capture script writes:\n%s", out)
+	}
+}
+
+// The identifiers a real SIM entry carries alongside those six fields. The
+// policy for these is absent rather than redacted, so any appearance is a
+// violation — and pin_tries_remaining is deliberately in the list as a bare
+// number, because a guard that only recognised quoted values would wave every
+// numeric secret through.
+func TestSIMIdentifiersAreRejected(t *testing.T) {
+	tests := []struct{ name, field string }{
+		{"iccid", `"iccid": "89000000000000000000"`},
+		{"imei", `"imei": "000000000000000"`},
+		{"pin retry counter", `"pin_tries_remaining": 3`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := captureWithSIM(t, tt.field)
+			if out, err := runVerifyTestdata(t, root); err == nil {
+				t.Fatalf("verify-testdata.sh accepted a capture carrying a SIM identifier:\n%s", out)
+			}
+		})
+	}
+}
+
+// spn is the carrier's name as the SIM reports it, and it gets the guard #94
+// gave the WAN carrier: required to equal the placeholder, so every real
+// carrier from every future capture is caught without any of their names ever
+// appearing in this repository.
+func TestASIMCarrierThatIsNotThePlaceholderIsRejected(t *testing.T) {
+	root := captureWithSIM(t, `"spn": "Northwind Mobile"`)
+
+	out, err := runVerifyTestdata(t, root)
+	if err == nil {
+		t.Fatalf("verify-testdata.sh accepted a capture carrying a real-looking SIM carrier:\n%s", out)
+	}
+	if !strings.Contains(out, "spn") {
+		t.Errorf("the failure should name the spn field; got:\n%s", out)
+	}
+	if strings.Contains(out, "Northwind") {
+		t.Errorf("the failure echoed the carrier it caught, got:\n%s", out)
+	}
+}
+
+func TestTheSIMCarrierPlaceholderIsAccepted(t *testing.T) {
+	root := captureWithSIM(t, fmt.Sprintf(`"spn": %q`, placeholderCarrier(t, "ISP")))
+	if out, err := runVerifyTestdata(t, root); err != nil {
+		t.Fatalf("verify-testdata.sh rejected the placeholder carrier in spn:\n%s", out)
+	}
+}
+
 func TestTheCommittedCapturesPassEveryGuard(t *testing.T) {
 	if out, err := runVerifyTestdata(t, ""); err != nil {
 		t.Fatalf("the committed captures do not pass hack/verify-testdata.sh:\n%s", out)


### PR DESCRIPTION
Closes #13.

## The key

`data.usage: under | warning | over`, derived from the **active** SIM in the gateway's `mbb.sim[]` block. The console does the byte accounting and the threshold comparison against the SIM's real plan and reports the result as two flags, so there is no counting, no cross-restart persistence and no threshold to configure on this side. `data_limited` wins when both flags are set: a limit that has been reached is not also a warning about approaching one.

**Absent is not `under`.** The key is not published when there is no `mbb` block, no SIM reporting itself active, no card in the active slot, or no data plan on the active SIM — `under` means "there is an allowance and it is not close", and publishing it for a site with no allowance reports headroom that does not exist. More than one SIM reporting itself active is the console contradicting itself, so it is a counted disagreement (`sim-multiple-active`) and a log line rather than a guess at which slot is live.

`data.usage` joins `StateVocabulary()` (closed three-value set) and ships debounced at 1 in the chart, matching `wan` rather than `ups.battery`: the threshold crossing happened on the console's side, where the hysteresis belongs.

## Capture policy, landed first

`mbb.sim[]` is the most sensitive block this API has shown so far — alongside the six fields the key reads, a real entry carries the SIM's `iccid`, the modem's `imei`, the PIN/PUK lock state and retry counters, the carrier's name in `spn`, and `mcc`/`mnc`/`asn`. The first commit, ahead of any code that could motivate a fixture:

- the capture script projects `mbb` down to `active`, `slot`, `card_present`, `has_data_plan`, `data_warning`, `data_limited` — everything else absent, not redacted
- `SECRET_FIELDS` learns `iccid`, `imei` and the PIN/PUK fields; while adding them, the guard also needed to learn jq's pretty-printed spacing (the old pattern only matched compact JSON, which no committed capture uses) and bare numeric values (the retry counters are numbers)
- `spn` joins the required-to-equal carrier guard from #94, so every real carrier from every future capture is caught without any name appearing in the repository
- all of it exercised from `verify_testdata_test.go` in both directions, like the existing carrier guard

**No fixture is added.** Every test record is built in code: the interesting cases are combinations of four booleans, and a committed fixture carrying an `mbb` block is a standing risk no realistic device would pay for.

## Verified

`make test`, `make lint` and `./hack/verify-testdata.sh` all pass; `make docs` regenerated the reference with no other drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)