### PR TITLE
chore(deps): take the seven action majors as one change

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,24 +38,24 @@ jobs:
           echo "image=ghcr.io/${{ github.repository }}" >> "$GITHUB_OUTPUT"
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@398d4b0eeef1380460a10c8013a76f728fb906ac # v3
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Build and push multi-arch image
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
@@ -77,7 +77,7 @@ jobs:
         run: cosign sign --yes "${IMAGE}@${DIGEST}"
 
       - name: Set up Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
 
       - name: Add the Artifact Hub changes annotation
         run: |
@@ -118,7 +118,7 @@ jobs:
         run: make build-installer IMG=${{ steps.version.outputs.image }}:${{ github.ref_name }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         with:
           files: dist/install.yaml
           generate_release_notes: true

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -67,7 +67,7 @@ jobs:
       # The reaction and lifecycle suites install the chart rather than the
       # kustomize manifests, so helm has to be there rather than merely likely.
       - name: Setup Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
 
       - name: Install the latest version of kind
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       # The chart render tests skip themselves without it, which would hide the
       # packaging regressions they exist to catch.
       - name: Setup Helm
-        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
 
       - name: Running Tests
         run: |


### PR DESCRIPTION
Renovate opened seven PRs for GitHub Action majors, and all but two of them edit the same file. This takes them as one change.

## Why combine

Merged individually, each would force the other six to rebase and re-run the full suite — hours of CI to change seven pinned digests in `release.yaml`.

**It costs no verification.** `release.yaml` has no `pull_request` trigger, so PR CI never exercises it whether these land as one PR or seven. The first real test of the release pipeline is the next tag, either way. The two changes that *are* covered by PR CI — `azure/setup-helm` in `test.yml` and `test-e2e.yml` — are exercised here exactly as they would have been.

## What changed

Every digest is Renovate's own, copied from the PR it opened rather than resolved by hand:

| action | | in |
|---|---|---|
| `azure/setup-helm` | v4 → v5 | release, test, test-e2e |
| `docker/build-push-action` | v6 → v7 | release |
| `docker/login-action` | v3 → v4 | release |
| `docker/setup-buildx-action` | v3 → v4 | release |
| `docker/setup-qemu-action` | v3 → v4 | release |
| `sigstore/cosign-installer` | v3 → v4.1.2 | release |
| `softprops/action-gh-release` | v2 → v3 | release |

## Risk worth naming

Six of these are in the path that builds, signs and publishes a release, and nothing verifies them until a tag is pushed. If one misbehaves the release job fails — recoverable by deleting the tag, fixing, and re-tagging, but it will fail loudly rather than silently, and cosign verification of the result is the backstop.

Closes #117, closes #118, closes #119, closes #120, closes #121, closes #123, closes #124.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release and testing automation components to newer, securely pinned versions.
  * Improved reliability and maintainability of container, Helm, signing, and release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->