### PR TITLE
ci(renovate): run go mod tidy after a Go dependency update

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,6 +8,7 @@
   ],
   "labels": ["dependencies"],
   "rangeStrategy": "bump",
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
Renovate ran for the first time on this repository and #111 failed both generated-output jobs immediately.

The bumps themselves are fine. The failure is `go.sum`: Renovate updated it, but not to what `go mod tidy` produces, so `make test` rewrote it and the "Check generated output is committed" job found a dirty tree. The diff was `sigs.k8s.io/structured-merge-diff/v6` and a handful of `k8s.io` entries.

`postUpdateOptions: ["gomodTidy"]` makes Renovate run `go mod tidy` after it touches `go.mod`, which is exactly what that check expects of any commit touching Go dependencies.

Without it, **every** Go update fails the same way — which also defeats the `automerge: true` rule on minor and patch, since nothing can automerge while CI is red.

#111 should go green once Renovate regenerates it against this.