### PR TITLE
ci: build the docs site on pull requests, and stop hiding 0.x minors

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,6 +16,13 @@
       "automerge": true
     },
     {
+      "description": "A 0.x minor is a breaking change under semver, so grouping one into allNonMajor hides it. Starlight 0.37 -> 0.41 arrived that way, needed an Astro the repo did not have, and broke the Pages deploy for half an hour without failing a single check.",
+      "matchCurrentVersion": "/^0\\./",
+      "matchUpdateTypes": ["minor"],
+      "groupName": null,
+      "automerge": false
+    },
+    {
       "description": "controller-tools and controller-runtime decide what `make manifests` and the envtest matrix produce; land those deliberately",
       "matchPackageNames": [
         "kubernetes-sigs/controller-tools",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,42 @@ jobs:
             exit 1
           fi
 
+  # The published site is built by docs.yml, which runs only on push. Without
+  # this job a docs-only dependency change merges green and breaks the deploy,
+  # and nobody finds out because Pages keeps serving the last good build. That
+  # happened: a Starlight 0.x minor landed in a "non-major" group needing an
+  # Astro it did not have, and main deployed nothing for half an hour.
+  #
+  # Node is pinned to what withastro/action installs rather than left to the
+  # runner's default, because Astro enforces an engine floor and the whole
+  # point is to fail here rather than at deploy.
+  site:
+    permissions:
+      contents: read
+    name: Check the docs site builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone the code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+
+      - name: Install with the committed lockfile
+        run: bun install --frozen-lockfile
+        working-directory: docs
+
+      - name: Build the site
+        run: bun run build
+        working-directory: docs
+
   # The site's Reference section is generated from the API types, the chart's
   # values, the metric definitions and the controller's Event reasons. Without
   # this job those pages rot the first time somebody adds a field in a hurry,


### PR DESCRIPTION
Closing a gap that cost the published site half an hour of broken deploys today, and the config hole that let it through.

## What happened

`docs.yml` builds the site and runs only on `push`. **Nothing on a pull request has ever run `astro build`**, so a docs-only dependency change merges with every check green and the deploy is the first thing that tries it.

```
12:57  00b1ea7  #111 merged (deps group)   Deploy Docs  FAILED
13:30  5a0fa40  #125 merged (astro action) Deploy Docs  FAILED
13:31  390bc6b  #127 merged (astro v7)     Deploy Docs  SUCCESS
```

`@astrojs/starlight` went 0.37.7 → 0.41.7 inside the "all non-major" group. Starlight 0.41 needs a newer Astro than the 5.x it landed beside — `astro/zod` no longer exports `locales` — so the build died at config evaluation.

**Pages keeps serving the last good build**, so the site looked healthy the entire time. Only the Actions tab showed it. And it was fixed by luck rather than design: the Astro 7 bump happened to be next in the queue.

## Two causes, two changes

**1. Nothing built the site on a PR.** A `site` job now does, on every pull request. Node is pinned to what `withastro/action` installs rather than left to the runner default, because Astro enforces an engine floor (`>=22.12`) and the whole point is to fail here rather than at deploy. Install uses the committed lockfile. The build takes about **two seconds**.

**2. A 0.x minor is a breaking change, and the grouping hid it.** Under semver `0.37 → 0.41` may break anything, but `group:allNonMajor` treats it as routine and buries it with a dozen safe bumps. A new rule pulls 0.x minors out of the group and blocks automerge on them, so they arrive as their own reviewable PR.

## Verification

Astro 7 was verified by hand before merge — Node 22, 54 pages, sitemap, Pagefind index. This PR makes that automatic instead of dependent on somebody remembering.

The site job on this PR is itself the proof it works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved dependency update handling for early-stage dependencies by preventing automatic minor-version merges.
* **Tests**
  * Added automated documentation build checks for pull requests and pushes.
  * Documentation builds now run in a consistent Node and Bun environment using locked dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->